### PR TITLE
Allow to use only one client via user-friendly API

### DIFF
--- a/packages/browser/src/BacktraceClient.ts
+++ b/packages/browser/src/BacktraceClient.ts
@@ -8,12 +8,13 @@ import {
     DebugIdContainer,
     VariableDebugIdMapProvider,
 } from '@backtrace/sdk-core';
+import { AGENT } from './agentDefinition';
 import { BacktraceBrowserSessionProvider } from './BacktraceBrowserSessionProvider';
 import { BacktraceConfiguration } from './BacktraceConfiguration';
-import { AGENT } from './agentDefinition';
 import { BacktraceClientBuilder } from './builder/BacktraceClientBuilder';
 
 export class BacktraceClient extends BacktraceCoreClient {
+    protected static _instance?: BacktraceClient;
     constructor(
         options: BacktraceConfiguration,
         handler: BacktraceRequestHandler,
@@ -41,10 +42,25 @@ export class BacktraceClient extends BacktraceCoreClient {
         return new BacktraceClientBuilder(options);
     }
 
-    public static initialize(options: BacktraceConfiguration, build?: (builder: BacktraceClientBuilder) => void) {
+    public static initialize(
+        options: BacktraceConfiguration,
+        build?: (builder: BacktraceClientBuilder) => void,
+    ): BacktraceClient {
+        if (this._instance) {
+            return this._instance;
+        }
         const builder = this.builder(options);
         build && build(builder);
-        return builder.build().initialize();
+        this._instance = builder.build().initialize();
+        return this._instance;
+    }
+
+    /**
+     * Returns created BacktraceClient instance if the instance exists.
+     * Otherwise undefined.
+     */
+    public static get instance(): BacktraceClient | undefined {
+        return this._instance;
     }
 
     private captureUnhandledErrors(captureUnhandledExceptions = true, captureUnhandledRejections = true) {

--- a/packages/browser/src/BacktraceClient.ts
+++ b/packages/browser/src/BacktraceClient.ts
@@ -42,6 +42,13 @@ export class BacktraceClient extends BacktraceCoreClient {
         return new BacktraceClientBuilder(options);
     }
 
+    /**
+     * Initializes the client. If the client already exists, the available instance
+     * will be returned and all other options will be ignored.
+     * @param options client configuration
+     * @param build builder
+     * @returns backtrace client
+     */
     public static initialize(
         options: BacktraceConfiguration,
         build?: (builder: BacktraceClientBuilder) => void,

--- a/packages/node/src/BacktraceClient.ts
+++ b/packages/node/src/BacktraceClient.ts
@@ -41,6 +41,13 @@ export class BacktraceClient extends BacktraceCoreClient {
         return new BacktraceClientBuilder(options);
     }
 
+    /**
+     * Initializes the client. If the client already exists, the available instance
+     * will be returned and all other options will be ignored.
+     * @param options client configuration
+     * @param build builder
+     * @returns backtrace client
+     */
     public static initialize(options: BacktraceConfiguration, build?: (builder: BacktraceClientBuilder) => void) {
         if (this._instance) {
             return this._instance;

--- a/packages/react/src/BacktraceClient.ts
+++ b/packages/react/src/BacktraceClient.ts
@@ -5,7 +5,13 @@ export class BacktraceClient extends BrowserClient {
     public static builder(options: BacktraceConfiguration): BacktraceReactClientBuilder {
         return new BacktraceReactClientBuilder(options);
     }
-
+    /**
+     * Initializes the client. If the client already exists, the available instance
+     * will be returned and all other options will be ignored.
+     * @param options client configuration
+     * @param build builder
+     * @returns backtrace client
+     */
     public static initialize(options: BacktraceConfiguration, build?: (builder: BacktraceReactClientBuilder) => void) {
         if (this._instance) {
             return this._instance;

--- a/packages/react/src/BacktraceClient.ts
+++ b/packages/react/src/BacktraceClient.ts
@@ -1,24 +1,26 @@
-import { BacktraceConfiguration, BacktraceClient as BrowserClient } from '@backtrace/browser';
+import { BacktraceClient as BrowserClient, BacktraceConfiguration } from '@backtrace/browser';
 import { BacktraceReactClientBuilder } from './builder/BacktraceReactClientBuilder';
 
 export class BacktraceClient extends BrowserClient {
-    private static _instance?: BacktraceClient;
-
     public static builder(options: BacktraceConfiguration): BacktraceReactClientBuilder {
         return new BacktraceReactClientBuilder(options);
     }
 
     public static initialize(options: BacktraceConfiguration, build?: (builder: BacktraceReactClientBuilder) => void) {
+        if (this._instance) {
+            return this._instance;
+        }
         const builder = this.builder(options);
         build && build(builder);
-        this._instance = this.builder(options).build().initialize();
+        this._instance = builder.build().initialize();
         return this._instance;
     }
 
-    public static get instance(): BacktraceClient {
-        if (!this._instance) {
-            throw new Error('BacktraceClient is uninitialized. Call "BacktraceClient.initialize" function first.');
-        }
+    /**
+     * Returns created BacktraceClient instance if the instance exists.
+     * Otherwise undefined.
+     */
+    public static get instance(): BacktraceClient | undefined {
         return this._instance;
     }
 }

--- a/packages/react/src/ErrorBoundary.tsx
+++ b/packages/react/src/ErrorBoundary.tsx
@@ -1,6 +1,6 @@
-import { Component, ErrorInfo, ReactElement, ReactNode, isValidElement } from 'react';
-import { BacktraceClient } from './BacktraceClient';
+import { Component, ErrorInfo, isValidElement, ReactElement, ReactNode } from 'react';
 import { BacktraceReport } from '.';
+import { BacktraceClient } from './BacktraceClient';
 
 type RenderFallback = () => ReactElement;
 
@@ -25,7 +25,11 @@ export class ErrorBoundary extends Component<Props, State> {
             error: undefined,
         };
         // grabbing here so it will fail fast if BacktraceClient is uninitialized
-        this._client = BacktraceClient.instance;
+        const client = BacktraceClient.instance;
+        if (!client) {
+            throw new Error('BacktraceClient is uninitialized. Call "BacktraceClient.initialize" function first.');
+        }
+        this._client = client;
     }
 
     public static getDerivedStateFromError(error: Error) {

--- a/packages/sdk-core/src/BacktraceCoreClient.ts
+++ b/packages/sdk-core/src/BacktraceCoreClient.ts
@@ -139,7 +139,7 @@ export abstract class BacktraceCoreClient {
         }
     }
 
-    public initialize() {
+    protected initialize() {
         this._database?.start();
         this._metrics?.start();
         this.breadcrumbsManager?.start();


### PR DESCRIPTION
# Why

We can only have one crash-reporting solution available in the application created/spawned by us! In addition to that, if someone initialize the client once again, we might have a race condition between Backtrace Database instances. To avoid those problems the initialize method caches now the instance. With this change we know there is only one existing instance of the client. 

We still leave an option to create a backtrace client by the super user if there is a use case and benefit from doing that. 