### PR TITLE
Add 'backtrace.agent' attribute specifying submitting agent name

### DIFF
--- a/packages/sdk-core/src/BacktraceCoreClient.ts
+++ b/packages/sdk-core/src/BacktraceCoreClient.ts
@@ -89,6 +89,7 @@ export abstract class BacktraceCoreClient {
         this._rateLimitWatcher = new RateLimitWatcher(options.rateLimit);
         this._attributeProvider = new AttributeManager([
             new ClientAttributeProvider(
+                _sdkOptions.agent,
                 _sdkOptions.agentVersion,
                 _sessionProvider.sessionId,
                 options.userAttributes ?? {},

--- a/packages/sdk-core/src/modules/attribute/ClientAttributeProvider.ts
+++ b/packages/sdk-core/src/modules/attribute/ClientAttributeProvider.ts
@@ -2,6 +2,7 @@ import { BacktraceAttributeProvider } from './BacktraceAttributeProvider';
 
 export class ClientAttributeProvider implements BacktraceAttributeProvider {
     constructor(
+        private readonly _sdkName: string,
         private readonly _sdkVersion: string,
         private readonly _sessionId: string,
         private readonly _userAttributes: Record<string, unknown>,
@@ -12,6 +13,7 @@ export class ClientAttributeProvider implements BacktraceAttributeProvider {
     public get(): Record<string, unknown> {
         return {
             'application.session': this._sessionId,
+            'backtrace.agent': this._sdkName,
             'backtrace.version': this._sdkVersion,
             ...this._userAttributes,
         };


### PR DESCRIPTION
To make agent name queryable in Backtrace, I've added `backtrace.agent` as an additional attribute aside `backtrace.version`.