### PR TITLE
Add debug IDs support to sdk-core, node and browser packages

### DIFF
--- a/packages/browser/src/BacktraceClient.ts
+++ b/packages/browser/src/BacktraceClient.ts
@@ -3,10 +3,12 @@ import {
     BacktraceCoreClient,
     BacktraceRequestHandler,
     BacktraceStackTraceConverter,
+    DebugIdContainer,
+    VariableDebugIdMapProvider,
 } from '@backtrace/sdk-core';
-import { AGENT } from './agentDefinition';
 import { BacktraceBrowserSessionProvider } from './BacktraceBrowserSessionProvider';
 import { BacktraceConfiguration } from './BacktraceConfiguration';
+import { AGENT } from './agentDefinition';
 import { BacktraceClientBuilder } from './builder/BacktraceClientBuilder';
 
 export class BacktraceClient extends BacktraceCoreClient {
@@ -16,7 +18,15 @@ export class BacktraceClient extends BacktraceCoreClient {
         attributeProviders: BacktraceAttributeProvider[],
         stackTraceConverter: BacktraceStackTraceConverter,
     ) {
-        super(options, AGENT, handler, attributeProviders, stackTraceConverter, new BacktraceBrowserSessionProvider());
+        super(
+            options,
+            AGENT,
+            handler,
+            attributeProviders,
+            stackTraceConverter,
+            new BacktraceBrowserSessionProvider(),
+            new VariableDebugIdMapProvider(window as DebugIdContainer),
+        );
     }
 
     public static builder(options: BacktraceConfiguration): BacktraceClientBuilder {

--- a/packages/node/src/BacktraceClient.ts
+++ b/packages/node/src/BacktraceClient.ts
@@ -1,11 +1,13 @@
 import {
     BacktraceAttributeProvider,
-    BacktraceConfiguration as CoreConfiguration,
     BacktraceCoreClient,
     BacktraceRequestHandler,
+    BacktraceConfiguration as CoreConfiguration,
+    DebugIdContainer,
+    VariableDebugIdMapProvider,
 } from '@backtrace/sdk-core';
-import { AGENT } from './agentDefinition';
 import { BacktraceConfiguration } from './BacktraceConfiguration';
+import { AGENT } from './agentDefinition';
 import { BacktraceClientBuilder } from './builder/BacktraceClientBuilder';
 
 export class BacktraceClient extends BacktraceCoreClient {
@@ -14,7 +16,15 @@ export class BacktraceClient extends BacktraceCoreClient {
         handler: BacktraceRequestHandler,
         attributeProviders: BacktraceAttributeProvider[],
     ) {
-        super(options, AGENT, handler, attributeProviders);
+        super(
+            options,
+            AGENT,
+            handler,
+            attributeProviders,
+            undefined,
+            undefined,
+            new VariableDebugIdMapProvider(global as DebugIdContainer),
+        );
     }
 
     public static builder(options: BacktraceConfiguration): BacktraceClientBuilder {

--- a/packages/sdk-core/src/BacktraceCoreClient.ts
+++ b/packages/sdk-core/src/BacktraceCoreClient.ts
@@ -3,6 +3,8 @@ import {
     BacktraceAttributeProvider,
     BacktraceSessionProvider,
     BacktraceStackTraceConverter,
+    DebugIdMapProvider,
+    DebugIdProvider,
 } from '.';
 import { SdkOptions } from './builder/SdkOptions';
 import { BacktraceConfiguration } from './model/configuration/BacktraceConfiguration';
@@ -75,8 +77,14 @@ export abstract class BacktraceCoreClient {
         attributeProviders: BacktraceAttributeProvider[] = [],
         stackTraceConverter: BacktraceStackTraceConverter = new V8StackTraceConverter(),
         private readonly _sessionProvider: BacktraceSessionProvider = new SingleSessionProvider(),
+        debugIdMapProvider?: DebugIdMapProvider,
     ) {
-        this._dataBuilder = new BacktraceDataBuilder(this._sdkOptions, stackTraceConverter);
+        this._dataBuilder = new BacktraceDataBuilder(
+            this._sdkOptions,
+            stackTraceConverter,
+            new DebugIdProvider(stackTraceConverter, debugIdMapProvider),
+        );
+
         this._reportSubmission = new BacktraceReportSubmission(options, requestHandler);
         this._rateLimitWatcher = new RateLimitWatcher(options.rateLimit);
         this._attributeProvider = new AttributeManager([

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -11,3 +11,4 @@ export * from './model/report/BacktraceReport';
 export * from './modules/attribute/BacktraceAttributeProvider';
 export * from './modules/converter';
 export * from './modules/metrics/BacktraceSessionProvider';
+export * from './sourcemaps/index';

--- a/packages/sdk-core/src/model/data/BacktraceStackTrace.ts
+++ b/packages/sdk-core/src/model/data/BacktraceStackTrace.ts
@@ -4,7 +4,7 @@ export interface BacktraceStackFrame {
     column?: number;
     sourceCode?: string;
     library: string;
-    debugId?: string;
+    debug_identifier?: string;
 }
 
 /**

--- a/packages/sdk-core/src/model/data/BacktraceStackTrace.ts
+++ b/packages/sdk-core/src/model/data/BacktraceStackTrace.ts
@@ -4,6 +4,7 @@ export interface BacktraceStackFrame {
     column?: number;
     sourceCode?: string;
     library: string;
+    debugId?: string;
 }
 
 /**

--- a/packages/sdk-core/src/modules/data/BacktraceDataBuilder.ts
+++ b/packages/sdk-core/src/modules/data/BacktraceDataBuilder.ts
@@ -24,7 +24,6 @@ export class BacktraceDataBuilder {
 
         const stackTrace = this._stackTraceConverter.convert(report.stackTrace, report.message);
 
-        this._debugIdProvider.loadDebugIds();
         for (const frame of stackTrace) {
             frame.debug_identifier = this._debugIdProvider.getDebugId(frame.library);
         }

--- a/packages/sdk-core/src/modules/data/BacktraceDataBuilder.ts
+++ b/packages/sdk-core/src/modules/data/BacktraceDataBuilder.ts
@@ -26,7 +26,7 @@ export class BacktraceDataBuilder {
 
         this._debugIdProvider.loadDebugIds();
         for (const frame of stackTrace) {
-            frame.debugId = this._debugIdProvider.getDebugId(frame.library);
+            frame.debug_identifier = this._debugIdProvider.getDebugId(frame.library);
         }
 
         return {

--- a/packages/sdk-core/src/modules/data/BacktraceDataBuilder.ts
+++ b/packages/sdk-core/src/modules/data/BacktraceDataBuilder.ts
@@ -1,4 +1,4 @@
-import { BacktraceStackTraceConverter } from '../..';
+import { BacktraceStackTraceConverter, DebugIdProvider } from '../..';
 import { SdkOptions } from '../../builder/SdkOptions';
 import { IdGenerator } from '../../common/IdGenerator';
 import { TimeHelper } from '../../common/TimeHelper';
@@ -12,6 +12,7 @@ export class BacktraceDataBuilder {
     constructor(
         private readonly _sdkOptions: SdkOptions,
         private readonly _stackTraceConverter: BacktraceStackTraceConverter,
+        private readonly _debugIdProvider: DebugIdProvider,
     ) {}
 
     public build(
@@ -20,6 +21,13 @@ export class BacktraceDataBuilder {
         clientAnnotations: Record<string, unknown> = {},
     ): BacktraceData {
         const reportData = ReportDataBuilder.build(report.attributes);
+
+        const stackTrace = this._stackTraceConverter.convert(report.stackTrace, report.message);
+
+        this._debugIdProvider.loadDebugIds();
+        for (const frame of stackTrace) {
+            frame.debugId = this._debugIdProvider.getDebugId(frame.library);
+        }
 
         return {
             uuid: IdGenerator.uuid(),
@@ -34,7 +42,7 @@ export class BacktraceDataBuilder {
                 [this.MAIN_THREAD_NAME]: {
                     fault: true,
                     name: this.MAIN_THREAD_NAME,
-                    stack: this._stackTraceConverter.convert(report.stackTrace, report.message),
+                    stack: stackTrace,
                 },
             },
             annotations: {

--- a/packages/sdk-core/src/sourcemaps/DebugIdProvider.ts
+++ b/packages/sdk-core/src/sourcemaps/DebugIdProvider.ts
@@ -4,23 +4,23 @@ import { DebugIdMapProvider } from './interfaces/DebugIdMapProvider';
 export const SOURCE_DEBUG_ID_VARIABLE = '_btDebugIds';
 
 export class DebugIdProvider {
-    private _fileDebugIds?: Record<string, string>;
+    private readonly _fileDebugIds: Record<string, string>;
 
     constructor(
         private readonly _stackTraceConverter: BacktraceStackTraceConverter,
         private readonly _debugIdMapProvider?: DebugIdMapProvider,
-    ) {}
+    ) {
+        this._fileDebugIds = this.loadDebugIds();
+    }
 
-    public loadDebugIds(debugIdMap?: Record<string, string>) {
-        if (this._fileDebugIds) {
-            return this._fileDebugIds;
-        }
+    public getDebugId(file: string): string | undefined {
+        return this._fileDebugIds[file];
+    }
 
+    private loadDebugIds() {
+        const debugIdMap = this._debugIdMapProvider?.getDebugIdMap();
         if (!debugIdMap) {
-            debugIdMap = this._debugIdMapProvider?.getDebugIdMap();
-            if (!debugIdMap) {
-                return;
-            }
+            return {};
         }
 
         const message = new Error().message;
@@ -36,10 +36,6 @@ export class DebugIdProvider {
             result[frame.library] = debugId;
         }
 
-        return (this._fileDebugIds = result);
-    }
-
-    public getDebugId(file: string): string | undefined {
-        return this._fileDebugIds?.[file];
+        return result;
     }
 }

--- a/packages/sdk-core/src/sourcemaps/DebugIdProvider.ts
+++ b/packages/sdk-core/src/sourcemaps/DebugIdProvider.ts
@@ -1,0 +1,44 @@
+import { BacktraceStackTraceConverter } from '../modules/converter';
+import { DebugIdMapProvider } from './interfaces/DebugIdMapProvider';
+
+export const SOURCE_DEBUG_ID_VARIABLE = '_btDebugIds';
+
+export class DebugIdProvider {
+    private readonly _fileDebugIds: Record<string, string> = {};
+
+    constructor(
+        private readonly _stackTraceConverter: BacktraceStackTraceConverter,
+        private readonly _debugIdMapProvider?: DebugIdMapProvider,
+    ) {}
+
+    public loadDebugIds(debugIdMap?: Record<string, string>) {
+        if (!debugIdMap) {
+            debugIdMap = this._debugIdMapProvider?.getDebugIdMap();
+            if (!debugIdMap) {
+                return;
+            }
+        }
+
+        const message = new Error().message;
+        const result: Record<string, string> = {};
+        for (const entry in Object.entries(debugIdMap)) {
+            const [rawStack, debugId] = entry;
+            const frames = this._stackTraceConverter.convert(rawStack, message);
+            if (!frames.length) {
+                continue;
+            }
+
+            // The first frame will have the file's path
+            const frame = frames[0];
+            result[frame.library] = debugId;
+        }
+
+        Object.assign(this._fileDebugIds, result);
+
+        return result;
+    }
+
+    public getDebugId(file: string): string | undefined {
+        return this._fileDebugIds[file];
+    }
+}

--- a/packages/sdk-core/src/sourcemaps/VariableDebugIdMapProvider.ts
+++ b/packages/sdk-core/src/sourcemaps/VariableDebugIdMapProvider.ts
@@ -1,0 +1,14 @@
+import { SOURCE_DEBUG_ID_VARIABLE } from './DebugIdProvider';
+import { DebugIdMapProvider } from './interfaces/DebugIdMapProvider';
+
+export interface DebugIdContainer {
+    [SOURCE_DEBUG_ID_VARIABLE]?: Record<string, string>;
+}
+
+export class VariableDebugIdMapProvider implements DebugIdMapProvider {
+    constructor(private readonly _variable: DebugIdContainer) {}
+
+    public getDebugIdMap(): Record<string, string> {
+        return this._variable[SOURCE_DEBUG_ID_VARIABLE] ?? {};
+    }
+}

--- a/packages/sdk-core/src/sourcemaps/index.ts
+++ b/packages/sdk-core/src/sourcemaps/index.ts
@@ -1,0 +1,3 @@
+export * from './DebugIdProvider';
+export * from './VariableDebugIdMapProvider';
+export * from './interfaces/DebugIdMapProvider';

--- a/packages/sdk-core/src/sourcemaps/interfaces/DebugIdMapProvider.ts
+++ b/packages/sdk-core/src/sourcemaps/interfaces/DebugIdMapProvider.ts
@@ -1,0 +1,3 @@
+export interface DebugIdMapProvider {
+    getDebugIdMap(): Record<string, string>;
+}


### PR DESCRIPTION
This PR adds support for debug IDs in previously built files.

How it works:
1. debug IDs are being injected while building the files using for example a Webpack plugin
2. when creating a report, debug IDs are loaded using `DebugIdProvider`:
    1. debug IDs are being retrieved using `DebugIdMapProvider` - in node and browser using `VariableDebugIdMapProvider` from `global` and `window`, respectively,
    2. first frame's library from each file's stack and debug ID are saved
3. the debug IDs are assigned to each frame to `debug_identifier` property where a debug ID for library exists