### PR TITLE
Add uploading sourcemaps via Webpack after build.

### DIFF
--- a/tools/webpack-plugin/src/models/BacktracePluginOptions.ts
+++ b/tools/webpack-plugin/src/models/BacktracePluginOptions.ts
@@ -1,5 +1,7 @@
-import { DebugIdGenerator } from '@backtrace/sourcemap-tools';
+import { DebugIdGenerator, SourceMapUploader } from '@backtrace/sourcemap-tools';
 
 export interface BacktracePluginOptions {
     debugIdGenerator?: DebugIdGenerator;
+    sourceMapUploader?: SourceMapUploader;
+    uploadUrl?: string | URL;
 }

--- a/tools/webpack-plugin/tests/e2e/createE2ETest.ts
+++ b/tools/webpack-plugin/tests/e2e/createE2ETest.ts
@@ -1,5 +1,8 @@
+import { SourceMapUploader } from '@backtrace/sourcemap-tools';
 import assert from 'assert';
+import crypto from 'crypto';
 import fs from 'fs';
+import path from 'path';
 import webpack from 'webpack';
 import {
     asyncWebpack,
@@ -17,6 +20,7 @@ interface E2ETestOptions {
     testSourceComment?: boolean;
     testSourceMap?: boolean;
     testSourceEval?: boolean;
+    testSourceMapUpload?: boolean;
 }
 
 export function createE2ETest(
@@ -24,9 +28,21 @@ export function createE2ETest(
     opts?: E2ETestOptions,
 ) {
     webpackModeTest((mode) => {
+        function mockUploader() {
+            return jest.spyOn(SourceMapUploader.prototype, 'upload').mockImplementation((_, debugId) =>
+                Promise.resolve({
+                    debugId: debugId ?? crypto.randomUUID(),
+                    rxid: crypto.randomUUID(),
+                }),
+            );
+        }
+
         let result: webpack.Stats;
+        let uploadSpy: ReturnType<typeof mockUploader>;
 
         beforeAll(async () => {
+            uploadSpy = mockUploader();
+
             const config = configBuilder(mode);
             if (config.output?.path) {
                 await removeDir(config.output.path);
@@ -95,6 +111,21 @@ export function createE2ETest(
                     await expectSourceMapSnippet(content);
                 }
             });
+
+            if (opts?.testSourceMapUpload ?? true) {
+                it('should upload sourcemaps using SourceMapUploader', async () => {
+                    const outputDir = result.compilation.outputOptions.path;
+                    assert(outputDir);
+
+                    const mapFiles = await getFiles(outputDir, /.js.map$/);
+                    expect(mapFiles.length).toBeGreaterThan(0);
+
+                    const uploadedFiles = uploadSpy.mock.calls.map((c) => path.resolve(c[0]));
+                    for (const file of mapFiles) {
+                        expect(uploadedFiles).toContain(path.resolve(file));
+                    }
+                });
+            }
         }
     });
 }

--- a/tools/webpack-plugin/tests/e2e/helpers.ts
+++ b/tools/webpack-plugin/tests/e2e/helpers.ts
@@ -1,3 +1,4 @@
+import { SourceMapUploader } from '@backtrace/sourcemap-tools';
 import fs from 'fs';
 import path from 'path';
 import webpack from 'webpack';
@@ -30,7 +31,14 @@ export function getBaseConfig(config: webpack.Configuration, options?: BaseConfi
                 },
             ],
         },
-        plugins: [new BacktracePlugin(options?.pluginOptions ?? { debugIdGenerator: new TestDebugIdGenerator() })],
+        plugins: [
+            new BacktracePlugin(
+                options?.pluginOptions ?? {
+                    debugIdGenerator: new TestDebugIdGenerator(),
+                    sourceMapUploader: new SourceMapUploader('http://localhost'),
+                },
+            ),
+        ],
         ...config,
     };
 }


### PR DESCRIPTION
Uses the previously added `SourceMapUploader` to upload sourcemaps to Backtrace. The `uploadUrl` has to be set.