### PR TITLE
Add bin entry to CLI.

### DIFF
--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -7,6 +7,9 @@
     "engines": {
         "node": ">=14"
     },
+    "bin": {
+        "backtrace-js": "./lib/index.js"
+    },
     "scripts": {
         "build": "tsc",
         "clean": "tsc -b --clean && rimraf \"lib\"",

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import commandLineArgs from 'command-line-args';
 import { Command } from './commands/Command';
 import { LoggerOptions, createLogger } from './logger';


### PR DESCRIPTION
This adds `backtrace-js` as a bin entry to enable using `backtrace-js` in the shell.