### PR TITLE
Make stack trace converter simpler by requiring only stack trace and message

### DIFF
--- a/packages/browser/src/converters/JavaScriptCoreStackTraceConverter.ts
+++ b/packages/browser/src/converters/JavaScriptCoreStackTraceConverter.ts
@@ -1,4 +1,4 @@
-import { ANONYMOUS_FUNCTION, BacktraceReport, BacktraceStackTraceConverter, UNKNOWN_FRAME } from '@backtrace/sdk-core';
+import { ANONYMOUS_FUNCTION, BacktraceStackTraceConverter, UNKNOWN_FRAME } from '@backtrace/sdk-core';
 import { BacktraceStackFrame } from '@backtrace/sdk-core/lib/model/data/BacktraceStackTrace';
 import { JavaScriptEngine } from '@backtrace/sdk-core/lib/model/data/JavaScriptEngine';
 
@@ -7,12 +7,9 @@ export class JavaScriptCoreStackTraceConverter implements BacktraceStackTraceCon
         return 'JavaScriptCore';
     }
 
-    public convert(report: BacktraceReport): BacktraceStackFrame[] {
+    public convert(stackTrace: string): BacktraceStackFrame[] {
         const result: BacktraceStackFrame[] = [];
-        if (!report.stackTrace) {
-            return result;
-        }
-        const stackFrames = report.stackTrace.split('\n');
+        const stackFrames = stackTrace.split('\n');
 
         for (const stackFrame of stackFrames) {
             const normalizedStackFrame = stackFrame.trim();

--- a/packages/browser/src/converters/SpiderMonkeyStackTraceConverter.ts
+++ b/packages/browser/src/converters/SpiderMonkeyStackTraceConverter.ts
@@ -1,4 +1,4 @@
-import { ANONYMOUS_FUNCTION, BacktraceReport, BacktraceStackTraceConverter, UNKNOWN_FRAME } from '@backtrace/sdk-core';
+import { ANONYMOUS_FUNCTION, BacktraceStackTraceConverter, UNKNOWN_FRAME } from '@backtrace/sdk-core';
 import { BacktraceStackFrame } from '@backtrace/sdk-core/lib/model/data/BacktraceStackTrace';
 import { JavaScriptEngine } from '@backtrace/sdk-core/lib/model/data/JavaScriptEngine';
 
@@ -9,12 +9,9 @@ export class SpiderMonkeyStackTraceConverter implements BacktraceStackTraceConve
         return 'SpiderMonkey';
     }
 
-    public convert(report: BacktraceReport): BacktraceStackFrame[] {
+    public convert(stackTrace: string): BacktraceStackFrame[] {
         const result: BacktraceStackFrame[] = [];
-        if (!report.stackTrace) {
-            return result;
-        }
-        const stackFrames = report.stackTrace.split('\n');
+        const stackFrames = stackTrace.split('\n');
 
         for (const stackFrame of stackFrames) {
             const normalizedStackFrame = stackFrame.trim();

--- a/packages/browser/tests/converters/javascriptCore/javaScriptCoreStackTraceConverterTests.spec.ts
+++ b/packages/browser/tests/converters/javascriptCore/javaScriptCoreStackTraceConverterTests.spec.ts
@@ -1,4 +1,3 @@
-import { BacktraceReport } from '@backtrace/sdk-core';
 import { JavaScriptCoreStackTraceConverter } from '../../../src/converters/JavaScriptCoreStackTraceConverter';
 import { javaScriptCoreStackTraceTests } from './javaScriptCoreStackTraceTestCases';
 
@@ -9,7 +8,7 @@ describe('Stack trace converter tests', () => {
         describe('Stack trace generator', () => {
             for (const stackTraceTest of javaScriptCoreStackTraceTests) {
                 it(`Generator: ${stackTraceTest.name}`, () => {
-                    const convertedStackFrames = converter.convert(stackTraceTest.test as BacktraceReport);
+                    const convertedStackFrames = converter.convert(stackTraceTest.test.stackTrace);
 
                     expect(convertedStackFrames.length).toBe(stackTraceTest.expectation.length);
                     for (let index = 0; index < convertedStackFrames.length; index++) {

--- a/packages/browser/tests/converters/spiderMonkey/spiderMonkeyStackTraceConverterTests.spec.ts
+++ b/packages/browser/tests/converters/spiderMonkey/spiderMonkeyStackTraceConverterTests.spec.ts
@@ -1,5 +1,3 @@
-import { BacktraceReport } from '@backtrace/sdk-core';
-
 import { SpiderMonkeyStackTraceConverter } from '../../../src/converters/SpiderMonkeyStackTraceConverter';
 import { spiderMonkeyStackTraceTests } from './spiderMonkeyStackTraceTestCases';
 
@@ -10,7 +8,7 @@ describe('Stack trace converter tests', () => {
         describe('Stack trace generator', () => {
             for (const stackTraceTest of spiderMonkeyStackTraceTests) {
                 it(`Generator: ${stackTraceTest.name}`, () => {
-                    const convertedStackFrames = converter.convert(stackTraceTest.test as BacktraceReport);
+                    const convertedStackFrames = converter.convert(stackTraceTest.test.stackTrace);
 
                     expect(convertedStackFrames.length).toBe(stackTraceTest.expectation.length);
                     for (let index = 0; index < convertedStackFrames.length; index++) {

--- a/packages/sdk-core/src/modules/converter/BacktraceStackTraceConverter.ts
+++ b/packages/sdk-core/src/modules/converter/BacktraceStackTraceConverter.ts
@@ -1,8 +1,7 @@
 import { BacktraceStackFrame } from '../../model/data/BacktraceStackTrace';
 import { JavaScriptEngine } from '../../model/data/JavaScriptEngine';
-import { BacktraceReport } from '../../model/report/BacktraceReport';
 
 export interface BacktraceStackTraceConverter {
     get engine(): JavaScriptEngine;
-    convert(report: BacktraceReport): BacktraceStackFrame[];
+    convert(stackTrace: string, message: string): BacktraceStackFrame[];
 }

--- a/packages/sdk-core/src/modules/converter/V8StackTraceConverter.ts
+++ b/packages/sdk-core/src/modules/converter/V8StackTraceConverter.ts
@@ -1,6 +1,5 @@
 import { BacktraceStackFrame } from '../../model/data/BacktraceStackTrace';
 import { JavaScriptEngine } from '../../model/data/JavaScriptEngine';
-import { BacktraceReport } from '../../model/report/BacktraceReport';
 import { BacktraceStackTraceConverter } from './BacktraceStackTraceConverter';
 import { ANONYMOUS_FUNCTION, UNKNOWN_FRAME } from './consts/frameNamesConsts';
 
@@ -9,13 +8,10 @@ export class V8StackTraceConverter implements BacktraceStackTraceConverter {
         return 'v8';
     }
 
-    convert(report: BacktraceReport): BacktraceStackFrame[] {
+    convert(stackTrace: string, message: string): BacktraceStackFrame[] {
         const result: BacktraceStackFrame[] = [];
-        if (!report.stackTrace) {
-            return result;
-        }
-        let stackFrames = report.stackTrace.split('\n');
-        const errorHeader = report.message.split('\n');
+        let stackFrames = stackTrace.split('\n');
+        const errorHeader = message.split('\n');
 
         // remove error header from stack trace - if the error header exists
         if (stackFrames[0].indexOf(errorHeader[0]) !== -1) {

--- a/packages/sdk-core/src/modules/data/BacktraceDataBuilder.ts
+++ b/packages/sdk-core/src/modules/data/BacktraceDataBuilder.ts
@@ -34,7 +34,7 @@ export class BacktraceDataBuilder {
                 [this.MAIN_THREAD_NAME]: {
                     fault: true,
                     name: this.MAIN_THREAD_NAME,
-                    stack: this._stackTraceConverter.convert(report),
+                    stack: this._stackTraceConverter.convert(report.stackTrace, report.message),
                 },
             },
             annotations: {

--- a/packages/sdk-core/tests/converters/stackTraceConverterTests.spec.ts
+++ b/packages/sdk-core/tests/converters/stackTraceConverterTests.spec.ts
@@ -1,4 +1,3 @@
-import { BacktraceReport } from '../../src';
 import { V8StackTraceConverter } from '../../src/modules/converter/V8StackTraceConverter';
 import { v8StackTraceTests } from './v8stackTraceTestCases';
 
@@ -9,7 +8,10 @@ describe('Stack trace converter tests', () => {
         describe('Stack trace generator', () => {
             for (const stackTraceTest of v8StackTraceTests) {
                 it(`Generator: ${stackTraceTest.name}`, () => {
-                    const convertedStackFrames = converter.convert(stackTraceTest.test as BacktraceReport);
+                    const convertedStackFrames = converter.convert(
+                        stackTraceTest.test.stackTrace,
+                        stackTraceTest.test.message,
+                    );
 
                     expect(convertedStackFrames.length).toBe(stackTraceTest.expectation.length);
                     for (let index = 0; index < convertedStackFrames.length; index++) {


### PR DESCRIPTION
This removes the necessity to pass the whole `BacktraceReport` to the stack trace converters.