### PR TITLE
Use factory to generate client and send report to Backtrace

### DIFF
--- a/packages/browser/src/BacktraceClient.ts
+++ b/packages/browser/src/BacktraceClient.ts
@@ -1,3 +1,22 @@
-import { BacktraceCoreClient } from '@backtrace/sdk-core';
+import {
+    BacktraceConfiguration,
+    BacktraceCoreClient,
+    BacktraceRequestHandler,
+    BacktraceStackTraceConverter,
+} from '@backtrace/sdk-core';
+import { AGENT } from './agentDefinition';
+import { BacktraceClientBuilder } from './builder/BacktraceClientBuilder';
 
-export class BacktraceClient extends BacktraceCoreClient {}
+export class BacktraceClient extends BacktraceCoreClient {
+    constructor(
+        options: BacktraceConfiguration,
+        handler: BacktraceRequestHandler,
+        stackTraceConverter: BacktraceStackTraceConverter,
+    ) {
+        super(options, AGENT, handler, stackTraceConverter);
+    }
+
+    public static builder(options: BacktraceConfiguration): BacktraceClientBuilder {
+        return new BacktraceClientBuilder(options);
+    }
+}

--- a/packages/browser/src/agentDefinition.ts
+++ b/packages/browser/src/agentDefinition.ts
@@ -1,0 +1,14 @@
+import { SdkOptions } from '@backtrace/sdk-core/src/builder/SdkOptions';
+
+export const AGENT: SdkOptions = {
+    langName: 'js',
+    langVersion: navigator.userAgent,
+    /**
+     * To do - in the build stage, we can inject information
+     * about our package name and agent version. Since we don't have
+     * it now, I'm leaving it hardcoded, but in the future we want
+     * to change it and use webpack to generate it
+     */
+    agent: 'backtrace-js',
+    agentVersion: '0.0.1',
+};

--- a/packages/browser/src/builder/BacktraceClientBuilder.ts
+++ b/packages/browser/src/builder/BacktraceClientBuilder.ts
@@ -1,0 +1,30 @@
+import { BacktraceConfiguration, BacktraceCoreClientBuilder, BacktraceStackTraceConverter } from '@backtrace/sdk-core';
+import { V8StackTraceConverter } from '@backtrace/sdk-core/src/modules/converter/V8StackTraceConverter';
+import { BacktraceBrowserRequestHandler } from '../BacktraceBrowserRequestHandler';
+import { BacktraceClient } from '../BacktraceClient';
+import { JavaScriptCoreStackTraceConverter } from '../converters/JavaScriptCoreStackTraceConverter';
+import { SpiderMonkeyStackTraceConverter } from '../converters/SpiderMonkeyStackTraceConverter';
+import { getEngine } from '../engineDetector';
+
+export class BacktraceClientBuilder extends BacktraceCoreClientBuilder<BacktraceClient> {
+    constructor(private readonly _options: BacktraceConfiguration) {
+        super(new BacktraceBrowserRequestHandler(_options));
+    }
+    public build(): BacktraceClient {
+        return new BacktraceClient(this._options, this.handler, this.generateStackTraceConverter());
+    }
+
+    private generateStackTraceConverter(): BacktraceStackTraceConverter {
+        switch (getEngine()) {
+            case 'JavaScriptCore': {
+                return new JavaScriptCoreStackTraceConverter();
+            }
+            case 'SpiderMonkey': {
+                return new SpiderMonkeyStackTraceConverter();
+            }
+            default: {
+                return new V8StackTraceConverter();
+            }
+        }
+    }
+}

--- a/packages/browser/tests/client/clientTests.spec.ts
+++ b/packages/browser/tests/client/clientTests.spec.ts
@@ -1,7 +1,10 @@
 import { BacktraceClient } from '../../src/';
+
 describe('Client tests', () => {
     it('Should create a client', () => {
-        const client = new BacktraceClient();
+        const client = BacktraceClient.builder({
+            url: 'https://submit.backtrace.io/foo/bar/baz',
+        }).build();
 
         expect(client).toBeDefined();
     });

--- a/packages/node/src/BacktraceClient.ts
+++ b/packages/node/src/BacktraceClient.ts
@@ -1,3 +1,13 @@
-import { BacktraceCoreClient } from '@backtrace/sdk-core';
+import { BacktraceConfiguration, BacktraceCoreClient, BacktraceRequestHandler } from '@backtrace/sdk-core';
+import { AGENT } from './agentDefinition';
+import { BacktraceClientBuilder } from './builder/BacktraceClientBuilder';
 
-export class BacktraceClient extends BacktraceCoreClient {}
+export class BacktraceClient extends BacktraceCoreClient {
+    constructor(options: BacktraceConfiguration, handler: BacktraceRequestHandler) {
+        super(options, AGENT, handler);
+    }
+
+    public static builder(options: BacktraceConfiguration): BacktraceClientBuilder {
+        return new BacktraceClientBuilder(options);
+    }
+}

--- a/packages/node/src/agentDefinition.ts
+++ b/packages/node/src/agentDefinition.ts
@@ -1,0 +1,14 @@
+import { SdkOptions } from '@backtrace/sdk-core/src/builder/SdkOptions';
+
+export const AGENT: SdkOptions = {
+    langName: 'nodejs',
+    langVersion: process.version,
+    /**
+     * To do - in the build stage, we can inject information
+     * about our package name and agent version. Since we don't have
+     * it now, I'm leaving it hardcoded, but in the future we want
+     * to change it and use webpack to generate it
+     */
+    agent: 'backtrace-node',
+    agentVersion: '0.0.1',
+};

--- a/packages/node/src/builder/BacktraceClientBuilder.ts
+++ b/packages/node/src/builder/BacktraceClientBuilder.ts
@@ -1,0 +1,12 @@
+import { BacktraceConfiguration, BacktraceCoreClientBuilder } from '@backtrace/sdk-core';
+import { BacktraceClient } from '../BacktraceClient';
+import { BacktraceNodeRequestHandler } from '../BacktraceNodeRequestHandler';
+
+export class BacktraceClientBuilder extends BacktraceCoreClientBuilder<BacktraceClient> {
+    constructor(private readonly _options: BacktraceConfiguration) {
+        super(new BacktraceNodeRequestHandler(_options));
+    }
+    public build(): BacktraceClient {
+        return new BacktraceClient(this._options, this.handler);
+    }
+}

--- a/packages/node/tests/client/clientTests.spec.ts
+++ b/packages/node/tests/client/clientTests.spec.ts
@@ -1,7 +1,9 @@
 import { BacktraceClient } from '../../src/';
 describe('Client tests', () => {
     it('Should create a client', () => {
-        const client = new BacktraceClient();
+        const client = BacktraceClient.builder({
+            url: 'https://submit.backtrace.io/foo/bar/baz',
+        });
 
         expect(client).toBeDefined();
     });

--- a/packages/sdk-core/src/BacktraceCoreClient.ts
+++ b/packages/sdk-core/src/BacktraceCoreClient.ts
@@ -1,10 +1,39 @@
+import { BacktraceStackTraceConverter } from '.';
+import { SdkOptions } from './builder/SdkOptions';
+import { BacktraceConfiguration } from './model/configuration/BacktraceConfiguration';
+import { BacktraceReportSubmission } from './model/http/BacktraceReportSubmission';
+import { BacktraceRequestHandler } from './model/http/BacktraceRequestHandler';
 import { BacktraceAttachment } from './model/report/BacktraceAttachment';
 import { BacktraceReport } from './model/report/BacktraceReport';
-import { BacktraceStackTraceConverter } from './modules/converter/BacktraceStackTraceConverter';
+import { ReportConverter } from './modules/converter/ReportConverter';
 import { V8StackTraceConverter } from './modules/converter/V8StackTraceConverter';
+export abstract class BacktraceCoreClient {
+    /**
+     * Backtrace SDK name
+     */
+    public get agent(): string {
+        return this._sdkOptions.agent;
+    }
+    /**
+     * Backtrace SDK version
+     */
+    public get agentVersion(): string {
+        return this._sdkOptions.agentVersion;
+    }
 
-export class BacktraceCoreClient {
-    constructor(private readonly _stackTraceConverter: BacktraceStackTraceConverter = new V8StackTraceConverter()) {}
+    private readonly _reportConverter: ReportConverter;
+    private readonly _reportSubmission: BacktraceReportSubmission;
+
+    protected constructor(
+        protected readonly options: BacktraceConfiguration,
+        private readonly _sdkOptions: SdkOptions,
+        requestHandler: BacktraceRequestHandler,
+        stackTraceConverter: BacktraceStackTraceConverter = new V8StackTraceConverter(),
+    ) {
+        this._reportConverter = new ReportConverter(this._sdkOptions, stackTraceConverter);
+        this._reportSubmission = new BacktraceReportSubmission(options, requestHandler);
+    }
+
     /**
      * Asynchronously sends error data to Backtrace.
      * @param error Backtrace Report or error or message
@@ -44,7 +73,8 @@ export class BacktraceCoreClient {
                   skipFrames: this.skipFrameOnMessage(data),
               });
 
-        console.log(this._stackTraceConverter.convert(report));
+        const backtraceData = this._reportConverter.convert(report, {}, {});
+        await this._reportSubmission.send(backtraceData, attachments);
     }
 
     private skipFrameOnMessage(data: Error | string): number {

--- a/packages/sdk-core/src/BacktraceCoreClient.ts
+++ b/packages/sdk-core/src/BacktraceCoreClient.ts
@@ -5,8 +5,8 @@ import { BacktraceReportSubmission } from './model/http/BacktraceReportSubmissio
 import { BacktraceRequestHandler } from './model/http/BacktraceRequestHandler';
 import { BacktraceAttachment } from './model/report/BacktraceAttachment';
 import { BacktraceReport } from './model/report/BacktraceReport';
-import { ReportConverter } from './modules/converter/ReportConverter';
 import { V8StackTraceConverter } from './modules/converter/V8StackTraceConverter';
+import { BacktraceDataBuilder } from './modules/data/BacktraceDataBuilder';
 export abstract class BacktraceCoreClient {
     /**
      * Backtrace SDK name
@@ -21,7 +21,7 @@ export abstract class BacktraceCoreClient {
         return this._sdkOptions.agentVersion;
     }
 
-    private readonly _reportConverter: ReportConverter;
+    private readonly _dataBuilder: BacktraceDataBuilder;
     private readonly _reportSubmission: BacktraceReportSubmission;
 
     protected constructor(
@@ -30,7 +30,7 @@ export abstract class BacktraceCoreClient {
         requestHandler: BacktraceRequestHandler,
         stackTraceConverter: BacktraceStackTraceConverter = new V8StackTraceConverter(),
     ) {
-        this._reportConverter = new ReportConverter(this._sdkOptions, stackTraceConverter);
+        this._dataBuilder = new BacktraceDataBuilder(this._sdkOptions, stackTraceConverter);
         this._reportSubmission = new BacktraceReportSubmission(options, requestHandler);
     }
 
@@ -73,7 +73,7 @@ export abstract class BacktraceCoreClient {
                   skipFrames: this.skipFrameOnMessage(data),
               });
 
-        const backtraceData = this._reportConverter.convert(report, {}, {});
+        const backtraceData = this._dataBuilder.build(report, {}, {});
         await this._reportSubmission.send(backtraceData, attachments);
     }
 

--- a/packages/sdk-core/src/builder/BacktraceCoreClientBuilder.ts
+++ b/packages/sdk-core/src/builder/BacktraceCoreClientBuilder.ts
@@ -1,0 +1,12 @@
+import { BacktraceCoreClient } from '../BacktraceCoreClient';
+import { BacktraceRequestHandler } from '../model/http/BacktraceRequestHandler';
+
+export abstract class BacktraceCoreClientBuilder<T extends BacktraceCoreClient> {
+    constructor(protected handler: BacktraceRequestHandler) {}
+    public useRequestHandler(handler: BacktraceRequestHandler): BacktraceCoreClientBuilder<T> {
+        this.handler = handler;
+        return this;
+    }
+
+    public abstract build(): T;
+}

--- a/packages/sdk-core/src/builder/SdkOptions.ts
+++ b/packages/sdk-core/src/builder/SdkOptions.ts
@@ -1,0 +1,9 @@
+/**
+ * Sdk-specific options used to provide information in the report about the SDK
+ */
+export interface SdkOptions {
+    langName: string;
+    langVersion: string;
+    agent: string;
+    agentVersion: string;
+}

--- a/packages/sdk-core/src/builder/SdkOptions.ts
+++ b/packages/sdk-core/src/builder/SdkOptions.ts
@@ -2,8 +2,8 @@
  * Sdk-specific options used to provide information in the report about the SDK
  */
 export interface SdkOptions {
-    langName: string;
-    langVersion: string;
-    agent: string;
-    agentVersion: string;
+    readonly langName: string;
+    readonly langVersion: string;
+    readonly agent: string;
+    readonly agentVersion: string;
 }

--- a/packages/sdk-core/src/common/IdGenerator.ts
+++ b/packages/sdk-core/src/common/IdGenerator.ts
@@ -2,6 +2,8 @@ import { pseudoRandomBytes } from 'crypto';
 export class IdGenerator {
     public static uuid() {
         const bytes = pseudoRandomBytes(16);
+        bytes[6] = (bytes[6] & 0x0f) | 0x40;
+        bytes[8] = (bytes[8] & 0x3f) | 0x80;
         return (
             bytes.slice(0, 4).toString('hex') +
             '-' +

--- a/packages/sdk-core/src/common/IdGenerator.ts
+++ b/packages/sdk-core/src/common/IdGenerator.ts
@@ -1,0 +1,17 @@
+import { pseudoRandomBytes } from 'crypto';
+export class IdGenerator {
+    public static uuid() {
+        const bytes = pseudoRandomBytes(16);
+        return (
+            bytes.slice(0, 4).toString('hex') +
+            '-' +
+            bytes.slice(4, 6).toString('hex') +
+            '-' +
+            bytes.slice(6, 8).toString('hex') +
+            '-' +
+            bytes.slice(8, 10).toString('hex') +
+            '-' +
+            bytes.slice(10, 16).toString('hex')
+        );
+    }
+}

--- a/packages/sdk-core/src/common/TimeHelper.ts
+++ b/packages/sdk-core/src/common/TimeHelper.ts
@@ -1,0 +1,5 @@
+export class TimeHelper {
+    public static now(): number {
+        return Math.floor(new Date().getTime() / 1000);
+    }
+}

--- a/packages/sdk-core/src/common/TimeHelper.ts
+++ b/packages/sdk-core/src/common/TimeHelper.ts
@@ -1,5 +1,5 @@
 export class TimeHelper {
-    public static now(): number {
+    public static timeNowInSec(): number {
         return Math.floor(new Date().getTime() / 1000);
     }
 }

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -1,4 +1,6 @@
 export * from './BacktraceCoreClient';
+export * from './builder/BacktraceCoreClientBuilder';
+export * from './builder/SdkOptions';
 export * from './model/configuration/BacktraceConfiguration';
 export * from './model/configuration/BacktraceDatabaseConfiguration';
 export * from './model/http';

--- a/packages/sdk-core/src/model/data/BacktraceData.ts
+++ b/packages/sdk-core/src/model/data/BacktraceData.ts
@@ -12,6 +12,6 @@ export interface BacktraceData {
     mainThread: string;
     classifiers: string[];
     attributes: Record<string, AttributeType>;
-    annotations: Record<string, object>;
+    annotations: Record<string, unknown>;
     threads: Record<string, BacktraceStackTrace>;
 }

--- a/packages/sdk-core/src/model/report/BacktraceReport.ts
+++ b/packages/sdk-core/src/model/report/BacktraceReport.ts
@@ -26,6 +26,11 @@ export class BacktraceReport {
     public readonly innerReport: unknown[] = [];
 
     /**
+     * Report timestamp in sec
+     */
+    public readonly timestamp = Math.floor(Date.now() / 1000);
+
+    /**
      * Sets how many top frames should be skipped.
      */
     public skipFrames = 0;

--- a/packages/sdk-core/src/model/report/BacktraceReport.ts
+++ b/packages/sdk-core/src/model/report/BacktraceReport.ts
@@ -1,3 +1,4 @@
+import { TimeHelper } from '../../common/TimeHelper';
 import { BacktraceAttachment } from './BacktraceAttachment';
 import { BacktraceErrorType } from './BacktraceErrorType';
 
@@ -28,7 +29,7 @@ export class BacktraceReport {
     /**
      * Report timestamp in sec
      */
-    public readonly timestamp = Math.floor(Date.now() / 1000);
+    public readonly timestamp = TimeHelper.now();
 
     /**
      * Sets how many top frames should be skipped.

--- a/packages/sdk-core/src/model/report/BacktraceReport.ts
+++ b/packages/sdk-core/src/model/report/BacktraceReport.ts
@@ -29,7 +29,7 @@ export class BacktraceReport {
     /**
      * Report timestamp in sec
      */
-    public readonly timestamp = TimeHelper.now();
+    public readonly timestamp = TimeHelper.timeNowInSec();
 
     /**
      * Sets how many top frames should be skipped.

--- a/packages/sdk-core/src/modules/converter/AttributeConverter.ts
+++ b/packages/sdk-core/src/modules/converter/AttributeConverter.ts
@@ -1,0 +1,42 @@
+import { AttributeType } from '../../model/data/BacktraceData';
+import { BacktraceReport } from '../../model/report/BacktraceReport';
+
+export class AttributeConverter {
+    public convert(
+        report: BacktraceReport,
+        clientAttributes: Record<string, AttributeType>,
+        clientAnnotations: Record<string, object>,
+    ): { attributes: Record<string, AttributeType>; annotations: Record<string, unknown> } {
+        const annotations: Record<string, unknown> = {
+            ...clientAnnotations,
+            ...report.annotations,
+        };
+
+        const attributes: Record<string, AttributeType> = {
+            ...clientAttributes,
+        };
+
+        for (const attributeKey in report.attributes) {
+            const value = report.attributes[attributeKey];
+            if (value == null) {
+                attributes[attributeKey] = value;
+            }
+
+            switch (typeof value) {
+                case 'object': {
+                    annotations[attributeKey] = value;
+                    break;
+                }
+                case 'bigint': {
+                    attributes[attributeKey] = value.toString();
+                    break;
+                }
+                default: {
+                    attributes[attributeKey] = value as AttributeType;
+                }
+            }
+        }
+
+        return { attributes, annotations };
+    }
+}

--- a/packages/sdk-core/src/modules/converter/ReportConverter.ts
+++ b/packages/sdk-core/src/modules/converter/ReportConverter.ts
@@ -1,0 +1,47 @@
+import { SdkOptions } from '../../builder/SdkOptions';
+import { IdGenerator } from '../../common/IdGenerator';
+import { AttributeType, BacktraceData } from '../../model/data/BacktraceData';
+import { BacktraceReport } from '../../model/report/BacktraceReport';
+import { AttributeConverter } from './AttributeConverter';
+import { BacktraceStackTraceConverter } from './BacktraceStackTraceConverter';
+
+export class ReportConverter {
+    public readonly MAIN_THREAD_NAME = 'main';
+
+    constructor(
+        private readonly _sdkOptions: SdkOptions,
+        private readonly _stackTraceConverter: BacktraceStackTraceConverter,
+        private readonly _attributeConverter: AttributeConverter = new AttributeConverter(),
+    ) {}
+
+    public convert(
+        report: BacktraceReport,
+        clientAttributes: Record<string, AttributeType> = {},
+        clientAnnotations: Record<string, object> = {},
+    ): BacktraceData {
+        const { attributes, annotations } = this._attributeConverter.convert(
+            report,
+            clientAttributes,
+            clientAnnotations,
+        );
+        return {
+            uuid: IdGenerator.uuid(),
+            timestamp: report.timestamp,
+            agent: this._sdkOptions.agent,
+            agentVersion: this._sdkOptions.agentVersion,
+            lang: this._sdkOptions.langName,
+            langVersion: this._sdkOptions.langVersion,
+            classifiers: report.classifiers,
+            mainThread: this.MAIN_THREAD_NAME,
+            threads: {
+                [this.MAIN_THREAD_NAME]: {
+                    fault: true,
+                    name: this.MAIN_THREAD_NAME,
+                    stack: this._stackTraceConverter.convert(report),
+                },
+            },
+            annotations,
+            attributes,
+        };
+    }
+}

--- a/packages/sdk-core/src/modules/data/AttributeAndAnnotationBuilder.ts
+++ b/packages/sdk-core/src/modules/data/AttributeAndAnnotationBuilder.ts
@@ -1,8 +1,8 @@
 import { AttributeType } from '../../model/data/BacktraceData';
 import { BacktraceReport } from '../../model/report/BacktraceReport';
 
-export class AttributeConverter {
-    public convert(
+export class AttributeAndAnnotationBuilder {
+    public generate(
         report: BacktraceReport,
         clientAttributes: Record<string, AttributeType>,
         clientAnnotations: Record<string, object>,
@@ -18,6 +18,7 @@ export class AttributeConverter {
 
         for (const attributeKey in report.attributes) {
             const value = report.attributes[attributeKey];
+
             if (value == null) {
                 attributes[attributeKey] = value;
             }

--- a/packages/sdk-core/src/modules/data/AttributeAndAnnotationBuilder.ts
+++ b/packages/sdk-core/src/modules/data/AttributeAndAnnotationBuilder.ts
@@ -21,6 +21,7 @@ export class AttributeAndAnnotationBuilder {
 
             if (value == null) {
                 attributes[attributeKey] = value;
+                continue;
             }
 
             switch (typeof value) {

--- a/packages/sdk-core/src/modules/data/BacktraceDataBuilder.ts
+++ b/packages/sdk-core/src/modules/data/BacktraceDataBuilder.ts
@@ -1,25 +1,25 @@
+import { BacktraceStackTraceConverter } from '../..';
 import { SdkOptions } from '../../builder/SdkOptions';
 import { IdGenerator } from '../../common/IdGenerator';
 import { AttributeType, BacktraceData } from '../../model/data/BacktraceData';
 import { BacktraceReport } from '../../model/report/BacktraceReport';
-import { AttributeConverter } from './AttributeConverter';
-import { BacktraceStackTraceConverter } from './BacktraceStackTraceConverter';
+import { AttributeAndAnnotationBuilder } from './AttributeAndAnnotationBuilder';
 
-export class ReportConverter {
+export class BacktraceDataBuilder {
     public readonly MAIN_THREAD_NAME = 'main';
 
     constructor(
         private readonly _sdkOptions: SdkOptions,
         private readonly _stackTraceConverter: BacktraceStackTraceConverter,
-        private readonly _attributeConverter: AttributeConverter = new AttributeConverter(),
+        private readonly _attributeAndAnnotationBuilder: AttributeAndAnnotationBuilder = new AttributeAndAnnotationBuilder(),
     ) {}
 
-    public convert(
+    public build(
         report: BacktraceReport,
         clientAttributes: Record<string, AttributeType> = {},
         clientAnnotations: Record<string, object> = {},
     ): BacktraceData {
-        const { attributes, annotations } = this._attributeConverter.convert(
+        const { attributes, annotations } = this._attributeAndAnnotationBuilder.generate(
             report,
             clientAttributes,
             clientAnnotations,

--- a/packages/sdk-core/tests/client/clientTests.spec.ts
+++ b/packages/sdk-core/tests/client/clientTests.spec.ts
@@ -1,23 +1,29 @@
-import { BacktraceCoreClient, BacktraceReport } from '../../src/';
+import { BacktraceReport } from '../../src/';
+import { BacktraceTestClient } from '../mocks/BacktraceTestClient';
 describe('Client tests', () => {
     describe('Send tests', () => {
-        const client = new BacktraceCoreClient();
-        it('Message report shouldnt throw', async () => {
+        const client = BacktraceTestClient.buildFakeClient();
+
+        it(`Sending a message report shouldn't throw an error`, async () => {
             expect(async () => await client.send('test')).not.toThrow();
+            expect(client.requestHandler.postError).toBeCalled();
         });
 
-        it('Error report shouldnt throw', async () => {
+        it(`Sending an error report shouldn't throw`, async () => {
             expect(async () => await client.send(new Error('test'))).not.toThrow();
+            expect(client.requestHandler.postError).toBeCalled();
         });
 
-        it('Report shouldnt throw', async () => {
+        it(`Sending a report shouldn't throw`, async () => {
             expect(async () => await client.send(new BacktraceReport(new Error('test')))).not.toThrow();
+            expect(client.requestHandler.postError).toBeCalled();
         });
 
         it('Should be able to define nullable parameters', async () => {
             expect(
                 async () => await client.send(new BacktraceReport(new Error('test'), undefined, undefined)),
             ).not.toThrow();
+            expect(client.requestHandler.postError).toBeCalled();
         });
     });
 });

--- a/packages/sdk-core/tests/client/clientTests.spec.ts
+++ b/packages/sdk-core/tests/client/clientTests.spec.ts
@@ -4,17 +4,17 @@ describe('Client tests', () => {
     describe('Send tests', () => {
         const client = BacktraceTestClient.buildFakeClient();
 
-        it(`Sending a message report shouldn't throw an error`, async () => {
+        it(`Should not throw an error when sending a message`, async () => {
             expect(async () => await client.send('test')).not.toThrow();
             expect(client.requestHandler.postError).toBeCalled();
         });
 
-        it(`Sending an error report shouldn't throw`, async () => {
+        it(`Should not throw when sending an error report`, async () => {
             expect(async () => await client.send(new Error('test'))).not.toThrow();
             expect(client.requestHandler.postError).toBeCalled();
         });
 
-        it(`Sending a report shouldn't throw`, async () => {
+        it(`Should not throw when sending a report`, async () => {
             expect(async () => await client.send(new BacktraceReport(new Error('test')))).not.toThrow();
             expect(client.requestHandler.postError).toBeCalled();
         });

--- a/packages/sdk-core/tests/converters/attributeConverterTests.spec.ts
+++ b/packages/sdk-core/tests/converters/attributeConverterTests.spec.ts
@@ -1,0 +1,117 @@
+import { BacktraceReport } from '../../lib';
+import { AttributeType } from '../../lib/model/data/BacktraceData';
+import { AttributeConverter } from '../../src/modules/converter/AttributeConverter';
+describe('Attribute converter tests', () => {
+    const attributeConverter = new AttributeConverter();
+    describe('Annotations tests', () => {
+        it('Should include error information from the report annotations', () => {
+            const error = new Error('foo');
+            const report = new BacktraceReport(error);
+
+            const { annotations } = attributeConverter.convert(report, {}, {});
+
+            const receivedError = annotations['error'] as Error;
+            expect(receivedError).toBeDefined();
+            expect(receivedError.message).toEqual(error.message);
+        });
+
+        it('Should merge client and report annotations', () => {
+            const report = new BacktraceReport(new Error('foo'));
+
+            const clientAnnotations: Record<string, object> = {
+                foo: {
+                    a: 1,
+                    b: 2,
+                },
+            };
+            const { annotations } = attributeConverter.convert(report, {}, clientAnnotations);
+
+            for (const clientAnnotationKey in clientAnnotations) {
+                expect(annotations[clientAnnotationKey]).toEqual(clientAnnotations[clientAnnotationKey]);
+            }
+
+            for (const reportAnnotation in report.annotations) {
+                expect(annotations[reportAnnotation]).toEqual(report.annotations[reportAnnotation]);
+            }
+        });
+
+        it('Report annotation should override client annotation', () => {
+            const annotationKey = 'foo';
+            const reportAnnotation: Record<string, object> = {
+                bar: {
+                    a: 3,
+                    b: 4,
+                },
+            };
+            const report = new BacktraceReport(new Error('foo'), {
+                [annotationKey]: reportAnnotation,
+            });
+            const clientAnnotations: Record<string, object> = {
+                [annotationKey]: {
+                    a: 1,
+                    b: 2,
+                },
+            };
+            const { annotations } = attributeConverter.convert(report, {}, clientAnnotations);
+
+            expect(annotations[annotationKey]).toEqual(reportAnnotation);
+        });
+    });
+
+    describe('Attributes tests', () => {
+        it('Should combine report and client attributes', () => {
+            const reportAttributes: Record<string, AttributeType> = { foo: '1', bar: true };
+            const clientAttributes: Record<string, AttributeType> = { baz: 1 };
+            const report = new BacktraceReport(new Error('foo'), reportAttributes);
+
+            const { attributes } = attributeConverter.convert(report, clientAttributes, {});
+
+            for (const reportAttributeKey in reportAttributes) {
+                expect(attributes[reportAttributeKey]).toEqual(reportAttributes[reportAttributeKey]);
+            }
+
+            for (const clientAttributeKey in clientAttributes) {
+                expect(attributes[clientAttributeKey]).toEqual(clientAttributes[clientAttributeKey]);
+            }
+        });
+
+        it('Report attribute should override client attribute', () => {
+            const attributeName = 'foo';
+            const reportAttributes = { [attributeName]: '1' };
+            const clientAttributes = { [attributeName]: 'client attribute' };
+            const report = new BacktraceReport(new Error('foo'), reportAttributes);
+
+            const { attributes } = attributeConverter.convert(report, clientAttributes, {});
+
+            expect(attributes[attributeName]).toEqual(reportAttributes[attributeName]);
+        });
+
+        it('Should convert bigint to string', () => {
+            const attributeName = 'bigint';
+            const testedValue = BigInt('9999999999999999999999');
+            const expectedValue = testedValue.toString();
+            const reportAttributes = { [attributeName]: testedValue };
+            const report = new BacktraceReport(new Error('foo'), reportAttributes);
+
+            const { attributes } = attributeConverter.convert(report, {}, {});
+
+            expect(attributes[attributeName]).toEqual(expectedValue);
+        });
+
+        it(`Should allow to set undefined/null/0/''`, () => {
+            const reportAttributes: Record<string, AttributeType> = {
+                undefinedTest: undefined,
+                nullTest: null,
+                zeroTest: 0,
+                emptyStringTest: '',
+            };
+            const report = new BacktraceReport(new Error('foo'), reportAttributes);
+
+            const { attributes } = attributeConverter.convert(report, {}, {});
+
+            for (const attributeKey in reportAttributes) {
+                expect(attributes[attributeKey]).toEqual(reportAttributes[attributeKey]);
+            }
+        });
+    });
+});

--- a/packages/sdk-core/tests/converters/attributeConverterTests.spec.ts
+++ b/packages/sdk-core/tests/converters/attributeConverterTests.spec.ts
@@ -1,14 +1,14 @@
 import { BacktraceReport } from '../../lib';
 import { AttributeType } from '../../lib/model/data/BacktraceData';
-import { AttributeConverter } from '../../src/modules/converter/AttributeConverter';
+import { AttributeAndAnnotationBuilder } from '../../src/modules/data/AttributeAndAnnotationBuilder';
 describe('Attribute converter tests', () => {
-    const attributeConverter = new AttributeConverter();
+    const attributeAndAnnotationBuilder = new AttributeAndAnnotationBuilder();
     describe('Annotations tests', () => {
         it('Should include error information from the report annotations', () => {
             const error = new Error('foo');
             const report = new BacktraceReport(error);
 
-            const { annotations } = attributeConverter.convert(report, {}, {});
+            const { annotations } = attributeAndAnnotationBuilder.generate(report, {}, {});
 
             const receivedError = annotations['error'] as Error;
             expect(receivedError).toBeDefined();
@@ -24,7 +24,7 @@ describe('Attribute converter tests', () => {
                     b: 2,
                 },
             };
-            const { annotations } = attributeConverter.convert(report, {}, clientAnnotations);
+            const { annotations } = attributeAndAnnotationBuilder.generate(report, {}, clientAnnotations);
 
             for (const clientAnnotationKey in clientAnnotations) {
                 expect(annotations[clientAnnotationKey]).toEqual(clientAnnotations[clientAnnotationKey]);
@@ -52,7 +52,7 @@ describe('Attribute converter tests', () => {
                     b: 2,
                 },
             };
-            const { annotations } = attributeConverter.convert(report, {}, clientAnnotations);
+            const { annotations } = attributeAndAnnotationBuilder.generate(report, {}, clientAnnotations);
 
             expect(annotations[annotationKey]).toEqual(reportAnnotation);
         });
@@ -64,7 +64,7 @@ describe('Attribute converter tests', () => {
             const clientAttributes: Record<string, AttributeType> = { baz: 1 };
             const report = new BacktraceReport(new Error('foo'), reportAttributes);
 
-            const { attributes } = attributeConverter.convert(report, clientAttributes, {});
+            const { attributes } = attributeAndAnnotationBuilder.generate(report, clientAttributes, {});
 
             for (const reportAttributeKey in reportAttributes) {
                 expect(attributes[reportAttributeKey]).toEqual(reportAttributes[reportAttributeKey]);
@@ -81,7 +81,7 @@ describe('Attribute converter tests', () => {
             const clientAttributes = { [attributeName]: 'client attribute' };
             const report = new BacktraceReport(new Error('foo'), reportAttributes);
 
-            const { attributes } = attributeConverter.convert(report, clientAttributes, {});
+            const { attributes } = attributeAndAnnotationBuilder.generate(report, clientAttributes, {});
 
             expect(attributes[attributeName]).toEqual(reportAttributes[attributeName]);
         });
@@ -93,12 +93,12 @@ describe('Attribute converter tests', () => {
             const reportAttributes = { [attributeName]: testedValue };
             const report = new BacktraceReport(new Error('foo'), reportAttributes);
 
-            const { attributes } = attributeConverter.convert(report, {}, {});
+            const { attributes } = attributeAndAnnotationBuilder.generate(report, {}, {});
 
             expect(attributes[attributeName]).toEqual(expectedValue);
         });
 
-        it(`Should allow to set undefined/null/0/''`, () => {
+        it(`Should allow to set undefined or null or 0 or empty string`, () => {
             const reportAttributes: Record<string, AttributeType> = {
                 undefinedTest: undefined,
                 nullTest: null,
@@ -107,7 +107,7 @@ describe('Attribute converter tests', () => {
             };
             const report = new BacktraceReport(new Error('foo'), reportAttributes);
 
-            const { attributes } = attributeConverter.convert(report, {}, {});
+            const { attributes } = attributeAndAnnotationBuilder.generate(report, {}, {});
 
             for (const attributeKey in reportAttributes) {
                 expect(attributes[attributeKey]).toEqual(reportAttributes[attributeKey]);

--- a/packages/sdk-core/tests/mocks/BacktraceTestClient.ts
+++ b/packages/sdk-core/tests/mocks/BacktraceTestClient.ts
@@ -1,0 +1,31 @@
+import { BacktraceCoreClient, BacktraceRequestHandler } from '../../src';
+
+export const TOKEN = '590d39eb154cff1d30f2b689f9a928bb592b25e7e7c10192fe208485ea68d91c';
+export const UNIVERSE_NAME = 'test';
+export const TEST_SUBMISSION_URL = `https://${UNIVERSE_NAME}.sp.backtrace.io:6098/post?format=json&token=${TOKEN}`;
+export class BacktraceTestClient extends BacktraceCoreClient {
+    public readonly requestHandler: BacktraceRequestHandler;
+    constructor(handler: BacktraceRequestHandler) {
+        super(
+            {
+                url: TEST_SUBMISSION_URL,
+                token: TOKEN,
+            },
+            {
+                agent: 'test',
+                agentVersion: '0.0.1',
+                langName: 'test',
+                langVersion: 'test',
+            },
+            handler,
+        );
+        this.requestHandler = handler;
+    }
+
+    public static buildFakeClient() {
+        return new BacktraceTestClient({
+            post: jest.fn().mockResolvedValue(Promise.resolve()),
+            postError: jest.fn().mockResolvedValue(Promise.resolve()),
+        });
+    }
+}

--- a/packages/sdk-core/tests/report/dataGenerationTests.spec.ts
+++ b/packages/sdk-core/tests/report/dataGenerationTests.spec.ts
@@ -1,4 +1,5 @@
 import { BacktraceReport } from '../../src';
+import { TimeHelper } from '../../src/common/TimeHelper';
 import { ReportConverter } from '../../src/modules/converter/ReportConverter';
 import { V8StackTraceConverter } from '../../src/modules/converter/V8StackTraceConverter';
 
@@ -27,12 +28,13 @@ describe('Data generation tests', () => {
     });
 
     it('Should generate correct timestamp', () => {
-        const timeNowInSec = Math.floor(Date.now() / 1000);
+        const timestamp = Date.now();
+        jest.spyOn(TimeHelper, 'now').mockImplementation(() => {
+            return timestamp;
+        });
         const backtraceData = reportConverter.convert(new BacktraceReport(new Error()));
-        const timeAfterConversionInSec = Math.floor(Date.now() / 1000);
 
-        expect(backtraceData.timestamp).toBeGreaterThanOrEqual(timeNowInSec);
-        expect(backtraceData.timestamp).toBeLessThanOrEqual(timeAfterConversionInSec);
+        expect(backtraceData.timestamp).toEqual(timestamp);
     });
 
     it('Should set classifiers based on the error report', () => {

--- a/packages/sdk-core/tests/report/dataGenerationTests.spec.ts
+++ b/packages/sdk-core/tests/report/dataGenerationTests.spec.ts
@@ -1,0 +1,67 @@
+import { BacktraceReport } from '../../src';
+import { ReportConverter } from '../../src/modules/converter/ReportConverter';
+import { V8StackTraceConverter } from '../../src/modules/converter/V8StackTraceConverter';
+
+describe('Data generation tests', () => {
+    const sdkOptions = {
+        agent: 'test',
+        agentVersion: '0.0.1',
+        langName: 'test',
+        langVersion: 'test',
+    };
+    const reportConverter = new ReportConverter(sdkOptions, new V8StackTraceConverter());
+
+    it('Should set sdk options in the Backtrace data', () => {
+        const backtraceData = reportConverter.convert(new BacktraceReport(new Error()));
+        expect(backtraceData.agent).toEqual(sdkOptions.agent);
+        expect(backtraceData.agentVersion).toEqual(sdkOptions.agentVersion);
+        expect(backtraceData.langVersion).toEqual(sdkOptions.langVersion);
+        expect(backtraceData.lang).toEqual(sdkOptions.langName);
+    });
+
+    it('Should generate different uuid for each report ', () => {
+        const backtraceData = reportConverter.convert(new BacktraceReport(new Error()));
+        const comparedData = reportConverter.convert(new BacktraceReport(new Error()));
+
+        expect(backtraceData.uuid).not.toEqual(comparedData.uuid);
+    });
+
+    it('Should generate correct timestamp', () => {
+        const timeNowInSec = Math.floor(Date.now() / 1000);
+        const backtraceData = reportConverter.convert(new BacktraceReport(new Error()));
+        const timeAfterConversionInSec = Math.floor(Date.now() / 1000);
+
+        expect(backtraceData.timestamp).toBeGreaterThanOrEqual(timeNowInSec);
+        expect(backtraceData.timestamp).toBeLessThanOrEqual(timeAfterConversionInSec);
+    });
+
+    it('Should set classifiers based on the error report', () => {
+        const errorReport = new BacktraceReport(new Error());
+        const backtraceData = reportConverter.convert(errorReport);
+
+        expect(backtraceData.classifiers).toBe(errorReport.classifiers);
+    });
+
+    it('Should set classifiers based on the message report', () => {
+        const errorReport = new BacktraceReport('test');
+        const backtraceData = reportConverter.convert(errorReport);
+
+        expect(backtraceData.classifiers).toBe(errorReport.classifiers);
+    });
+
+    it('Should always have annotations', () => {
+        const errorReport = new BacktraceReport(new Error());
+        const backtraceData = reportConverter.convert(errorReport);
+
+        expect(backtraceData.annotations).toBeDefined();
+        expect(backtraceData.annotations).toMatchObject(errorReport.annotations);
+    });
+
+    it('Should always have attributes', () => {
+        const errorReport = new BacktraceReport(new Error());
+        const backtraceData = reportConverter.convert(errorReport);
+
+        expect(backtraceData.attributes).toBeDefined();
+        expect(backtraceData.attributes).toMatchObject(errorReport.attributes);
+    });
+});

--- a/packages/sdk-core/tests/report/dataGenerationTests.spec.ts
+++ b/packages/sdk-core/tests/report/dataGenerationTests.spec.ts
@@ -1,7 +1,7 @@
 import { BacktraceReport } from '../../src';
 import { TimeHelper } from '../../src/common/TimeHelper';
-import { ReportConverter } from '../../src/modules/converter/ReportConverter';
 import { V8StackTraceConverter } from '../../src/modules/converter/V8StackTraceConverter';
+import { BacktraceDataBuilder } from '../../src/modules/data/BacktraceDataBuilder';
 
 describe('Data generation tests', () => {
     const sdkOptions = {
@@ -10,10 +10,10 @@ describe('Data generation tests', () => {
         langName: 'test',
         langVersion: 'test',
     };
-    const reportConverter = new ReportConverter(sdkOptions, new V8StackTraceConverter());
+    const dataBuilder = new BacktraceDataBuilder(sdkOptions, new V8StackTraceConverter());
 
     it('Should set sdk options in the Backtrace data', () => {
-        const backtraceData = reportConverter.convert(new BacktraceReport(new Error()));
+        const backtraceData = dataBuilder.build(new BacktraceReport(new Error()));
         expect(backtraceData.agent).toEqual(sdkOptions.agent);
         expect(backtraceData.agentVersion).toEqual(sdkOptions.agentVersion);
         expect(backtraceData.langVersion).toEqual(sdkOptions.langVersion);
@@ -21,39 +21,39 @@ describe('Data generation tests', () => {
     });
 
     it('Should generate different uuid for each report ', () => {
-        const backtraceData = reportConverter.convert(new BacktraceReport(new Error()));
-        const comparedData = reportConverter.convert(new BacktraceReport(new Error()));
+        const backtraceData = dataBuilder.build(new BacktraceReport(new Error()));
+        const comparedData = dataBuilder.build(new BacktraceReport(new Error()));
 
         expect(backtraceData.uuid).not.toEqual(comparedData.uuid);
     });
 
     it('Should generate correct timestamp', () => {
         const timestamp = Date.now();
-        jest.spyOn(TimeHelper, 'now').mockImplementation(() => {
+        jest.spyOn(TimeHelper, 'timeNowInSec').mockImplementation(() => {
             return timestamp;
         });
-        const backtraceData = reportConverter.convert(new BacktraceReport(new Error()));
+        const backtraceData = dataBuilder.build(new BacktraceReport(new Error()));
 
         expect(backtraceData.timestamp).toEqual(timestamp);
     });
 
     it('Should set classifiers based on the error report', () => {
         const errorReport = new BacktraceReport(new Error());
-        const backtraceData = reportConverter.convert(errorReport);
+        const backtraceData = dataBuilder.build(errorReport);
 
         expect(backtraceData.classifiers).toBe(errorReport.classifiers);
     });
 
     it('Should set classifiers based on the message report', () => {
         const errorReport = new BacktraceReport('test');
-        const backtraceData = reportConverter.convert(errorReport);
+        const backtraceData = dataBuilder.build(errorReport);
 
         expect(backtraceData.classifiers).toBe(errorReport.classifiers);
     });
 
     it('Should always have annotations', () => {
         const errorReport = new BacktraceReport(new Error());
-        const backtraceData = reportConverter.convert(errorReport);
+        const backtraceData = dataBuilder.build(errorReport);
 
         expect(backtraceData.annotations).toBeDefined();
         expect(backtraceData.annotations).toMatchObject(errorReport.annotations);
@@ -61,7 +61,7 @@ describe('Data generation tests', () => {
 
     it('Should always have attributes', () => {
         const errorReport = new BacktraceReport(new Error());
-        const backtraceData = reportConverter.convert(errorReport);
+        const backtraceData = dataBuilder.build(errorReport);
 
         expect(backtraceData.attributes).toBeDefined();
         expect(backtraceData.attributes).toMatchObject(errorReport.attributes);


### PR DESCRIPTION
# Why


This diff connects all logic from the previous pull requests together to send report to Backtrace! In this diff you can find a:
* Builder definition
* Report generation logic

Goal: create a client and send a basic backtrace report to Backtrace.
