### PR TITLE
Include symbolication in the diagnostic error object

### DIFF
--- a/packages/sdk-core/src/model/data/BacktraceData.ts
+++ b/packages/sdk-core/src/model/data/BacktraceData.ts
@@ -14,4 +14,5 @@ export interface BacktraceData {
     attributes: Record<string, AttributeType>;
     annotations: Record<string, unknown>;
     threads: Record<string, BacktraceStackTrace>;
+    symbolication?: 'sourcemap';
 }

--- a/packages/sdk-core/src/modules/data/BacktraceDataBuilder.ts
+++ b/packages/sdk-core/src/modules/data/BacktraceDataBuilder.ts
@@ -24,11 +24,18 @@ export class BacktraceDataBuilder {
 
         const stackTrace = this._stackTraceConverter.convert(report.stackTrace, report.message);
 
+        let detectedDebugIdentifier = false;
+
         for (const frame of stackTrace) {
-            frame.debug_identifier = this._debugIdProvider.getDebugId(frame.library);
+            const debugIdentifier = this._debugIdProvider.getDebugId(frame.library);
+            if (!debugIdentifier) {
+                continue;
+            }
+            detectedDebugIdentifier = true;
+            frame.debug_identifier = debugIdentifier;
         }
 
-        return {
+        const result: BacktraceData = {
             uuid: IdGenerator.uuid(),
             timestamp: TimeHelper.toTimestampInSec(report.timestamp),
             agent: this._sdkOptions.agent,
@@ -54,5 +61,11 @@ export class BacktraceDataBuilder {
                 ...reportData.attributes,
             },
         };
+
+        if (detectedDebugIdentifier) {
+            result.symbolication = 'sourcemap';
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
# Why

This diff adds the symbolication type to the backtrace data object. By doing that, the backend can start using source maps to adjust stack trace