### PR TITLE
Lazy load debug ids

### DIFF
--- a/packages/sdk-core/src/sourcemaps/DebugIdProvider.ts
+++ b/packages/sdk-core/src/sourcemaps/DebugIdProvider.ts
@@ -4,7 +4,7 @@ import { DebugIdMapProvider } from './interfaces/DebugIdMapProvider';
 export const SOURCE_DEBUG_ID_VARIABLE = '_btDebugIds';
 
 export class DebugIdProvider {
-    private readonly _fileDebugIds: Record<string, string>;
+    private _fileDebugIds: Record<string, string>;
 
     constructor(
         private readonly _stackTraceConverter: BacktraceStackTraceConverter,
@@ -14,6 +14,12 @@ export class DebugIdProvider {
     }
 
     public getDebugId(file: string): string | undefined {
+        const debugId = this._fileDebugIds[file];
+        if (debugId) {
+            return debugId;
+        }
+        // in case of dynamic require - lazy load dynamically debug ids
+        this._fileDebugIds = this.loadDebugIds();
         return this._fileDebugIds[file];
     }
 


### PR DESCRIPTION
# Why

This diff allows to handle a situation when the debugId is not present because of the dynamic import executed after the application startup.