### PR TITLE
cli: quality of life improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4569,7 +4569,6 @@
         },
         "node_modules/error-ex": {
             "version": "1.3.2",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-arrayish": "^0.2.1"
@@ -5403,6 +5402,11 @@
             "version": "2.0.6",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/fast-safe-stringify": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
         },
         "node_modules/fastest-levenshtein": {
             "version": "1.0.16",
@@ -6379,7 +6383,6 @@
         },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/is-bigint": {
@@ -7513,7 +7516,6 @@
         },
         "node_modules/json-parse-better-errors": {
             "version": "1.0.2",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/json-parse-even-better-errors": {
@@ -7543,6 +7545,42 @@
             },
             "bin": {
                 "json5": "lib/cli.js"
+            }
+        },
+        "node_modules/jsonc": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/jsonc/-/jsonc-2.0.0.tgz",
+            "integrity": "sha512-B281bLCT2TRMQa+AQUQY5AGcqSOXBOKaYGP4wDzoA/+QswUfN8sODektbPEs9Baq7LGKun5jQbNFpzwGuVYKhw==",
+            "dependencies": {
+                "fast-safe-stringify": "^2.0.6",
+                "graceful-fs": "^4.1.15",
+                "mkdirp": "^0.5.1",
+                "parse-json": "^4.0.0",
+                "strip-bom": "^4.0.0",
+                "strip-json-comments": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/jsonc/node_modules/parse-json": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+            "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+            "dependencies": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/jsonc/node_modules/strip-bom": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+            "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/kind-of": {
@@ -7874,7 +7912,6 @@
         },
         "node_modules/minimist": {
             "version": "1.2.8",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -7922,7 +7959,6 @@
         },
         "node_modules/mkdirp": {
             "version": "0.5.6",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "minimist": "^1.2.6"
@@ -10035,7 +10071,6 @@
         },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -12303,7 +12338,8 @@
                 "@backtrace/sourcemap-tools": "^0.0.1",
                 "command-line-args": "^5.2.1",
                 "command-line-usage": "^7.0.1",
-                "glob": "^10.3.3"
+                "glob": "^10.3.3",
+                "jsonc": "^2.0.0"
             },
             "bin": {
                 "backtrace-js": "lib/index.js"
@@ -12825,7 +12861,8 @@
                 "@types/command-line-usage": "^5.0.2",
                 "command-line-args": "^5.2.1",
                 "command-line-usage": "^7.0.1",
-                "glob": "^10.3.3"
+                "glob": "^10.3.3",
+                "jsonc": "*"
             }
         },
         "@backtrace/node": {
@@ -15531,7 +15568,6 @@
         },
         "error-ex": {
             "version": "1.3.2",
-            "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
             }
@@ -16121,6 +16157,11 @@
         "fast-levenshtein": {
             "version": "2.0.6",
             "dev": true
+        },
+        "fast-safe-stringify": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
         },
         "fastest-levenshtein": {
             "version": "1.0.16",
@@ -16736,8 +16777,7 @@
             }
         },
         "is-arrayish": {
-            "version": "0.2.1",
-            "dev": true
+            "version": "0.2.1"
         },
         "is-bigint": {
             "version": "1.0.4",
@@ -17468,8 +17508,7 @@
             "dev": true
         },
         "json-parse-better-errors": {
-            "version": "1.0.2",
-            "dev": true
+            "version": "1.0.2"
         },
         "json-parse-even-better-errors": {
             "version": "2.3.1"
@@ -17490,6 +17529,35 @@
             "dev": true,
             "requires": {
                 "minimist": "^1.2.0"
+            }
+        },
+        "jsonc": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/jsonc/-/jsonc-2.0.0.tgz",
+            "integrity": "sha512-B281bLCT2TRMQa+AQUQY5AGcqSOXBOKaYGP4wDzoA/+QswUfN8sODektbPEs9Baq7LGKun5jQbNFpzwGuVYKhw==",
+            "requires": {
+                "fast-safe-stringify": "^2.0.6",
+                "graceful-fs": "^4.1.15",
+                "mkdirp": "^0.5.1",
+                "parse-json": "^4.0.0",
+                "strip-bom": "^4.0.0",
+                "strip-json-comments": "^3.0.1"
+            },
+            "dependencies": {
+                "parse-json": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                    "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+                    "requires": {
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
+                    }
+                },
+                "strip-bom": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+                    "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
+                }
             }
         },
         "kind-of": {
@@ -17709,8 +17777,7 @@
             }
         },
         "minimist": {
-            "version": "1.2.8",
-            "dev": true
+            "version": "1.2.8"
         },
         "minipass": {
             "version": "7.0.2",
@@ -17743,7 +17810,6 @@
         },
         "mkdirp": {
             "version": "0.5.6",
-            "dev": true,
             "requires": {
                 "minimist": "^1.2.6"
             }
@@ -19123,8 +19189,7 @@
             "dev": true
         },
         "strip-json-comments": {
-            "version": "3.1.1",
-            "dev": true
+            "version": "3.1.1"
         },
         "supports-color": {
             "version": "7.2.0",

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -43,7 +43,8 @@
         "@backtrace/sourcemap-tools": "^0.0.1",
         "command-line-args": "^5.2.1",
         "command-line-usage": "^7.0.1",
-        "glob": "^10.3.3"
+        "glob": "^10.3.3",
+        "jsonc": "^2.0.0"
     },
     "devDependencies": {
         "@types/command-line-args": "^5.2.0",

--- a/tools/cli/src/helpers/jsonc.ts
+++ b/tools/cli/src/helpers/jsonc.ts
@@ -1,0 +1,7 @@
+import { Err, Ok, Result } from '@backtrace/sourcemap-tools';
+import { jsonc } from 'jsonc';
+
+export function parseJSONC<T>(content: string): Result<T, string> {
+    const [err, result] = jsonc.safe.parse(content);
+    return !err ? Ok(result) : Err(`failed to parse content: ${err.message}`);
+}

--- a/tools/cli/src/helpers/normalizePaths.ts
+++ b/tools/cli/src/helpers/normalizePaths.ts
@@ -1,0 +1,15 @@
+export function normalizePaths(paths: string | string[] | undefined, defaults: string | string[]) {
+    if (!paths || !paths.length) {
+        return toArray(defaults);
+    }
+
+    return toArray(paths);
+}
+
+function toArray<T>(t: T | T[]) {
+    if (Array.isArray(t)) {
+        return t;
+    }
+
+    return [t];
+}

--- a/tools/cli/src/helpers/version.ts
+++ b/tools/cli/src/helpers/version.ts
@@ -6,7 +6,11 @@ interface PackageJson {
 }
 
 export function loadVersion() {
-    return AsyncResult.equip(readFile(path.join(__dirname, '../../package.json')))
+    const packageJsonPath = require.main?.path
+        ? path.join(require.main?.path, '..', 'package.json')
+        : path.join(__dirname, '../../package.json');
+
+    return AsyncResult.equip(readFile(packageJsonPath))
         .then(parseJSON<PackageJson>)
         .then((p) => p.version).inner;
 }

--- a/tools/cli/src/helpers/version.ts
+++ b/tools/cli/src/helpers/version.ts
@@ -1,0 +1,12 @@
+import { AsyncResult, parseJSON, readFile } from '@backtrace/sourcemap-tools';
+import path from 'path';
+
+interface PackageJson {
+    readonly version: string;
+}
+
+export function loadVersion() {
+    return AsyncResult.equip(readFile(path.join(__dirname, '../../package.json')))
+        .then(parseJSON<PackageJson>)
+        .then((p) => p.version).inner;
+}

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
+import { AsyncResult, Err } from '@backtrace/sourcemap-tools';
 import commandLineArgs from 'command-line-args';
 import { Command } from './commands/Command';
+import { loadVersion } from './helpers/version';
 import { LoggerOptions, createLogger } from './logger';
 import { addSourcesCmd } from './sourcemaps/add-sources';
 import { processCmd } from './sourcemaps/process';
@@ -11,7 +13,11 @@ export interface GlobalOptions extends LoggerOptions {
     readonly help: boolean;
 }
 
-const mainCommand = new Command<GlobalOptions>({
+export interface MainOptions {
+    readonly version: boolean;
+}
+
+const mainCommand = new Command<GlobalOptions & MainOptions>({
     name: '',
 })
     .subcommand(processCmd)
@@ -44,6 +50,32 @@ const mainCommand = new Command<GlobalOptions>({
         type: String,
         global: true,
         description: 'Sets the logging level. Can be one of: quiet, error, warn, info, debug, verbose. Default: info',
+    })
+    .option({
+        name: 'version',
+        type: Boolean,
+        description: 'Displays the version of backtrace-js',
+    })
+    .execute(function (opts, stack, unknown) {
+        const logger = createLogger(opts);
+        if (opts.version) {
+            return AsyncResult.equip(loadVersion())
+                .then((version) => logger.output(version))
+                .then(() => 0).inner;
+        } else {
+            logger.info(this.getHelpMessage(stack));
+
+            const unknownOption = unknown?.[0];
+            if (!unknownOption) {
+                return Err(`Unknown command.`);
+            }
+
+            if (unknownOption.startsWith('-')) {
+                return Err(`Unknown option: ${unknownOption}`);
+            }
+
+            return Err(`Unknown command: ${unknownOption}`);
+        }
     });
 
 (async () => {

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -5,12 +5,14 @@ import commandLineArgs from 'command-line-args';
 import { Command } from './commands/Command';
 import { loadVersion } from './helpers/version';
 import { LoggerOptions, createLogger } from './logger';
+import { DEFAULT_OPTIONS_PATH } from './options/loadOptions';
 import { addSourcesCmd } from './sourcemaps/add-sources';
 import { processCmd } from './sourcemaps/process';
 import { uploadCmd } from './sourcemaps/upload';
 
 export interface GlobalOptions extends LoggerOptions {
     readonly help: boolean;
+    readonly config: string;
 }
 
 export interface MainOptions {
@@ -50,6 +52,12 @@ const mainCommand = new Command<GlobalOptions & MainOptions>({
         type: String,
         global: true,
         description: 'Sets the logging level. Can be one of: quiet, error, warn, info, debug, verbose. Default: info',
+    })
+    .option({
+        name: 'config',
+        type: String,
+        global: true,
+        description: `Path to the config file. Default: ${DEFAULT_OPTIONS_PATH}`,
     })
     .option({
         name: 'version',

--- a/tools/cli/src/options/loadOptions.ts
+++ b/tools/cli/src/options/loadOptions.ts
@@ -1,0 +1,44 @@
+import { AsyncResult, Ok, ResultPromise, parseJSON, readFile } from '@backtrace/sourcemap-tools';
+import { CliOptions, CommandCliOptions } from './models/CliOptions';
+
+export const DEFAULT_OPTIONS_PATH = '.backtracejsrc';
+
+export function loadAndJoinOptions(path?: string) {
+    return async function loadAndJoinOptions<K extends keyof CommandCliOptions>(
+        key: K,
+        options: Partial<CommandCliOptions[K]>,
+        defaults?: Partial<CommandCliOptions[K]>,
+    ): ResultPromise<Partial<CommandCliOptions[K]>, string> {
+        const readResult = await readFile(path ?? DEFAULT_OPTIONS_PATH);
+        if (readResult.isErr()) {
+            return path ? readResult : Ok(options);
+        }
+
+        return AsyncResult.equip(readResult)
+            .then(parseJSON<CliOptions>)
+            .then(joinOptions(key, options, defaults)).inner;
+    };
+}
+
+export function loadOptions(path?: string) {
+    return AsyncResult.equip(readFile(path ?? DEFAULT_OPTIONS_PATH)).then(parseJSON<CliOptions>).inner;
+}
+
+export function joinOptions<K extends keyof CommandCliOptions>(
+    key: K,
+    options: Partial<CommandCliOptions[K]>,
+    defaults?: Partial<CommandCliOptions[K]>,
+) {
+    return function joinOptions(loadedOptions: CliOptions): Partial<CommandCliOptions[K] & CliOptions> {
+        // console.log(key, defaults, loadedOptions, loadedOptions[key], options);
+        return {
+            ...defaults,
+            ...loadedOptions,
+            ...loadedOptions[key],
+            ...options,
+            'add-sources': undefined,
+            upload: undefined,
+            process: undefined,
+        };
+    };
+}

--- a/tools/cli/src/options/loadOptions.ts
+++ b/tools/cli/src/options/loadOptions.ts
@@ -1,4 +1,5 @@
 import { AsyncResult, Ok, ResultPromise, parseJSON, readFile } from '@backtrace/sourcemap-tools';
+import { parseJSONC } from '../helpers/jsonc';
 import { CliOptions, CommandCliOptions } from './models/CliOptions';
 
 export const DEFAULT_OPTIONS_PATH = '.backtracejsrc';
@@ -15,7 +16,7 @@ export function loadAndJoinOptions(path?: string) {
         }
 
         return AsyncResult.equip(readResult)
-            .then(parseJSON<CliOptions>)
+            .then(parseJSONC<CliOptions>)
             .then(joinOptions(key, options, defaults)).inner;
     };
 }

--- a/tools/cli/src/options/models/CliOptions.ts
+++ b/tools/cli/src/options/models/CliOptions.ts
@@ -1,0 +1,22 @@
+import { GlobalOptions } from '../..';
+import { AddSourcesOptions } from '../../sourcemaps/add-sources';
+import { ProcessOptions } from '../../sourcemaps/process';
+import { UploadOptions } from '../../sourcemaps/upload';
+
+export type CommonCliOptions = Omit<
+    {
+        [K in keyof UploadOptions & keyof AddSourcesOptions & keyof ProcessOptions]:
+            | UploadOptions[K]
+            | AddSourcesOptions[K]
+            | ProcessOptions[K];
+    },
+    keyof GlobalOptions
+>;
+
+export interface CommandCliOptions {
+    readonly upload: UploadOptions;
+    readonly 'add-sources': AddSourcesOptions;
+    readonly process: ProcessOptions;
+}
+
+export type CliOptions = Partial<CommonCliOptions & CommandCliOptions>;

--- a/tools/cli/src/sourcemaps/add-sources.ts
+++ b/tools/cli/src/sourcemaps/add-sources.ts
@@ -133,13 +133,18 @@ export const addSourcesCmd = new Command<AddSourcesOptions>({
             .then(filter(matchSourceMapExtension))
             .then(logDebug((r) => `found ${r.length} files matching sourcemap extension`))
             .then(map(logTrace((path) => `file matching extension: ${path}`)))
+            .then(opts['pass-with-no-files'] ? Ok : failIfEmpty('no sourcemaps found'))
             .then(map(toAsset))
             .then(map(readAssetCommand))
             .then(map(loadAssetCommand))
             .then(opts.force ? Ok : filterAssetsCommand)
             .then(logDebug((r) => `adding sources to ${r.length} files`))
             .then(map(logTrace(({ path }) => `file to add sources to: ${path}`)))
-            .then(opts['pass-with-no-files'] ? Ok : failIfEmpty('no valid sourcemaps found'))
+            .then(
+                opts['pass-with-no-files']
+                    ? Ok
+                    : failIfEmpty('no sourcemaps without sources found, use --force to overwrite sources'),
+            )
             .then(map(addSourceCommand))
             .then(opts['dry-run'] ? Ok : map(writeSourceMapCommand))
             .then(map(output(logger)))

--- a/tools/cli/src/sourcemaps/add-sources.ts
+++ b/tools/cli/src/sourcemaps/add-sources.ts
@@ -18,10 +18,12 @@ import { GlobalOptions } from '..';
 import { Command } from '../commands/Command';
 import { find } from '../helpers/find';
 import { logAsset } from '../helpers/logs';
+import { normalizePaths } from '../helpers/normalizePaths';
 import { CliLogger, createLogger } from '../logger';
+import { loadAndJoinOptions } from '../options/loadOptions';
 
-interface AddSourcesOptions extends GlobalOptions {
-    readonly path: string[];
+export interface AddSourcesOptions extends GlobalOptions {
+    readonly path: string | string[];
     readonly 'dry-run': boolean;
     readonly force: boolean;
     readonly skipFailing: boolean;
@@ -44,7 +46,6 @@ export const addSourcesCmd = new Command<AddSourcesOptions>({
         name: 'path',
         description: 'Path to sourcemap files to append sources to.',
         defaultOption: true,
-        defaultValue: process.cwd(),
         multiple: true,
         alias: 'p',
     })
@@ -53,27 +54,35 @@ export const addSourcesCmd = new Command<AddSourcesOptions>({
         alias: 'n',
         type: Boolean,
         description: 'Does not modify the files at the end.',
-        defaultValue: false,
     })
     .option({
         name: 'force',
         alias: 'f',
         type: Boolean,
         description: 'Processes files even if sourcesContent is not empty. Will overwrite existing sources.',
-        defaultValue: false,
     })
     .option({
         name: 'pass-with-no-files',
         type: Boolean,
         description: 'Exits with zero exit code if no sourcemaps are found.',
     })
-    .execute(function (opts, stack) {
+    .execute(async function (opts, stack) {
         const logger = createLogger(opts);
         const sourceProcessor = new SourceProcessor(new DebugIdGenerator());
+
+        const optsResult = await loadAndJoinOptions(opts.config)('add-sources', opts, {
+            path: process.cwd(),
+        });
+        if (optsResult.isErr()) {
+            return optsResult;
+        }
+
+        opts = optsResult.data;
+
         logger.trace(`resolved options: \n${JSON.stringify(opts, null, '  ')}`);
 
-        const searchPaths = opts.path;
-        if (!searchPaths) {
+        const searchPaths = normalizePaths(opts.path, process.cwd());
+        if (!searchPaths.length) {
             logger.info(this.getHelpMessage(stack));
             return Err('path must be specified');
         }

--- a/tools/cli/src/sourcemaps/process.ts
+++ b/tools/cli/src/sourcemaps/process.ts
@@ -113,11 +113,16 @@ export const processCmd = new Command<ProcessOptions>({
             .then(filter(matchSourceExtension))
             .then(logDebug((r) => `found ${r.length} files matching source extension`))
             .then(map(logTrace((path) => `file matching extension: ${path}`)))
+            .then(opts['pass-with-no-files'] ? Ok : failIfEmpty('no source files found'))
             .then(map(toAsset))
             .then(opts.force ? Ok : filterUnprocessedAssetsCommand)
             .then(logDebug((r) => `processing ${r.length} files`))
             .then(map(logTrace(({ path }) => `file to process: ${path}`)))
-            .then(opts['pass-with-no-files'] ? Ok : failIfEmpty('no files for processing found'))
+            .then(
+                opts['pass-with-no-files']
+                    ? Ok
+                    : failIfEmpty('no files for processing found, they may be already processed'),
+            )
             .then(map(processCommand))
             .then(opts['dry-run'] ? Ok : map(writeCommand))
             .then(map(output(logger)))

--- a/tools/cli/src/sourcemaps/upload.ts
+++ b/tools/cli/src/sourcemaps/upload.ts
@@ -177,12 +177,17 @@ export const uploadCmd = new Command<UploadOptions>({
             .then(filter(matchSourceMapExtension))
             .then(logDebug((r) => `found ${r.length} files matching sourcemap extension`))
             .then(map(logTrace((path) => `file matching extension: ${path}`)))
+            .then(opts['pass-with-no-files'] ? Ok : failIfEmpty('no sourcemaps found'))
             .then(map(toAsset))
             .then(opts.force ? Ok : filterProcessedAssetsCommand)
             .then(map(loadSourceMapCommand))
             .then(logDebug((r) => `uploading ${r.length} files`))
             .then(map(logTrace(({ path }) => `file to upload: ${path}`)))
-            .then(opts['pass-with-no-files'] ? Ok : failIfEmpty('no files for uploading found'))
+            .then(
+                opts['pass-with-no-files']
+                    ? Ok
+                    : failIfEmpty('no processed sourcemaps found, make sure to run process first'),
+            )
             .then(createArchiveCommand)
             .then((archive) => (opts['dry-run'] ? Ok(null) : saveArchiveCommand(archive)))
             .then(output(logger))


### PR DESCRIPTION
* `--version` option
* Additional messages about missing files for processing/upload/adding sources
* Add `.backracejsrc` file support, which enables configuration of every command line option, for example:
  ```jsonc
  {
      // Supports comments!
      "path": "global path",
      "add-sources": {
          "path": "add-sources specific path"
      },
      "upload": {
          "url": "url for uploading"
      }
  }
  ```