### PR TITLE
Add support for Node 14.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,3 +24,23 @@ jobs:
             - run: npm run lint
             - run: npm run format:check
             - run: npm test
+
+    build_pre_workspaces:
+        runs-on: ubuntu-latest
+
+        strategy:
+            matrix:
+                node-version: [14.x]
+
+        steps:
+            - uses: actions/checkout@v3
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v3
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - run: npm i -g npm@7
+            - run: npm ci
+            - run: npm run build
+            - run: npm run lint
+            - run: npm run format:check
+            - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "packages/*"
             ],
             "devDependencies": {
+                "@types/node": "^14.18.51",
                 "@typescript-eslint/eslint-plugin": "^5.59.7",
                 "@typescript-eslint/parser": "^5.59.7",
                 "eslint": "^8.41.0",
@@ -1310,9 +1311,10 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "11.15.54",
-            "dev": true,
-            "license": "MIT"
+            "version": "14.18.51",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.51.tgz",
+            "integrity": "sha512-P9bsdGFPpVtofEKlhWMVS2qqx1A/rt9QBfihWlklfHHpUpjtYse5AzFz6j4DWrARLYh6gRnw9+5+DJcrq3KvBA==",
+            "dev": true
         },
         "node_modules/@types/prettier": {
             "version": "2.7.2",
@@ -5734,6 +5736,12 @@
                 "node": ">=11.15.54"
             }
         },
+        "packages/node/node_modules/@types/node": {
+            "version": "11.15.54",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.54.tgz",
+            "integrity": "sha512-1RWYiq+5UfozGsU6MwJyFX6BtktcT10XRjvcAQmskCtMcW3tPske88lM/nHv7BQG1w9KBXI1zPGuu5PnNCX14g==",
+            "dev": true
+        },
         "packages/sdk-core": {
             "name": "@backtrace/sdk-core",
             "version": "0.0.1",
@@ -6130,6 +6138,14 @@
                 "jest": "^29.5.0",
                 "ts-jest": "^29.1.0",
                 "typescript": "^5.0.4"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "11.15.54",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.54.tgz",
+                    "integrity": "sha512-1RWYiq+5UfozGsU6MwJyFX6BtktcT10XRjvcAQmskCtMcW3tPske88lM/nHv7BQG1w9KBXI1zPGuu5PnNCX14g==",
+                    "dev": true
+                }
             }
         },
         "@backtrace/sdk-core": {
@@ -6641,7 +6657,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "11.15.54",
+            "version": "14.18.51",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.51.tgz",
+            "integrity": "sha512-P9bsdGFPpVtofEKlhWMVS2qqx1A/rt9QBfihWlklfHHpUpjtYse5AzFz6j4DWrARLYh6gRnw9+5+DJcrq3KvBA==",
             "dev": true
         },
         "@types/prettier": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     },
     "homepage": "https://github.com/backtrace-labs/backtrace-javascript#readme",
     "devDependencies": {
+        "@types/node": "^14.18.51",
         "@typescript-eslint/eslint-plugin": "^5.59.7",
         "@typescript-eslint/parser": "^5.59.7",
         "eslint": "^8.41.0",

--- a/packages/sdk-core/src/model/report/BacktraceReport.ts
+++ b/packages/sdk-core/src/model/report/BacktraceReport.ts
@@ -43,8 +43,10 @@ export class BacktraceReport {
             this.classifiers = [data.name];
             this.message = data.message;
             this.stackTrace = data.stack ?? '';
-            if (data.cause) {
-                this.innerReport.push(data.cause);
+
+            // Supported in ES2022
+            if ((data as { cause?: unknown }).cause) {
+                this.innerReport.push((data as { cause?: unknown }).cause);
             }
         } else {
             this.message = data;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es2022",
+        "target": "es2020",
         "module": "commonjs",
         "outDir": "./lib",
         "sourceMap": true,


### PR DESCRIPTION
* Adds a job to GitHub test workflows which tests on Node 14.
* Changes Typescript target to ES2020 - Node 14 supports it according to https://node.green/
* Updates `error.cause` code, because Typescript does not detect it prior to ES2022
