### PR TITLE
Add helpers for future sourcemap plugins and CLI.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
             "version": "0.0.1",
             "license": "MIT",
             "workspaces": [
-                "packages/*"
+                "packages/*",
+                "tools/*"
             ],
             "devDependencies": {
                 "@types/node": "^14.18.51",
@@ -603,6 +604,10 @@
         },
         "node_modules/@backtrace/sdk-core": {
             "resolved": "packages/sdk-core",
+            "link": true
+        },
+        "node_modules/@backtrace/sourcemap-tools": {
+            "resolved": "tools/sourcemap-tools",
             "link": true
         },
         "node_modules/@bcoe/v8-coverage": {
@@ -7031,6 +7036,17 @@
                 "ts-jest": "^29.1.0",
                 "typescript": "^5.0.4"
             }
+        },
+        "tools/sourcemap-tools": {
+            "name": "@backtrace/sourcemap-tools",
+            "version": "0.0.1",
+            "license": "MIT",
+            "devDependencies": {
+                "@types/jest": "^29.5.1",
+                "jest": "^29.5.0",
+                "ts-jest": "^29.1.0",
+                "typescript": "^5.0.4"
+            }
         }
     },
     "dependencies": {
@@ -7440,6 +7456,15 @@
         },
         "@backtrace/sdk-core": {
             "version": "file:packages/sdk-core",
+            "requires": {
+                "@types/jest": "^29.5.1",
+                "jest": "^29.5.0",
+                "ts-jest": "^29.1.0",
+                "typescript": "^5.0.4"
+            }
+        },
+        "@backtrace/sourcemap-tools": {
+            "version": "file:tools/sourcemap-tools",
             "requires": {
                 "@types/jest": "^29.5.1",
                 "jest": "^29.5.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
         "test": "npm run test --ws --if-present"
     },
     "workspaces": [
-        "packages/*"
+        "packages/*",
+        "tools/*"
     ],
     "repository": {
         "type": "git",

--- a/tools/sourcemap-tools/LICENSE
+++ b/tools/sourcemap-tools/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Backtrace Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/sourcemap-tools/jest.config.js
+++ b/tools/sourcemap-tools/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/tools/sourcemap-tools/package.json
+++ b/tools/sourcemap-tools/package.json
@@ -1,0 +1,40 @@
+{
+    "name": "@backtrace/sourcemap-tools",
+    "version": "0.0.1",
+    "description": "Backtrace-JavaScript sourcemap tools",
+    "main": "lib/index.js",
+    "types": "lib/index.d.ts",
+    "scripts": {
+        "build": "tsc",
+        "clean": "tsc -b --clean && rimraf \"lib\"",
+        "format": "prettier --write '**/*.ts'",
+        "lint": "eslint . --ext .ts",
+        "watch": "tsc -w",
+        "test": "NODE_ENV=test jest"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/backtrace-labs/backtrace-javascript.git"
+    },
+    "keywords": [
+        "Error",
+        "Reporting",
+        "Diagnostic",
+        "Tool",
+        "Bug",
+        "Bugs",
+        "StackTrace"
+    ],
+    "author": "Backtrace <team@backtrace.io>",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/backtrace-labs/backtrace-javascript/issues"
+    },
+    "homepage": "https://github.com/backtrace-labs/backtrace-javascript#readme",
+    "devDependencies": {
+        "@types/jest": "^29.5.1",
+        "jest": "^29.5.0",
+        "ts-jest": "^29.1.0",
+        "typescript": "^5.0.4"
+    }
+}

--- a/tools/sourcemap-tools/package.json
+++ b/tools/sourcemap-tools/package.json
@@ -4,6 +4,9 @@
     "description": "Backtrace-JavaScript sourcemap tools",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",
+    "engines": {
+        "node": ">=14"
+    },
     "scripts": {
         "build": "tsc",
         "clean": "tsc -b --clean && rimraf \"lib\"",
@@ -23,7 +26,9 @@
         "Tool",
         "Bug",
         "Bugs",
-        "StackTrace"
+        "StackTrace",
+        "Sourcemaps",
+        "Source maps"
     ],
     "author": "Backtrace <team@backtrace.io>",
     "license": "MIT",

--- a/tools/sourcemap-tools/src/ContentAppender.ts
+++ b/tools/sourcemap-tools/src/ContentAppender.ts
@@ -1,0 +1,11 @@
+export class ContentAppender {
+    public appendToJSON(json: string, keyValues: object) {
+        for (const [key, value] of Object.entries(keyValues)) {
+            // Replace closing bracket with additional key-values
+            // Keep the matched whitespaces at the end
+            json = json.replace(/}(\s*)$/, `,"${key}":${JSON.stringify(value)}}$1`);
+        }
+
+        return json;
+    }
+}

--- a/tools/sourcemap-tools/src/DebugIdGenerator.ts
+++ b/tools/sourcemap-tools/src/DebugIdGenerator.ts
@@ -1,0 +1,18 @@
+export const SOURCE_DEBUG_ID_VARIABLE = '_btDebugIds';
+export const SOURCE_DEBUG_ID_COMMENT = 'debugId';
+export const SOURCEMAP_DEBUG_ID_KEY = 'debugId';
+
+export class DebugIdGenerator {
+    public generateSourceSnippet(uuid: string) {
+        return `!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e.${SOURCE_DEBUG_ID_VARIABLE}=e.${SOURCE_DEBUG_ID_VARIABLE}||{},e.${SOURCE_DEBUG_ID_VARIABLE}[n]="${uuid}")}catch(e){}}()`;
+    }
+
+    public generateSourceComment(uuid: string) {
+        return `//# ${SOURCE_DEBUG_ID_COMMENT}=${uuid}`;
+    }
+
+    public addSourceMapKey(sourceMap: object, uuid: string) {
+        (sourceMap as Record<string, string>)[SOURCEMAP_DEBUG_ID_KEY] = uuid;
+        return sourceMap;
+    }
+}

--- a/tools/sourcemap-tools/src/DebugIdGenerator.ts
+++ b/tools/sourcemap-tools/src/DebugIdGenerator.ts
@@ -11,8 +11,10 @@ export class DebugIdGenerator {
         return `//# ${SOURCE_DEBUG_ID_COMMENT}=${uuid}`;
     }
 
-    public addSourceMapKey(sourceMap: object, uuid: string) {
-        (sourceMap as Record<string, string>)[SOURCEMAP_DEBUG_ID_KEY] = uuid;
-        return sourceMap;
+    public addSourceMapKey<T extends object>(sourceMap: T, uuid: string): T & { [SOURCEMAP_DEBUG_ID_KEY]: string } {
+        return {
+            ...sourceMap,
+            [SOURCEMAP_DEBUG_ID_KEY]: uuid,
+        };
     }
 }

--- a/tools/sourcemap-tools/src/index.ts
+++ b/tools/sourcemap-tools/src/index.ts
@@ -1,1 +1,2 @@
+export * from './ContentAppender';
 export * from './DebugIdGenerator';

--- a/tools/sourcemap-tools/src/index.ts
+++ b/tools/sourcemap-tools/src/index.ts
@@ -1,0 +1,1 @@
+export * from './DebugIdGenerator';

--- a/tools/sourcemap-tools/tests/ContentAppender.spec.ts
+++ b/tools/sourcemap-tools/tests/ContentAppender.spec.ts
@@ -1,0 +1,119 @@
+import { ContentAppender } from '../src';
+
+describe('ContentAppender', () => {
+    describe('appendToJSON', () => {
+        it('should return a parseable object', () => {
+            const obj = {
+                a: '123',
+                b: '456',
+            };
+
+            const keyValues = {
+                x: 'x',
+                y: 123,
+                z: true,
+            };
+
+            const contentAppender = new ContentAppender();
+            const actual = contentAppender.appendToJSON(JSON.stringify(obj), keyValues);
+
+            expect(() => JSON.parse(actual)).not.toThrow();
+        });
+
+        it('should return an object with new key values', () => {
+            const obj = {
+                a: '123',
+                b: '456',
+            };
+
+            const keyValues = {
+                x: 'x',
+                y: 123,
+                z: true,
+            };
+
+            const contentAppender = new ContentAppender();
+            const actual = contentAppender.appendToJSON(JSON.stringify(obj), keyValues);
+
+            expect(JSON.parse(actual)).toMatchObject(keyValues);
+        });
+
+        it('should return an object with old key values', () => {
+            const obj = {
+                a: '123',
+                b: '456',
+            };
+
+            const keyValues = {
+                x: 'x',
+                y: 123,
+                z: true,
+            };
+
+            const contentAppender = new ContentAppender();
+            const actual = contentAppender.appendToJSON(JSON.stringify(obj), keyValues);
+
+            expect(JSON.parse(actual)).toMatchObject(obj);
+        });
+
+        it('should return an object with old and new key values', () => {
+            const obj = {
+                a: '123',
+                b: '456',
+            };
+
+            const keyValues = {
+                x: 'x',
+                y: 123,
+                z: true,
+            };
+
+            const expected = {
+                ...obj,
+                ...keyValues,
+            };
+
+            const contentAppender = new ContentAppender();
+            const actual = contentAppender.appendToJSON(JSON.stringify(obj), keyValues);
+
+            expect(JSON.parse(actual)).toMatchObject(expected);
+        });
+
+        it('should return an object with old and new key values with whitespaces at the end of JSON', () => {
+            const obj = {
+                a: '123',
+                b: '456',
+            };
+
+            const keyValues = {
+                x: 'x',
+                y: 123,
+                z: true,
+            };
+
+            const expected = {
+                ...obj,
+                ...keyValues,
+            };
+
+            const contentAppender = new ContentAppender();
+            const actual = contentAppender.appendToJSON(JSON.stringify(obj) + '   \n\n   \n\t', keyValues);
+
+            expect(JSON.parse(actual)).toMatchObject(expected);
+        });
+
+        it('should not remove whitespaces at the end of JSON', () => {
+            const expected = '   \n\n   \n\t';
+            const json =
+                JSON.stringify({
+                    a: '123',
+                    b: '456',
+                }) + expected;
+
+            const contentAppender = new ContentAppender();
+            const actual = contentAppender.appendToJSON(json, { x: true });
+
+            expect(actual).toMatch(new RegExp(expected + '$'));
+        });
+    });
+});

--- a/tools/sourcemap-tools/tests/DebugIdGenerator.spec.ts
+++ b/tools/sourcemap-tools/tests/DebugIdGenerator.spec.ts
@@ -1,0 +1,177 @@
+import crypto from 'crypto';
+import { DebugIdGenerator, SOURCEMAP_DEBUG_ID_KEY, SOURCE_DEBUG_ID_COMMENT, SOURCE_DEBUG_ID_VARIABLE } from '../src';
+
+describe('DebugIdGenerator', () => {
+    describe('source snippet', () => {
+        /**
+         * Makes the `global` variable `undefined` in the callback.
+         * @param callback
+         */
+        function undefineGlobal(callback: () => void) {
+            const globalBackup = global;
+            // eslint-disable-next-line no-global-assign
+            global = undefined as never;
+
+            try {
+                callback();
+            } finally {
+                // eslint-disable-next-line no-global-assign
+                global = globalBackup;
+            }
+        }
+
+        beforeEach(() => {
+            // Clean the debug container from the global variable
+            delete global[SOURCE_DEBUG_ID_VARIABLE as never];
+
+            // Sanity checks
+            expect(typeof window).toEqual('undefined');
+            expect(typeof self).toEqual('undefined');
+        });
+
+        it('should return snippet containing passed UUID in quotes', () => {
+            const expected = crypto.randomUUID();
+
+            const debugIdGenerator = new DebugIdGenerator();
+            const snippet = debugIdGenerator.generateSourceSnippet(expected);
+
+            expect(snippet).toContain(`"${expected}"`);
+        });
+
+        it('should return snippet that is evaulable without exceptions', () => {
+            const debugIdGenerator = new DebugIdGenerator();
+            const snippet = debugIdGenerator.generateSourceSnippet(crypto.randomUUID());
+
+            expect(() => eval(snippet)).not.toThrow();
+        });
+
+        it('should assign debug ID container to "window" global variable when it is available', () => {
+            const debugIdGenerator = new DebugIdGenerator();
+            const snippet = debugIdGenerator.generateSourceSnippet(crypto.randomUUID());
+
+            const window = {};
+            // Node.JS defines global, we need to make it undefined so the snippet won't pick it up
+            undefineGlobal(() => eval(snippet));
+
+            expect(Object.keys(window)).toContain(SOURCE_DEBUG_ID_VARIABLE);
+        });
+
+        it('should assign debug ID container to "global" global variable when it is available', () => {
+            const debugIdGenerator = new DebugIdGenerator();
+            const snippet = debugIdGenerator.generateSourceSnippet(crypto.randomUUID());
+
+            eval(snippet);
+
+            expect(Object.keys(global)).toContain(SOURCE_DEBUG_ID_VARIABLE);
+        });
+
+        it('should assign debug ID container to "self" global variable when it is available', () => {
+            const debugIdGenerator = new DebugIdGenerator();
+            const snippet = debugIdGenerator.generateSourceSnippet(crypto.randomUUID());
+
+            const self = {};
+            // Node.JS defines global, we need to make it undefined so the snippet won't pick it up
+            undefineGlobal(() => eval(snippet));
+
+            expect(Object.keys(self)).toContain(SOURCE_DEBUG_ID_VARIABLE);
+        });
+
+        it('should not fail when "window", "self", "global" are undefined', () => {
+            const debugIdGenerator = new DebugIdGenerator();
+            const snippet = debugIdGenerator.generateSourceSnippet(crypto.randomUUID());
+
+            const self = undefined;
+            const window = undefined;
+
+            // "Use" the variables so Typescript won't complain about them being unused
+            self;
+            window;
+
+            // Node.JS defines global, we need to make it undefined so the snippet won't pick it up
+            expect(() => undefineGlobal(() => eval(snippet))).not.toThrow();
+        });
+
+        it('should assign error stack as key to debug ID container', () => {
+            const debugIdGenerator = new DebugIdGenerator();
+            const snippet = debugIdGenerator.generateSourceSnippet(crypto.randomUUID());
+
+            eval(snippet);
+
+            const container = global[SOURCE_DEBUG_ID_VARIABLE as never];
+            const keys = Object.keys(container);
+            for (const key of keys) {
+                expect(key).toMatch(/Error:/);
+                expect(key).toMatch(/\/DebugIdGenerator.spec.ts/);
+            }
+        });
+
+        it('should assign provided debug ID as value to debug ID container', () => {
+            const expected = crypto.randomUUID();
+
+            const debugIdGenerator = new DebugIdGenerator();
+            const snippet = debugIdGenerator.generateSourceSnippet(expected);
+
+            eval(snippet);
+
+            const container = global[SOURCE_DEBUG_ID_VARIABLE as never];
+            expect(Object.values(container)).toContain(expected);
+        });
+    });
+
+    describe('source comment', () => {
+        it('should return a comment matching regex', () => {
+            const regex = new RegExp(`^//# ${SOURCE_DEBUG_ID_COMMENT}=[a-fA-F0-9-]{36}$`);
+
+            const debugIdGenerator = new DebugIdGenerator();
+            const comment = debugIdGenerator.generateSourceComment(crypto.randomUUID());
+
+            expect(comment).toMatch(regex);
+        });
+
+        it('should return a comment with provided debug ID', () => {
+            const expected = crypto.randomUUID();
+
+            const debugIdGenerator = new DebugIdGenerator();
+            const comment = debugIdGenerator.generateSourceComment(expected);
+
+            expect(comment).toContain(expected);
+        });
+
+        it('should return a comment that is evaluable without exceptions', () => {
+            const debugIdGenerator = new DebugIdGenerator();
+            const comment = debugIdGenerator.generateSourceComment(crypto.randomUUID());
+
+            expect(() => eval(comment)).not.toThrow();
+        });
+    });
+
+    describe('source map', () => {
+        it('should add key to object', () => {
+            const obj = {};
+
+            const debugIdGenerator = new DebugIdGenerator();
+            debugIdGenerator.addSourceMapKey(obj, crypto.randomUUID());
+
+            expect(Object.keys(obj)).toContain(SOURCEMAP_DEBUG_ID_KEY);
+        });
+
+        it('should add provided debug ID to object', () => {
+            const obj = {};
+            const expected = crypto.randomUUID();
+
+            const debugIdGenerator = new DebugIdGenerator();
+            debugIdGenerator.addSourceMapKey(obj, crypto.randomUUID());
+
+            expect(obj[SOURCEMAP_DEBUG_ID_KEY as never]).toEqual(expected);
+        });
+
+        it('should return the same object', () => {
+            const expected = {};
+
+            const debugIdGenerator = new DebugIdGenerator();
+            const actual = debugIdGenerator.addSourceMapKey(expected, crypto.randomUUID());
+
+            expect(actual).toBe(expected);
+        });
+    });
+});

--- a/tools/sourcemap-tools/tests/DebugIdGenerator.spec.ts
+++ b/tools/sourcemap-tools/tests/DebugIdGenerator.spec.ts
@@ -147,31 +147,38 @@ describe('DebugIdGenerator', () => {
 
     describe('source map', () => {
         it('should add key to object', () => {
-            const obj = {};
-
             const debugIdGenerator = new DebugIdGenerator();
-            debugIdGenerator.addSourceMapKey(obj, crypto.randomUUID());
+            const actual = debugIdGenerator.addSourceMapKey({}, crypto.randomUUID());
 
-            expect(Object.keys(obj)).toContain(SOURCEMAP_DEBUG_ID_KEY);
+            expect(Object.keys(actual)).toContain(SOURCEMAP_DEBUG_ID_KEY);
         });
 
         it('should add provided debug ID to object', () => {
-            const obj = {};
             const expected = crypto.randomUUID();
 
             const debugIdGenerator = new DebugIdGenerator();
-            debugIdGenerator.addSourceMapKey(obj, crypto.randomUUID());
+            const actual = debugIdGenerator.addSourceMapKey({}, expected);
 
-            expect(obj[SOURCEMAP_DEBUG_ID_KEY as never]).toEqual(expected);
+            expect(actual[SOURCEMAP_DEBUG_ID_KEY as never]).toEqual(expected);
         });
 
-        it('should return the same object', () => {
+        it('should return a different object', () => {
             const expected = {};
 
             const debugIdGenerator = new DebugIdGenerator();
             const actual = debugIdGenerator.addSourceMapKey(expected, crypto.randomUUID());
 
-            expect(actual).toBe(expected);
+            expect(actual).not.toBe(expected);
+        });
+
+        it('should not modify the original object', () => {
+            const expected = {};
+            const actual = {};
+
+            const debugIdGenerator = new DebugIdGenerator();
+            debugIdGenerator.addSourceMapKey(actual, crypto.randomUUID());
+
+            expect(actual).toEqual(expected);
         });
     });
 });

--- a/tools/sourcemap-tools/tsconfig.json
+++ b/tools/sourcemap-tools/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "rootDir": "./src",
+        "outDir": "./lib"
+    },
+    "exclude": ["node_modules", "tests", "lib"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,9 @@
     "references": [
         {
             "path": "./packages/sdk-core"
+        },
+        {
+            "path": "./tools/sourcemap-tools"
         }
     ]
 }

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -3,6 +3,9 @@
     "references": [
         {
             "path": "packages/sdk-core"
+        },
+        {
+            "path": "tools/sourcemap-tools"
         }
     ]
 }


### PR DESCRIPTION
This PR adds `sourcemap-tools` package with `DebugIdGenerator` and `ContentAppender` classes to help create future plugins for working with sourcemaps.

Specific usage will be shown in the next PR with the Webpack plugin.