### PR TITLE
Backtrace report unhandled error/crash overrides

### DIFF
--- a/examples/sdk/node/src/index.ts
+++ b/examples/sdk/node/src/index.ts
@@ -44,9 +44,10 @@ async function sendMessage(message: string, attributes: Record<string, number>) 
 }
 
 async function rejectPromise(message: string) {
-    return new Promise(() => {
+    return new Promise((_, rej) => {
         console.log('Rejecting promise without .catch and finally.');
-        throw new Error(message);
+        rej(message);
+        // throw new Error(message);
     });
 }
 

--- a/examples/sdk/node/src/index.ts
+++ b/examples/sdk/node/src/index.ts
@@ -44,10 +44,9 @@ async function sendMessage(message: string, attributes: Record<string, number>) 
 }
 
 async function rejectPromise(message: string) {
-    return new Promise((_, rej) => {
+    return new Promise(() => {
         console.log('Rejecting promise without .catch and finally.');
-        rej(message);
-        // throw new Error(message);
+        throw new Error(message);
     });
 }
 

--- a/packages/browser/src/BacktraceClient.ts
+++ b/packages/browser/src/BacktraceClient.ts
@@ -8,9 +8,9 @@ import {
     DebugIdContainer,
     VariableDebugIdMapProvider,
 } from '@backtrace/sdk-core';
+import { AGENT } from './agentDefinition';
 import { BacktraceBrowserSessionProvider } from './BacktraceBrowserSessionProvider';
 import { BacktraceConfiguration } from './BacktraceConfiguration';
-import { AGENT } from './agentDefinition';
 import { BacktraceClientBuilder } from './builder/BacktraceClientBuilder';
 
 export class BacktraceClient extends BacktraceCoreClient {
@@ -61,9 +61,16 @@ export class BacktraceClient extends BacktraceCoreClient {
         if (captureUnhandledRejections) {
             window.addEventListener('unhandledrejection', async (errorEvent: PromiseRejectionEvent) => {
                 await this.send(
-                    new BacktraceReport(errorEvent.reason, {
-                        'error.type': 'Unhandled exception',
-                    }),
+                    new BacktraceReport(
+                        errorEvent.reason,
+                        {
+                            'error.type': 'Unhandled exception',
+                        },
+                        [],
+                        {
+                            classifiers: ['UnhandledPromiseRejection'],
+                        },
+                    ),
                 );
             });
         }

--- a/packages/node/src/converter/NodeDiagnosticReportConverter.ts
+++ b/packages/node/src/converter/NodeDiagnosticReportConverter.ts
@@ -8,19 +8,25 @@ export class NodeDiagnosticReportConverter {
         const validJsStack = jsStack && jsStack[0] !== 'Unavailable.';
 
         const message = validJsStack ? report.javascriptStack.message : report.header.event;
-        const btReport = new BacktraceReport(message, {
-            timestamp: parseInt(report.header.dumpEventTimeStamp),
-            hostname: report.header.host,
-            classifiers: [report.header.trigger],
-            ...this.getUnameData(report),
-            ...this.getCpuData(report),
-            ...this.getMemoryData(report),
+        const btReport = new BacktraceReport(
+            message,
+            {
+                hostname: report.header.host,
+                ...this.getUnameData(report),
+                ...this.getCpuData(report),
+                ...this.getMemoryData(report),
 
-            // Annotations
-            'Environment Variables': report.environmentVariables,
-            'Exec Arguments': report.header.commandLine,
-            Error: report,
-        });
+                // Annotations
+                'Environment Variables': report.environmentVariables,
+                'Exec Arguments': report.header.commandLine,
+                Error: report,
+            },
+            [],
+            {
+                timestamp: parseInt(report.header.dumpEventTimeStamp),
+                classifiers: [report.header.trigger],
+            },
+        );
 
         if (validJsStack) {
             btReport.addStackTrace('main', jsStack.join('\n'));

--- a/packages/sdk-core/src/model/report/BacktraceReport.ts
+++ b/packages/sdk-core/src/model/report/BacktraceReport.ts
@@ -106,7 +106,7 @@ export class BacktraceReport {
             this.timestamp = options.timestamp;
         }
         if (options?.classifiers) {
-            this.classifiers = options.classifiers;
+            this.classifiers.unshift(...options.classifiers);
         }
     }
 }

--- a/packages/sdk-core/src/model/report/BacktraceReport.ts
+++ b/packages/sdk-core/src/model/report/BacktraceReport.ts
@@ -64,7 +64,7 @@ export class BacktraceReport {
         public readonly data: Error | string,
         public readonly attributes: Record<string, unknown> = {},
         public readonly attachments: BacktraceAttachment[] = [],
-        options: { skipFrames?: number } = {},
+        options: { skipFrames?: number; classifiers?: string[]; timestamp?: number } = {},
     ) {
         this.skipFrames = options?.skipFrames ?? 0;
         let errorType: BacktraceErrorType = 'Exception';
@@ -92,6 +92,7 @@ export class BacktraceReport {
                 stack: new Error().stack ?? '',
                 message: data,
             };
+            this.classifiers = ['Message'];
             errorType = 'Message';
             this.skipFrames += 1;
         }
@@ -101,14 +102,11 @@ export class BacktraceReport {
         }
         this.attributes['error.message'] = this.message;
 
-        if (typeof this.attributes['timestamp'] === 'number') {
-            this.timestamp = this.attributes['timestamp'];
-            delete this.attributes['timestamp'];
+        if (options?.timestamp) {
+            this.timestamp = options.timestamp;
         }
-
-        if (Array.isArray(this.attributes['classifiers'])) {
-            this.classifiers = this.attributes['classifiers'];
-            delete this.attributes['classifiers'];
+        if (options?.classifiers) {
+            this.classifiers = options.classifiers;
         }
     }
 }


### PR DESCRIPTION
# Why

This diff extends unhandled error/crash report flow. In the past, the way how the unhandled rejection/error flow generated a not ideal classifier/message/annotations based on the error object (or conversion to the error object). 

With this change we can now:
*  override in the same way classifiers (and sets them when we need to), 
* timestamps

and because of this diff now:
* all unhandled promise rejections have classifier `UnhandledPromiseRejection` 
* the error object is not included if the user uses the reject API and returns a non-error object (for example reject('foo'))
* 