### PR TITLE
Provide more detailed error-data information in the report object

### DIFF
--- a/packages/sdk-core/src/model/report/BacktraceReport.ts
+++ b/packages/sdk-core/src/model/report/BacktraceReport.ts
@@ -69,7 +69,12 @@ export class BacktraceReport {
         this.skipFrames = options?.skipFrames ?? 0;
         let errorType: BacktraceErrorType = 'Exception';
         if (data instanceof Error) {
-            this.annotations['error'] = data;
+            this.annotations['error'] = {
+                ...data,
+                message: data.message,
+                name: data.name,
+                stack: data.stack,
+            };
             this.classifiers = [data.name];
             this.message = data.message;
             this.stackTrace['main'] = {

--- a/packages/sdk-core/src/modules/data/BacktraceDataBuilder.ts
+++ b/packages/sdk-core/src/modules/data/BacktraceDataBuilder.ts
@@ -64,6 +64,9 @@ export class BacktraceDataBuilder {
                 const { message, stack } = traceInfo;
                 stackFrames = this._stackTraceConverter.convert(stack, message);
             }
+            if (name === this.MAIN_THREAD_NAME && report.skipFrames > 0) {
+                stackFrames.splice(0, report.skipFrames);
+            }
 
             for (const frame of stackFrames) {
                 const debugIdentifier = this._debugIdProvider.getDebugId(frame.library);


### PR DESCRIPTION
# Why

In the past, we added a few cool pieces of information to the report object that we didn't use properly. 
- "skipFrames" option was ignored - all frames from the BacktraceCilent were included. 
- the error object available in the report annotation cannot be serialized - the reason why is that all error properties are not enumerable. In the result, we always generated an empty error object.

This diff fixes above changes. 