### PR TITLE
Before send event support

### DIFF
--- a/packages/sdk-core/src/model/configuration/BacktraceConfiguration.ts
+++ b/packages/sdk-core/src/model/configuration/BacktraceConfiguration.ts
@@ -1,4 +1,5 @@
 import { BacktraceAttachment } from '../attachment';
+import { BacktraceData } from '../data/BacktraceData';
 import { BacktraceDatabaseConfiguration } from './BacktraceDatabaseConfiguration';
 
 export interface BacktraceMetricsOptions {
@@ -55,6 +56,13 @@ export interface BacktraceConfiguration {
     token?: string;
     timeout?: number;
     ignoreSslCertificate?: boolean;
+
+    /**
+     * Triggers an event every time an exception in the managed environment occurs, which allows you to skip the report (by returning a null value)
+     * or to modify data that library collected before sending the report. You can use the BeforeSend event to extend attributes or JSON object
+     * data based on data the application has at the time of exception.
+     */
+    beforeSend?: (data: BacktraceData) => BacktraceData | undefined;
 
     /**
      * Limits the number of reports the client will send per minute. If set to '0', there is no limit.

--- a/packages/sdk-core/tests/client/attributesTests.spec.ts
+++ b/packages/sdk-core/tests/client/attributesTests.spec.ts
@@ -47,7 +47,7 @@ describe('Attributes tests', () => {
             const scopedAttributeGetFunction = jest
                 .fn()
                 .mockReturnValue({ [providerAttributeKey]: providerAttributeValue });
-            const fakeClient = BacktraceTestClient.buildFakeClient([
+            const fakeClient = BacktraceTestClient.buildFakeClient({}, [
                 {
                     type: 'scoped',
                     get: scopedAttributeGetFunction,
@@ -66,7 +66,7 @@ describe('Attributes tests', () => {
             const scopedAttributeGetFunction = jest
                 .fn()
                 .mockReturnValue({ [providerAttributeKey]: providerAttributeValue });
-            const fakeClient = BacktraceTestClient.buildFakeClient([
+            const fakeClient = BacktraceTestClient.buildFakeClient({}, [
                 {
                     type: 'dynamic',
                     get: scopedAttributeGetFunction,

--- a/packages/sdk-core/tests/client/clientCallbacksTests.spec.ts
+++ b/packages/sdk-core/tests/client/clientCallbacksTests.spec.ts
@@ -1,0 +1,50 @@
+import { BacktraceReportSubmissionResult } from '../../src';
+import { BacktraceData } from '../../src/model/data/BacktraceData';
+import { BacktraceTestClient } from '../mocks/BacktraceTestClient';
+
+describe('Client callbacks tests', () => {
+    describe('Submission data modification tests', () => {
+        it('Should invoke the before send event', async () => {
+            let triggered = false;
+            const client = BacktraceTestClient.buildFakeClient({
+                beforeSend: (data) => {
+                    triggered = true;
+                    return data;
+                },
+            });
+
+            await client.send(new Error());
+            expect(triggered).toBeTruthy();
+        });
+
+        it('Should allow to modify the report attribute', async () => {
+            const attributeName = 'test';
+            const expectedAttributeVaue = 'invoked';
+            const client = BacktraceTestClient.buildFakeClient({
+                beforeSend: (data) => {
+                    data.attributes[attributeName] = expectedAttributeVaue;
+                    return data;
+                },
+            });
+            jest.spyOn(client.requestHandler, 'postError').mockImplementationOnce((_: string, data: BacktraceData) => {
+                expect(data.attributes[attributeName]).toEqual(expectedAttributeVaue);
+                return Promise.resolve(BacktraceReportSubmissionResult.Ok({}));
+            });
+
+            client.addAttribute({ [attributeName]: 'not-invoked' });
+
+            await client.send(new Error());
+        });
+
+        it('Should skip sending events if the user decide not to send it', async () => {
+            const client = BacktraceTestClient.buildFakeClient({
+                beforeSend: () => {
+                    return undefined;
+                },
+            });
+
+            await client.send(new Error());
+            expect(client.requestHandler.postError).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/sdk-core/tests/client/clientTests.spec.ts
+++ b/packages/sdk-core/tests/client/clientTests.spec.ts
@@ -43,7 +43,7 @@ describe('Client tests', () => {
                 },
             };
 
-            const client = BacktraceTestClient.buildFakeClient([], [inMemoryAttachment]);
+            const client = BacktraceTestClient.buildFakeClient({}, [], [inMemoryAttachment]);
 
             expect(client.attachments).toBeDefined();
             expect(client.attachments.length).toEqual(1);
@@ -90,7 +90,7 @@ describe('Client tests', () => {
                     return new Uint8Array(0);
                 },
             };
-            const client = BacktraceTestClient.buildFakeClient([], [clientAttachment]);
+            const client = BacktraceTestClient.buildFakeClient({}, [], [clientAttachment]);
 
             await client.send(new Error(''), {}, [reportAttachment]);
 

--- a/packages/sdk-core/tests/mocks/BacktraceTestClient.ts
+++ b/packages/sdk-core/tests/mocks/BacktraceTestClient.ts
@@ -1,6 +1,7 @@
 import {
     BacktraceAttachment,
     BacktraceAttributeProvider,
+    BacktraceConfiguration,
     BacktraceCoreClient,
     BacktraceReportSubmissionResult,
     BacktraceRequestHandler,
@@ -13,18 +14,22 @@ export const APPLICATION_VERSION = '5.4.3';
 export class BacktraceTestClient extends BacktraceCoreClient {
     public readonly requestHandler: BacktraceRequestHandler;
     constructor(
+        options: Partial<BacktraceConfiguration>,
         handler: BacktraceRequestHandler,
         attributeProviders: BacktraceAttributeProvider[] = [],
         attachments: BacktraceAttachment[] = [],
     ) {
         super(
             {
-                url: TEST_SUBMISSION_URL,
-                token: TOKEN,
-                attachments,
-                metrics: {
-                    enable: false,
+                ...{
+                    url: TEST_SUBMISSION_URL,
+                    token: TOKEN,
+                    attachments,
+                    metrics: {
+                        enable: false,
+                    },
                 },
+                ...(options ?? {}),
             },
             {
                 agent: 'test',
@@ -39,6 +44,7 @@ export class BacktraceTestClient extends BacktraceCoreClient {
     }
 
     public static buildFakeClient(
+        options: Partial<BacktraceConfiguration> = {},
         attributeProviders: BacktraceAttributeProvider[] = [],
         attachments: BacktraceAttachment[] = [],
     ) {
@@ -52,6 +58,7 @@ export class BacktraceTestClient extends BacktraceCoreClient {
             },
         });
         return new BacktraceTestClient(
+            options,
             {
                 post: jest.fn().mockResolvedValue(Promise.resolve(BacktraceReportSubmissionResult.Ok('Ok'))),
                 postError: jest.fn().mockResolvedValue(Promise.resolve()),


### PR DESCRIPTION
# Why

This diff adds before send event to the client. We're trying to be consistent between different clients and SDKs that we offer. All our managed SDKs offer "before send" event to modify data or even skip sending it for any reason. Why do customers want to use it?
- based on dynamic criteria, decide to not send it
- apply PII settings 
- apply custom attribute logic when error happen 
