### PR TITLE
Add common stuff necessary for Webpack in browser and node.

### DIFF
--- a/build/agentDefinitionPlugin.js
+++ b/build/agentDefinitionPlugin.js
@@ -1,0 +1,9 @@
+const webpack = require('webpack');
+
+module.exports = function agentDefinitionPlugin(packageJsonPath) {
+    const packageJson = require(packageJsonPath);
+    return new webpack.DefinePlugin({
+        BACKTRACE_AGENT_NAME: JSON.stringify(packageJson.name),
+        BACKTRACE_AGENT_VERSION: JSON.stringify(packageJson.version),
+    });
+};

--- a/build/common.js
+++ b/build/common.js
@@ -1,0 +1,16 @@
+/** @type {import('webpack').Configuration} */
+const webpackTypescriptConfig = {
+    resolve: {
+        extensions: ['.js', '.ts', '.jsx', '.tsx'],
+    },
+    module: {
+        rules: [
+            {
+                test: /\.tsx?$/,
+                loader: 'ts-loader',
+            },
+        ],
+    },
+};
+
+module.exports = { webpackTypescriptConfig };

--- a/packages/sdk-core/src/common/IdGenerator.ts
+++ b/packages/sdk-core/src/common/IdGenerator.ts
@@ -1,19 +1,33 @@
-import { pseudoRandomBytes } from 'crypto';
 export class IdGenerator {
     public static uuid() {
-        const bytes = pseudoRandomBytes(16);
+        const bytes = [...new Array(16)].map(() => Math.floor(Math.random() * 256));
         bytes[6] = (bytes[6] & 0x0f) | 0x40;
         bytes[8] = (bytes[8] & 0x3f) | 0x80;
         return (
-            bytes.slice(0, 4).toString('hex') +
+            bytes
+                .slice(0, 4)
+                .map((n) => n.toString(16).padStart(2, '0'))
+                .join('') +
             '-' +
-            bytes.slice(4, 6).toString('hex') +
+            bytes
+                .slice(4, 6)
+                .map((n) => n.toString(16).padStart(2, '0'))
+                .join('') +
             '-' +
-            bytes.slice(6, 8).toString('hex') +
+            bytes
+                .slice(6, 8)
+                .map((n) => n.toString(16).padStart(2, '0'))
+                .join('') +
             '-' +
-            bytes.slice(8, 10).toString('hex') +
+            bytes
+                .slice(8, 10)
+                .map((n) => n.toString(16).padStart(2, '0'))
+                .join('') +
             '-' +
-            bytes.slice(10, 16).toString('hex')
+            bytes
+                .slice(10, 16)
+                .map((n) => n.toString(16).padStart(2, '0'))
+                .join('')
         );
     }
 }


### PR DESCRIPTION
This code is necessary for both browser and node packages to be built with Webpack.

The `IdGenerator` change is necessary to remove the `crypto` dependency, which is not possible to resolve in the browser package.