### PR TITLE
Database send operations

### DIFF
--- a/packages/node/src/database/BacktraceDatabaseFileRecord.ts
+++ b/packages/node/src/database/BacktraceDatabaseFileRecord.ts
@@ -6,6 +6,7 @@ export class BacktraceDatabaseFileRecord implements BacktraceDatabaseRecord {
     public readonly id: string;
     public readonly count: number;
     public readonly hash: string;
+    public readonly timestamp: number;
     public locked: boolean;
 
     private constructor(record: BacktraceDatabaseRecord, public readonly attachments: BacktraceFileAttachment[]) {
@@ -13,6 +14,7 @@ export class BacktraceDatabaseFileRecord implements BacktraceDatabaseRecord {
         this.id = record.id;
         this.count = record.count;
         this.hash = record.hash;
+        this.timestamp = record.timestamp;
         // make sure the database record stored in the database directory
         // is never locked. By doing this, we want to be sure once we load
         // the record once again, the record will be available for future usage

--- a/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
+++ b/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
@@ -1,4 +1,5 @@
 import { IdGenerator } from '../../common/IdGenerator';
+import { TimeHelper } from '../../common/TimeHelper';
 import { BacktraceAttachment } from '../../model/attachment';
 import { BacktraceDatabaseConfiguration } from '../../model/configuration/BacktraceDatabaseConfiguration';
 import { BacktraceData } from '../../model/data/BacktraceData';
@@ -73,9 +74,10 @@ export class BacktraceDatabase {
 
         this.prepareDatabase();
 
-        const record = {
+        const record: BacktraceDatabaseRecord = {
             count: 1,
             data: backtraceData,
+            timestamp: TimeHelper.now(),
             hash: '',
             id: IdGenerator.uuid(),
             locked: false,
@@ -129,6 +131,43 @@ export class BacktraceDatabase {
     }
 
     /**
+     * Sends all records available in the database to Backtrace and removes them
+     * no matter if the submission process was successful or not.
+     */
+    public async flush() {
+        const start = TimeHelper.now();
+        await this.send();
+        const records = this.get().filter((n) => n.timestamp <= start);
+        for (const record of records) {
+            this.remove(record);
+        }
+    }
+    /**
+     * Sends all records available in the database to Backtrace.
+     */
+    public async send() {
+        for (let bucketIndex = 0; bucketIndex < this._databaseRecordContext.bucketCount; bucketIndex++) {
+            for (const record of this._databaseRecordContext.getBucket(bucketIndex)) {
+                if (record.locked) {
+                    continue;
+                }
+                try {
+                    record.locked = true;
+                    const result = await this._requestHandler.send(record.data, record.attachments);
+                    if (result.status === 'Ok') {
+                        this.remove(record);
+                        continue;
+                    }
+                    this._databaseRecordContext.increaseBucket(bucketIndex);
+                    return;
+                } finally {
+                    record.locked = false;
+                }
+            }
+        }
+    }
+
+    /**
      * Prepare database to insert records
      * @param totalNumberOfRecords number of records to insert
      */
@@ -158,31 +197,9 @@ export class BacktraceDatabase {
         }
 
         const sendDatabaseReports = async () => {
-            await this.sendRecords();
+            await this.send();
         };
         this._intervalId = setInterval(sendDatabaseReports, this._retryInterval);
-        await this.sendRecords();
-    }
-
-    private async sendRecords() {
-        for (let bucketIndex = 0; bucketIndex < this._databaseRecordContext.bucketCount; bucketIndex++) {
-            for (const record of this._databaseRecordContext.getBucket(bucketIndex)) {
-                if (record.locked) {
-                    continue;
-                }
-                try {
-                    record.locked = true;
-                    const result = await this._requestHandler.send(record.data, record.attachments);
-                    if (result.status === 'Ok') {
-                        this.remove(record);
-                        continue;
-                    }
-                    this._databaseRecordContext.increaseBucket(bucketIndex);
-                    return;
-                } finally {
-                    record.locked = false;
-                }
-            }
-        }
+        await this.send();
     }
 }

--- a/packages/sdk-core/src/modules/database/model/BacktraceDatabaseRecord.ts
+++ b/packages/sdk-core/src/modules/database/model/BacktraceDatabaseRecord.ts
@@ -5,6 +5,7 @@ export interface BacktraceDatabaseRecord {
     readonly data: BacktraceData;
     readonly id: string;
     readonly hash: string;
+    readonly timestamp: number;
     attachments: BacktraceAttachment[];
     count: number;
     /**

--- a/packages/sdk-core/tests/database/databaseContextMemoryStorageTests.spec.ts
+++ b/packages/sdk-core/tests/database/databaseContextMemoryStorageTests.spec.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import { BacktraceData, BacktraceDatabaseRecord, BacktraceReportSubmissionResult } from '../../src';
+import { TimeHelper } from '../../src/common/TimeHelper';
 import { BacktraceDatabase } from '../../src/modules/database/BacktraceDatabase';
 import { BacktraceTestClient } from '../mocks/BacktraceTestClient';
 import { testStorageProvider } from '../mocks/testStorageProvider';
@@ -94,6 +95,7 @@ describe('Database context memory storage tests', () => {
         it('Should load records from the storage provider to context', async () => {
             const record: BacktraceDatabaseRecord = {
                 attachments: [],
+                timestamp: TimeHelper.now(),
                 count: 1,
                 data: {} as BacktraceData,
                 hash: '',

--- a/packages/sdk-core/tests/database/databaseSendTests.spec.ts
+++ b/packages/sdk-core/tests/database/databaseSendTests.spec.ts
@@ -1,0 +1,131 @@
+import path from 'path';
+import { BacktraceDatabaseConfiguration, BacktraceReportSubmissionResult } from '../../src';
+import { BacktraceDatabase } from '../../src/modules/database/BacktraceDatabase';
+import { BacktraceTestClient } from '../mocks/BacktraceTestClient';
+import { testStorageProvider } from '../mocks/testStorageProvider';
+
+describe('Database send tests', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+    const testDatabaseSettings: BacktraceDatabaseConfiguration = {
+        enabled: true,
+        autoSend: false,
+        // this option doesn't matter because we mock the database provider
+        // interface. However, if bug happen we want to be sure to not create
+        // anything. Instead we want to fail loud and hard.
+        createDatabaseDirectory: false,
+        path: path.join(__dirname, 'database'),
+    };
+
+    describe('Flush', () => {
+        it('Should flush every record from the database even if the submission was unsuccessful', async () => {
+            const client = BacktraceTestClient.buildFakeClient(
+                {
+                    database: testDatabaseSettings,
+                },
+                [],
+                [],
+                testStorageProvider,
+            );
+            const database = client.database as BacktraceDatabase;
+            if (!database) {
+                throw new Error('Invalid database setup. Database must be defined!');
+            }
+
+            jest.spyOn(client.requestHandler, 'postError').mockResolvedValue(
+                Promise.resolve(BacktraceReportSubmissionResult.OnInternalServerError('test')),
+            );
+
+            await client.send(new Error('foo'));
+
+            expect(database.count()).toEqual(1);
+            await database.flush();
+            expect(database.count()).toEqual(0);
+        });
+
+        it('Should flush every record from the database even if submission was successful', async () => {
+            const client = BacktraceTestClient.buildFakeClient(
+                {
+                    database: testDatabaseSettings,
+                },
+                [],
+                [],
+                testStorageProvider,
+            );
+            const database = client.database as BacktraceDatabase;
+            if (!database) {
+                throw new Error('Invalid database setup. Database must be defined!');
+            }
+
+            jest.spyOn(client.requestHandler, 'postError').mockResolvedValueOnce(
+                Promise.resolve(BacktraceReportSubmissionResult.OnInternalServerError('test')),
+            );
+
+            await client.send(new Error('foo'));
+
+            expect(database.count()).toEqual(1);
+            jest.spyOn(client.requestHandler, 'postError').mockResolvedValueOnce(
+                Promise.resolve(BacktraceReportSubmissionResult.Ok({})),
+            );
+            await database.flush();
+            expect(database.count()).toEqual(0);
+            expect(client.requestHandler.postError).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('Send', () => {
+        it('Should send all reports available in the database', async () => {
+            const client = BacktraceTestClient.buildFakeClient(
+                {
+                    database: testDatabaseSettings,
+                },
+                [],
+                [],
+                testStorageProvider,
+            );
+            const database = client.database as BacktraceDatabase;
+            if (!database) {
+                throw new Error('Invalid database setup. Database must be defined!');
+            }
+
+            const postErrorSpy = jest
+                .spyOn(client.requestHandler, 'postError')
+                .mockResolvedValue(Promise.resolve(BacktraceReportSubmissionResult.OnInternalServerError('test')));
+
+            await client.send(new Error('foo'));
+
+            expect(database.count()).toEqual(1);
+            await database.send();
+            expect(database.count()).toEqual(1);
+            expect(postErrorSpy).toHaveBeenCalledTimes(2);
+        });
+
+        it('Should send all reports available in the database and remove them', async () => {
+            const client = BacktraceTestClient.buildFakeClient(
+                {
+                    database: testDatabaseSettings,
+                },
+                [],
+                [],
+                testStorageProvider,
+            );
+            const database = client.database as BacktraceDatabase;
+            if (!database) {
+                throw new Error('Invalid database setup. Database must be defined!');
+            }
+
+            const postErrorSpy = jest
+                .spyOn(client.requestHandler, 'postError')
+                .mockResolvedValueOnce(Promise.resolve(BacktraceReportSubmissionResult.OnInternalServerError('test')));
+
+            await client.send(new Error('foo'));
+
+            expect(database.count()).toEqual(1);
+            postErrorSpy.mockResolvedValueOnce(Promise.resolve(BacktraceReportSubmissionResult.Ok({})));
+            await database.send();
+            expect(database.count()).toEqual(0);
+            expect(postErrorSpy).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/packages/sdk-core/tests/mocks/testStorageProvider.ts
+++ b/packages/sdk-core/tests/mocks/testStorageProvider.ts
@@ -1,14 +1,7 @@
-import { BacktraceData, BacktraceDatabaseStorageProvider } from '../../src';
+import { BacktraceDatabaseStorageProvider } from '../../src';
 
 export const testStorageProvider: BacktraceDatabaseStorageProvider = {
-    add: jest.fn().mockReturnValue({
-        attachments: [],
-        count: 1,
-        data: {} as BacktraceData,
-        hash: '',
-        id: '123',
-        locked: false,
-    }),
+    add: jest.fn().mockReturnValue(true),
     delete: jest.fn().mockReturnValue(true),
     start: jest.fn().mockReturnValue(true),
     get: jest.fn().mockResolvedValue(Promise.resolve([])),


### PR DESCRIPTION
# Why

This diff adds database operations to the offline database. In some situations, our customers need to be fully offline or want to send data only when something happens (for example: to not impact the application performance). In this situation our users would rather add to the database, not send them immediately. To provide full offline support we need to give our customers an option to send manually reports. 

This diff adds basic database send operations that allow to:
* send reports with respect of retry settings
* flush the database - send and forget. 