### PR TITLE
Add `SourceProcessor` class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10579,6 +10579,9 @@
             "name": "@backtrace/sourcemap-tools",
             "version": "0.0.1",
             "license": "MIT",
+            "dependencies": {
+                "source-map": "^0.7.4"
+            },
             "devDependencies": {
                 "@types/jest": "^29.5.1",
                 "jest": "^29.5.0",
@@ -10588,6 +10591,14 @@
             },
             "engines": {
                 "node": ">=14"
+            }
+        },
+        "tools/sourcemap-tools/node_modules/source-map": {
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+            "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+            "engines": {
+                "node": ">= 8"
             }
         },
         "tools/webpack-plugin": {
@@ -11042,8 +11053,16 @@
                 "@types/jest": "^29.5.1",
                 "jest": "^29.5.0",
                 "nock": "^13.3.1",
+                "source-map": "*",
                 "ts-jest": "^29.1.0",
                 "typescript": "^5.0.4"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.7.4",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+                    "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA=="
+                }
             }
         },
         "@backtrace/webpack-plugin": {

--- a/tools/sourcemap-tools/package.json
+++ b/tools/sourcemap-tools/package.json
@@ -42,5 +42,8 @@
         "nock": "^13.3.1",
         "ts-jest": "^29.1.0",
         "typescript": "^5.0.4"
+    },
+    "dependencies": {
+        "source-map": "^0.7.4"
     }
 }

--- a/tools/sourcemap-tools/src/DebugIdGenerator.ts
+++ b/tools/sourcemap-tools/src/DebugIdGenerator.ts
@@ -4,7 +4,7 @@ export const SOURCEMAP_DEBUG_ID_KEY = 'debugId';
 
 export class DebugIdGenerator {
     public generateSourceSnippet(uuid: string) {
-        return `;!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e.${SOURCE_DEBUG_ID_VARIABLE}=e.${SOURCE_DEBUG_ID_VARIABLE}||{},e.${SOURCE_DEBUG_ID_VARIABLE}[n]="${uuid}")}catch(e){}}()`;
+        return `;!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e.${SOURCE_DEBUG_ID_VARIABLE}=e.${SOURCE_DEBUG_ID_VARIABLE}||{},e.${SOURCE_DEBUG_ID_VARIABLE}[n]="${uuid}")}catch(e){}}();`;
     }
 
     public generateSourceComment(uuid: string) {

--- a/tools/sourcemap-tools/src/DebugIdGenerator.ts
+++ b/tools/sourcemap-tools/src/DebugIdGenerator.ts
@@ -4,7 +4,7 @@ export const SOURCEMAP_DEBUG_ID_KEY = 'debugId';
 
 export class DebugIdGenerator {
     public generateSourceSnippet(uuid: string) {
-        return `!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e.${SOURCE_DEBUG_ID_VARIABLE}=e.${SOURCE_DEBUG_ID_VARIABLE}||{},e.${SOURCE_DEBUG_ID_VARIABLE}[n]="${uuid}")}catch(e){}}()`;
+        return `;!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e.${SOURCE_DEBUG_ID_VARIABLE}=e.${SOURCE_DEBUG_ID_VARIABLE}||{},e.${SOURCE_DEBUG_ID_VARIABLE}[n]="${uuid}")}catch(e){}}()`;
     }
 
     public generateSourceComment(uuid: string) {

--- a/tools/sourcemap-tools/src/SourceProcessor.ts
+++ b/tools/sourcemap-tools/src/SourceProcessor.ts
@@ -6,6 +6,13 @@ import { stringToUuid } from './helpers/stringToUuid';
 export class SourceProcessor {
     constructor(private readonly _debugIdGenerator: DebugIdGenerator) {}
 
+    /**
+     * Adds required snippets and comments to source, and modifies sourcemap to include debug ID.
+     * @param source Source content.
+     * @param sourceMap Sourcemap object or JSON.
+     * @param debugId Debug ID. If not provided, one will be generated from `source`.
+     * @returns Used debug ID, new source and new sourcemap.
+     */
     public async processSourceAndSourceMap(source: string, sourceMap: string | RawSourceMap, debugId?: string) {
         if (!debugId) {
             debugId = stringToUuid(source);
@@ -23,6 +30,14 @@ export class SourceProcessor {
         return { debugId, source: newSource, sourceMap: newSourceMap };
     }
 
+    /**
+     * Adds required snippets and comments to source, and modifies sourcemap to include debug ID.
+     * Will write modified content to the files.
+     * @param sourcePath Path to the source.
+     * @param sourceMapPath Path to the sourcemap.
+     * @param debugId Debug ID. If not provided, one will be generated from `source`.
+     * @returns Used debug ID.
+     */
     public async processSourceAndSourceMapFiles(sourcePath: string, sourceMapPath: string, debugId?: string) {
         const source = await fs.promises.readFile(sourcePath, 'utf8');
         const sourceMap = await fs.promises.readFile(sourceMapPath, 'utf8');

--- a/tools/sourcemap-tools/src/SourceProcessor.ts
+++ b/tools/sourcemap-tools/src/SourceProcessor.ts
@@ -24,7 +24,13 @@ export class SourceProcessor {
         const newSource = sourceSnippet + '\n' + source + '\n' + sourceComment;
 
         // We need to offset the source map by amount of lines that we're inserting to the source code
-        const offsetSourceMap = await this.offsetSourceMap(sourceMap, 0, 1);
+        // Sourcemaps map code like this:
+        // original code X:Y => generated code A:B
+        // So if we add any code to generated code, mappings after that code will become invalid
+        // We need to offset the mapping lines by sourceSnippetNewlineCount:
+        // original code X:Y => generated code (A + sourceSnippetNewlineCount):B
+        const sourceSnippetNewlineCount = sourceSnippet.match(/\n/g)?.length ?? 0;
+        const offsetSourceMap = await this.offsetSourceMap(sourceMap, 0, sourceSnippetNewlineCount + 1);
         const newSourceMap = this._debugIdGenerator.addSourceMapKey(offsetSourceMap, debugId);
 
         return { debugId, source: newSource, sourceMap: newSourceMap };

--- a/tools/sourcemap-tools/src/SourceProcessor.ts
+++ b/tools/sourcemap-tools/src/SourceProcessor.ts
@@ -51,15 +51,16 @@ export class SourceProcessor {
                 return;
             }
 
+            // Despite how the mappings are written, addMapping expects here a null value if the column/line is not set
             newSourceMap.addMapping({
                 source: m.source,
                 name: m.name,
                 generated:
-                    m?.generatedColumn != null
+                    m?.generatedColumn != null && m?.generatedLine != null
                         ? { column: m.generatedColumn, line: m.generatedLine + count }
                         : (null as unknown as Position),
                 original:
-                    m?.originalColumn != null
+                    m?.originalColumn != null && m?.originalLine != null
                         ? { column: m.originalColumn, line: m.originalLine }
                         : (null as unknown as Position),
             });

--- a/tools/sourcemap-tools/src/SourceProcessor.ts
+++ b/tools/sourcemap-tools/src/SourceProcessor.ts
@@ -1,0 +1,70 @@
+import fs from 'fs';
+import { BasicSourceMapConsumer, Position, RawSourceMap, SourceMapConsumer, SourceMapGenerator } from 'source-map';
+import { DebugIdGenerator } from './DebugIdGenerator';
+import { stringToUuid } from './helpers/stringToUuid';
+
+export class SourceProcessor {
+    constructor(private readonly _debugIdGenerator: DebugIdGenerator) {}
+
+    public async processSourceAndSourceMap(source: string, sourceMap: string | RawSourceMap, debugId?: string) {
+        if (!debugId) {
+            debugId = stringToUuid(source);
+        }
+
+        const sourceSnippet = this._debugIdGenerator.generateSourceSnippet(debugId);
+        const sourceComment = this._debugIdGenerator.generateSourceComment(debugId);
+
+        const newSource = sourceSnippet + '\n' + source + '\n' + sourceComment;
+
+        // We need to offset the source map by amount of lines that we're inserting to the source code
+        const offsetSourceMap = await this.offsetSourceMap(sourceMap, 0, 1);
+        const newSourceMap = this._debugIdGenerator.addSourceMapKey(offsetSourceMap, debugId);
+
+        return { debugId, source: newSource, sourceMap: newSourceMap };
+    }
+
+    public async processSourceAndSourceMapFiles(sourcePath: string, sourceMapPath: string, debugId?: string) {
+        const source = await fs.promises.readFile(sourcePath, 'utf8');
+        const sourceMap = await fs.promises.readFile(sourceMapPath, 'utf8');
+
+        const result = await this.processSourceAndSourceMap(source, sourceMap, debugId);
+
+        await fs.promises.writeFile(sourcePath, result.source, 'utf8');
+        await fs.promises.writeFile(sourceMapPath, JSON.stringify(result.sourceMap), 'utf8');
+
+        return result.debugId;
+    }
+
+    private async offsetSourceMap(
+        sourceMap: string | RawSourceMap,
+        fromLine: number,
+        count: number,
+    ): Promise<RawSourceMap> {
+        const consumer = (await new SourceMapConsumer(sourceMap)) as BasicSourceMapConsumer;
+        const newSourceMap = new SourceMapGenerator({
+            file: consumer.file,
+            sourceRoot: consumer.sourceRoot,
+        });
+
+        consumer.eachMapping((m) => {
+            if (m.generatedLine < fromLine) {
+                return;
+            }
+
+            newSourceMap.addMapping({
+                source: m.source,
+                name: m.name,
+                generated:
+                    m?.generatedColumn != null
+                        ? { column: m.generatedColumn, line: m.generatedLine + count }
+                        : (null as unknown as Position),
+                original:
+                    m?.originalColumn != null
+                        ? { column: m.originalColumn, line: m.originalLine }
+                        : (null as unknown as Position),
+            });
+        });
+
+        return newSourceMap.toJSON();
+    }
+}

--- a/tools/sourcemap-tools/src/helpers/bytesToUuid.ts
+++ b/tools/sourcemap-tools/src/helpers/bytesToUuid.ts
@@ -1,0 +1,13 @@
+export function bytesToUuid(bytes: Buffer) {
+    return (
+        bytes.slice(0, 4).toString('hex') +
+        '-' +
+        bytes.slice(4, 6).toString('hex') +
+        '-' +
+        bytes.slice(6, 8).toString('hex') +
+        '-' +
+        bytes.slice(8, 10).toString('hex') +
+        '-' +
+        bytes.slice(10, 16).toString('hex')
+    );
+}

--- a/tools/sourcemap-tools/src/helpers/stringToUuid.ts
+++ b/tools/sourcemap-tools/src/helpers/stringToUuid.ts
@@ -1,0 +1,7 @@
+import crypto from 'crypto';
+import { bytesToUuid } from './bytesToUuid';
+
+export function stringToUuid(str: string) {
+    const bytes = crypto.createHash('sha1').update(str).digest();
+    return bytesToUuid(bytes);
+}

--- a/tools/sourcemap-tools/src/index.ts
+++ b/tools/sourcemap-tools/src/index.ts
@@ -2,4 +2,3 @@ export * from './ContentAppender';
 export * from './DebugIdGenerator';
 export * from './SourceMapUploader';
 export * from './SourceProcessor';
-

--- a/tools/sourcemap-tools/src/index.ts
+++ b/tools/sourcemap-tools/src/index.ts
@@ -1,3 +1,5 @@
 export * from './ContentAppender';
 export * from './DebugIdGenerator';
 export * from './SourceMapUploader';
+export * from './SourceProcessor';
+

--- a/tools/sourcemap-tools/tests/SourceMapProcessor.spec.ts
+++ b/tools/sourcemap-tools/tests/SourceMapProcessor.spec.ts
@@ -1,0 +1,64 @@
+import { SourceMapConsumer } from 'source-map';
+import { DebugIdGenerator, SOURCEMAP_DEBUG_ID_KEY, SourceProcessor } from '../src';
+
+describe('SourceMapProcessor', () => {
+    const source = `function foo(){console.log("Hello World!")}foo();`;
+    const sourceMap = {
+        version: 3,
+        file: 'source.js',
+        sources: ['source.js'],
+        names: ['foo', 'console', 'log'],
+        mappings: 'AAAA,SAASA,MACLC,QAAQC,IAAI,cAAc,CAC9B,CAEAF,IAAI',
+    };
+
+    it('should append source snippet to the source on the first line', async () => {
+        const expected = 'APPENDED_SOURCE';
+        const debugIdGenerator = new DebugIdGenerator();
+
+        jest.spyOn(debugIdGenerator, 'generateSourceSnippet').mockReturnValue(expected);
+
+        const sourceProcessor = new SourceProcessor(debugIdGenerator);
+        const result = await sourceProcessor.processSourceAndSourceMap(source, sourceMap);
+
+        expect(result.source).toMatch(new RegExp(`^${expected}\n`));
+    });
+
+    it('should append comment snippet to the source on the last line', async () => {
+        const expected = 'APPENDED_COMMENT';
+        const debugIdGenerator = new DebugIdGenerator();
+
+        jest.spyOn(debugIdGenerator, 'generateSourceComment').mockReturnValue(expected);
+
+        const sourceProcessor = new SourceProcessor(debugIdGenerator);
+        const result = await sourceProcessor.processSourceAndSourceMap(source, sourceMap);
+
+        expect(result.source).toMatch(new RegExp(`\n${expected}$`));
+    });
+
+    it('should return sourcemap from DebugIdGenerator', async () => {
+        const expected = { [SOURCEMAP_DEBUG_ID_KEY]: 'debugId' };
+        const debugIdGenerator = new DebugIdGenerator();
+
+        jest.spyOn(debugIdGenerator, 'addSourceMapKey').mockReturnValue(expected);
+
+        const sourceProcessor = new SourceProcessor(debugIdGenerator);
+        const result = await sourceProcessor.processSourceAndSourceMap(source, sourceMap);
+
+        expect(result.sourceMap).toStrictEqual(expected);
+    });
+
+    it('should offset sourcemap by one line', async () => {
+        const debugIdGenerator = new DebugIdGenerator();
+        const sourceProcessor = new SourceProcessor(debugIdGenerator);
+
+        const unmodifiedConsumer = await new SourceMapConsumer(sourceMap);
+        const expected = unmodifiedConsumer.originalPositionFor({ line: 1, column: source.indexOf('foo();') });
+
+        const result = await sourceProcessor.processSourceAndSourceMap(source, sourceMap);
+
+        const modifiedConsumer = await new SourceMapConsumer(result.sourceMap);
+        const actual = modifiedConsumer.originalPositionFor({ line: 2, column: source.indexOf('foo();') });
+
+        expect(actual).toEqual(expected);
+    });
+});

--- a/tools/sourcemap-tools/tests/SourceProcessor.spec.ts
+++ b/tools/sourcemap-tools/tests/SourceProcessor.spec.ts
@@ -1,7 +1,7 @@
 import { SourceMapConsumer } from 'source-map';
 import { DebugIdGenerator, SOURCEMAP_DEBUG_ID_KEY, SourceProcessor } from '../src';
 
-describe('SourceMapProcessor', () => {
+describe('SourceProcessor', () => {
     const source = `function foo(){console.log("Hello World!")}foo();`;
     const sourceMap = {
         version: 3,


### PR DESCRIPTION
When testing Webpack output with potential SDK changes, I've stumbled upon an error - source snippets adding debug IDs may have been executed later than the report was created, thus breaking the whole debug ID idea.

So I've opted to add them to the beginning of the file. This, however, breaks the sourcemaps, because a new line is added and all mappings are now offset.

I have decided to create a bundler-agnostic solution that appends the necessary code, and then fixes the sourcemaps. Webpack changes will be added in the next PR.