### PR TITLE
Add glob patterns for finding files in CLI.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -751,7 +751,6 @@
         },
         "node_modules/@isaacs/cliui": {
             "version": "8.0.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "string-width": "^5.1.2",
@@ -767,7 +766,6 @@
         },
         "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
             "version": "6.0.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -778,7 +776,6 @@
         },
         "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
             "version": "7.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^6.0.1"
@@ -1256,7 +1253,6 @@
         },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "engines": {
@@ -2162,7 +2158,6 @@
         },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -3580,7 +3575,6 @@
         },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
@@ -4056,7 +4050,6 @@
         },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
@@ -4095,7 +4088,6 @@
         },
         "node_modules/emoji-regex": {
             "version": "9.2.2",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/emojis-list": {
@@ -5221,7 +5213,6 @@
         },
         "node_modules/foreground-child": {
             "version": "3.1.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "cross-spawn": "^7.0.0",
@@ -5388,15 +5379,15 @@
             }
         },
         "node_modules/glob": {
-            "version": "10.2.6",
-            "dev": true,
-            "license": "ISC",
+            "version": "10.3.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
+            "integrity": "sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==",
             "dependencies": {
                 "foreground-child": "^3.1.0",
                 "jackspeak": "^2.0.3",
                 "minimatch": "^9.0.1",
-                "minipass": "^5.0.0 || ^6.0.2",
-                "path-scurry": "^1.7.0"
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+                "path-scurry": "^1.10.1"
             },
             "bin": {
                 "glob": "dist/cjs/src/bin.js"
@@ -5425,7 +5416,6 @@
         },
         "node_modules/glob/node_modules/brace-expansion": {
             "version": "2.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -5433,7 +5423,6 @@
         },
         "node_modules/glob/node_modules/minimatch": {
             "version": "9.0.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -6036,7 +6025,6 @@
         },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -6275,7 +6263,6 @@
         },
         "node_modules/isexe": {
             "version": "2.0.0",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/isobject": {
@@ -6357,7 +6344,6 @@
         },
         "node_modules/jackspeak": {
             "version": "2.2.1",
-            "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/cliui": "^8.0.2"
@@ -7231,9 +7217,9 @@
             }
         },
         "node_modules/lru-cache": {
-            "version": "9.1.1",
-            "dev": true,
-            "license": "ISC",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
+            "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==",
             "engines": {
                 "node": "14 || >=16.14"
             }
@@ -7414,9 +7400,9 @@
             }
         },
         "node_modules/minipass": {
-            "version": "6.0.2",
-            "dev": true,
-            "license": "ISC",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.2.tgz",
+            "integrity": "sha512-eL79dXrE1q9dBbDCLg7xfn/vl7MS4F1gvJAgjJrQli/jbQWdUttuVawphqpffoIYfRdq78LHx6GP4bU/EQ2ATA==",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
@@ -7997,7 +7983,6 @@
         },
         "node_modules/path-key": {
             "version": "3.1.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -8009,12 +7994,12 @@
             "license": "MIT"
         },
         "node_modules/path-scurry": {
-            "version": "1.9.2",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+            "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
             "dependencies": {
-                "lru-cache": "^9.1.1",
-                "minipass": "^5.0.0 || ^6.0.2"
+                "lru-cache": "^9.1.1 || ^10.0.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -8874,7 +8859,6 @@
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "shebang-regex": "^3.0.0"
@@ -8885,7 +8869,6 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -8906,7 +8889,6 @@
         },
         "node_modules/signal-exit": {
             "version": "4.0.2",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=14"
@@ -9352,7 +9334,6 @@
         },
         "node_modules/string-width": {
             "version": "5.1.2",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "eastasianwidth": "^0.2.0",
@@ -9369,7 +9350,6 @@
         "node_modules/string-width-cjs": {
             "name": "string-width",
             "version": "4.2.3",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
@@ -9382,12 +9362,10 @@
         },
         "node_modules/string-width-cjs/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/string-width/node_modules/ansi-regex": {
             "version": "6.0.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -9398,7 +9376,6 @@
         },
         "node_modules/string-width/node_modules/strip-ansi": {
             "version": "7.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^6.0.1"
@@ -9454,7 +9431,6 @@
         },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
@@ -9466,7 +9442,6 @@
         "node_modules/strip-ansi-cjs": {
             "name": "strip-ansi",
             "version": "6.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
@@ -11282,7 +11257,6 @@
         },
         "node_modules/which": {
             "version": "2.0.2",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"
@@ -11373,7 +11347,6 @@
         },
         "node_modules/wrap-ansi": {
             "version": "8.1.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^6.1.0",
@@ -11390,7 +11363,6 @@
         "node_modules/wrap-ansi-cjs": {
             "name": "wrap-ansi",
             "version": "7.0.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.0.0",
@@ -11406,12 +11378,10 @@
         },
         "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/wrap-ansi-cjs/node_modules/string-width": {
             "version": "4.2.3",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
@@ -11424,7 +11394,6 @@
         },
         "node_modules/wrap-ansi/node_modules/ansi-regex": {
             "version": "6.0.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -11435,7 +11404,6 @@
         },
         "node_modules/wrap-ansi/node_modules/ansi-styles": {
             "version": "6.2.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -11446,7 +11414,6 @@
         },
         "node_modules/wrap-ansi/node_modules/strip-ansi": {
             "version": "7.0.1",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^6.0.1"
@@ -11702,7 +11669,8 @@
             "dependencies": {
                 "@backtrace/sourcemap-tools": "^0.0.1",
                 "command-line-args": "^5.2.1",
-                "command-line-usage": "^7.0.1"
+                "command-line-usage": "^7.0.1",
+                "glob": "^10.3.3"
             },
             "devDependencies": {
                 "@types/command-line-args": "^5.2.0",
@@ -12182,7 +12150,8 @@
                 "@types/command-line-args": "^5.2.0",
                 "@types/command-line-usage": "^5.0.2",
                 "command-line-args": "^5.2.1",
-                "command-line-usage": "^7.0.1"
+                "command-line-usage": "^7.0.1",
+                "glob": "*"
             }
         },
         "@backtrace/node": {
@@ -12321,7 +12290,6 @@
         },
         "@isaacs/cliui": {
             "version": "8.0.2",
-            "dev": true,
             "requires": {
                 "string-width": "^5.1.2",
                 "string-width-cjs": "npm:string-width@^4.2.0",
@@ -12332,12 +12300,10 @@
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "6.0.1",
-                    "dev": true
+                    "version": "6.0.1"
                 },
                 "strip-ansi": {
                     "version": "7.0.1",
-                    "dev": true,
                     "requires": {
                         "ansi-regex": "^6.0.1"
                     }
@@ -12673,7 +12639,6 @@
         },
         "@pkgjs/parseargs": {
             "version": "0.11.0",
-            "dev": true,
             "optional": true
         },
         "@sinclair/typebox": {
@@ -13317,8 +13282,7 @@
             }
         },
         "ansi-regex": {
-            "version": "5.0.1",
-            "dev": true
+            "version": "5.0.1"
         },
         "ansi-styles": {
             "version": "4.3.0",
@@ -14292,7 +14256,6 @@
         },
         "cross-spawn": {
             "version": "7.0.3",
-            "dev": true,
             "requires": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -14630,8 +14593,7 @@
             }
         },
         "eastasianwidth": {
-            "version": "0.2.0",
-            "dev": true
+            "version": "0.2.0"
         },
         "electron-to-chromium": {
             "version": "1.4.408"
@@ -14660,8 +14622,7 @@
             "dev": true
         },
         "emoji-regex": {
-            "version": "9.2.2",
-            "dev": true
+            "version": "9.2.2"
         },
         "emojis-list": {
             "version": "3.0.0",
@@ -15432,7 +15393,6 @@
         },
         "foreground-child": {
             "version": "3.1.1",
-            "dev": true,
             "requires": {
                 "cross-spawn": "^7.0.0",
                 "signal-exit": "^4.0.1"
@@ -15534,26 +15494,25 @@
             "dev": true
         },
         "glob": {
-            "version": "10.2.6",
-            "dev": true,
+            "version": "10.3.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
+            "integrity": "sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==",
             "requires": {
                 "foreground-child": "^3.1.0",
                 "jackspeak": "^2.0.3",
                 "minimatch": "^9.0.1",
-                "minipass": "^5.0.0 || ^6.0.2",
-                "path-scurry": "^1.7.0"
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+                "path-scurry": "^1.10.1"
             },
             "dependencies": {
                 "brace-expansion": {
                     "version": "2.0.1",
-                    "dev": true,
                     "requires": {
                         "balanced-match": "^1.0.0"
                     }
                 },
                 "minimatch": {
                     "version": "9.0.1",
-                    "dev": true,
                     "requires": {
                         "brace-expansion": "^2.0.1"
                     }
@@ -15931,8 +15890,7 @@
             "dev": true
         },
         "is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "dev": true
+            "version": "3.0.0"
         },
         "is-generator-fn": {
             "version": "2.1.0",
@@ -16062,8 +16020,7 @@
             "version": "1.0.0"
         },
         "isexe": {
-            "version": "2.0.0",
-            "dev": true
+            "version": "2.0.0"
         },
         "isobject": {
             "version": "3.0.1",
@@ -16118,7 +16075,6 @@
         },
         "jackspeak": {
             "version": "2.2.1",
-            "dev": true,
             "requires": {
                 "@isaacs/cliui": "^8.0.2",
                 "@pkgjs/parseargs": "^0.11.0"
@@ -16714,8 +16670,9 @@
             }
         },
         "lru-cache": {
-            "version": "9.1.1",
-            "dev": true
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
+            "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw=="
         },
         "lz-string": {
             "version": "1.5.0",
@@ -16834,8 +16791,9 @@
             "dev": true
         },
         "minipass": {
-            "version": "6.0.2",
-            "dev": true
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.2.tgz",
+            "integrity": "sha512-eL79dXrE1q9dBbDCLg7xfn/vl7MS4F1gvJAgjJrQli/jbQWdUttuVawphqpffoIYfRdq78LHx6GP4bU/EQ2ATA=="
         },
         "mississippi": {
             "version": "3.0.0",
@@ -17231,19 +17189,19 @@
             "version": "1.0.1"
         },
         "path-key": {
-            "version": "3.1.1",
-            "dev": true
+            "version": "3.1.1"
         },
         "path-parse": {
             "version": "1.0.7",
             "dev": true
         },
         "path-scurry": {
-            "version": "1.9.2",
-            "dev": true,
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+            "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
             "requires": {
-                "lru-cache": "^9.1.1",
-                "minipass": "^5.0.0 || ^6.0.2"
+                "lru-cache": "^9.1.1 || ^10.0.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
             }
         },
         "path-type": {
@@ -17782,14 +17740,12 @@
         },
         "shebang-command": {
             "version": "2.0.0",
-            "dev": true,
             "requires": {
                 "shebang-regex": "^3.0.0"
             }
         },
         "shebang-regex": {
-            "version": "3.0.0",
-            "dev": true
+            "version": "3.0.0"
         },
         "side-channel": {
             "version": "1.0.4",
@@ -17801,8 +17757,7 @@
             }
         },
         "signal-exit": {
-            "version": "4.0.2",
-            "dev": true
+            "version": "4.0.2"
         },
         "sisteransi": {
             "version": "1.0.5",
@@ -18122,7 +18077,6 @@
         },
         "string-width": {
             "version": "5.1.2",
-            "dev": true,
             "requires": {
                 "eastasianwidth": "^0.2.0",
                 "emoji-regex": "^9.2.2",
@@ -18130,12 +18084,10 @@
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "6.0.1",
-                    "dev": true
+                    "version": "6.0.1"
                 },
                 "strip-ansi": {
                     "version": "7.0.1",
-                    "dev": true,
                     "requires": {
                         "ansi-regex": "^6.0.1"
                     }
@@ -18144,7 +18096,6 @@
         },
         "string-width-cjs": {
             "version": "npm:string-width@4.2.3",
-            "dev": true,
             "requires": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -18152,8 +18103,7 @@
             },
             "dependencies": {
                 "emoji-regex": {
-                    "version": "8.0.0",
-                    "dev": true
+                    "version": "8.0.0"
                 }
             }
         },
@@ -18186,14 +18136,12 @@
         },
         "strip-ansi": {
             "version": "6.0.1",
-            "dev": true,
             "requires": {
                 "ansi-regex": "^5.0.1"
             }
         },
         "strip-ansi-cjs": {
             "version": "npm:strip-ansi@6.0.1",
-            "dev": true,
             "requires": {
                 "ansi-regex": "^5.0.1"
             }
@@ -19418,7 +19366,6 @@
         },
         "which": {
             "version": "2.0.2",
-            "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
             }
@@ -19478,7 +19425,6 @@
         },
         "wrap-ansi": {
             "version": "8.1.0",
-            "dev": true,
             "requires": {
                 "ansi-styles": "^6.1.0",
                 "string-width": "^5.0.1",
@@ -19486,16 +19432,13 @@
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "6.0.1",
-                    "dev": true
+                    "version": "6.0.1"
                 },
                 "ansi-styles": {
-                    "version": "6.2.1",
-                    "dev": true
+                    "version": "6.2.1"
                 },
                 "strip-ansi": {
                     "version": "7.0.1",
-                    "dev": true,
                     "requires": {
                         "ansi-regex": "^6.0.1"
                     }
@@ -19504,7 +19447,6 @@
         },
         "wrap-ansi-cjs": {
             "version": "npm:wrap-ansi@7.0.0",
-            "dev": true,
             "requires": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -19512,12 +19454,10 @@
             },
             "dependencies": {
                 "emoji-regex": {
-                    "version": "8.0.0",
-                    "dev": true
+                    "version": "8.0.0"
                 },
                 "string-width": {
                     "version": "4.2.3",
-                    "dev": true,
                     "requires": {
                         "emoji-regex": "^8.0.0",
                         "is-fullwidth-code-point": "^3.0.0",

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -39,7 +39,8 @@
     "dependencies": {
         "@backtrace/sourcemap-tools": "^0.0.1",
         "command-line-args": "^5.2.1",
-        "command-line-usage": "^7.0.1"
+        "command-line-usage": "^7.0.1",
+        "glob": "^10.3.3"
     },
     "devDependencies": {
         "@types/command-line-args": "^5.2.0",

--- a/tools/cli/src/helpers/find.ts
+++ b/tools/cli/src/helpers/find.ts
@@ -1,5 +1,6 @@
 import { Err, FileFinder, Ok, ResultPromise } from '@backtrace/sourcemap-tools';
 import fs from 'fs';
+import { glob } from 'glob';
 import path from 'path';
 
 /**
@@ -11,28 +12,32 @@ import path from 'path';
 export async function find(regex: RegExp, ...paths: string[]): ResultPromise<string[], string> {
     const finder = new FileFinder();
     const results = new Map<string, string>();
-    for (const findPath of paths) {
-        const stat = await fs.promises.stat(findPath);
-        if (!stat.isDirectory()) {
-            if (!findPath.match(regex)) {
-                return Err(`${findPath} does not match regex: ${regex}`);
-            }
-            const fullPath = path.resolve(findPath);
-            if (!results.has(fullPath)) {
-                results.set(fullPath, findPath);
-            }
-            continue;
-        }
 
-        const findResult = await finder.find(findPath, { match: regex, recursive: true });
-        if (findResult.isErr()) {
-            return findResult;
-        }
+    for (const globPath of paths) {
+        const globResults = await glob(globPath);
+        for (const findPath of globResults) {
+            const stat = await fs.promises.stat(findPath);
+            if (!stat.isDirectory()) {
+                if (!findPath.match(regex)) {
+                    return Err(`${findPath} does not match regex: ${regex}`);
+                }
+                const fullPath = path.resolve(findPath);
+                if (!results.has(fullPath)) {
+                    results.set(fullPath, findPath);
+                }
+                continue;
+            }
 
-        for (const result of findResult.data) {
-            const fullPath = path.resolve(result);
-            if (!results.has(fullPath)) {
-                results.set(fullPath, result);
+            const findResult = await finder.find(findPath, { match: regex, recursive: true });
+            if (findResult.isErr()) {
+                return findResult;
+            }
+
+            for (const result of findResult.data) {
+                const fullPath = path.resolve(result);
+                if (!results.has(fullPath)) {
+                    results.set(fullPath, result);
+                }
             }
         }
     }


### PR DESCRIPTION
This PR adds the possibility of using glob patterns in the CLI, for example:

```
backtrace-js add-sources ./dir1/**/lib ./dir2/**/**/dir3`
```