### PR TITLE
sourcemap tools: fix doesSourceMapHaveSources with undefined sources

### DIFF
--- a/tools/sourcemap-tools/src/SourceProcessor.ts
+++ b/tools/sourcemap-tools/src/SourceProcessor.ts
@@ -202,7 +202,7 @@ export class SourceProcessor {
     }
 
     public doesSourceMapHaveSources(sourceMap: RawSourceMap): boolean {
-        return sourceMap.sources.length === sourceMap.sourcesContent?.length;
+        return sourceMap.sources?.length === sourceMap.sourcesContent?.length;
     }
 
     private async offsetSourceMap(


### PR DESCRIPTION
* Fixes issue when sourcemap does not have the `sources` array or it is `null`.


