### PR TITLE
Breadcrumb interceptor

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -12,6 +12,7 @@ export {
     BreadcrumbsManager,
     BreadcrumbType,
     JavaScriptEngine,
+    RawBreadcrumb,
 } from '@backtrace/sdk-core';
 export * from './agentDefinition';
 export * from './BacktraceClient';

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -9,6 +9,7 @@ export {
     BreadcrumbsEventSubscriber,
     BreadcrumbsManager,
     BreadcrumbType,
+    RawBreadcrumb,
 } from '@backtrace/sdk-core';
 export * from './attachment';
 export * from './BacktraceClient';

--- a/packages/sdk-core/src/model/configuration/BacktraceConfiguration.ts
+++ b/packages/sdk-core/src/model/configuration/BacktraceConfiguration.ts
@@ -1,4 +1,5 @@
 import { BreadcrumbLogLevel, BreadcrumbType } from '../../modules/breadcrumbs';
+import { RawBreadcrumb } from '../../modules/breadcrumbs/model/RawBreadcrumb';
 import { BacktraceAttachment } from '../attachment';
 import { BacktraceData } from '../data/BacktraceData';
 import { BacktraceReport } from '../report/BacktraceReport';
@@ -48,6 +49,12 @@ export interface BacktraceBreadcrumbsSettings {
      * wil be stored.
      */
     maximumBreadcrumbs?: number;
+
+    /**
+     * Inspects breadcrumb and allows to modify it. If the undefined value is being
+     * returned from the method, no breadcrumb will be added to the breadcrumb storage.
+     */
+    intercept?: (breadcrumb: RawBreadcrumb) => RawBreadcrumb | undefined;
 }
 
 export interface BacktraceConfiguration {

--- a/packages/sdk-core/src/modules/breadcrumbs/index.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/index.ts
@@ -4,4 +4,5 @@ export * from './BreadcrumbsSetup';
 export * from './events/BreadcrurmbsEventSubscriber';
 export * from './model/BreadcrumbLogLevel';
 export * from './model/BreadcrumbType';
+export * from './model/RawBreadcrumb';
 export * from './storage/BreadcrumbsStorage';

--- a/packages/sdk-core/src/modules/breadcrumbs/model/RawBreadcrumb.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/model/RawBreadcrumb.ts
@@ -1,0 +1,10 @@
+import { AttributeType } from '../../../model/data';
+import { BreadcrumbLogLevel } from './BreadcrumbLogLevel';
+import { BreadcrumbType } from './BreadcrumbType';
+
+export interface RawBreadcrumb {
+    message: string;
+    level: BreadcrumbLogLevel;
+    type: BreadcrumbType;
+    attributes?: Record<string, AttributeType>;
+}

--- a/packages/sdk-core/src/modules/breadcrumbs/storage/BreadcrumbsStorage.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/storage/BreadcrumbsStorage.ts
@@ -1,7 +1,5 @@
 import { BacktraceAttachment } from '../../../model/attachment';
-import { AttributeType } from '../../../model/data/BacktraceData';
-import { BreadcrumbLogLevel } from '../model/BreadcrumbLogLevel';
-import { BreadcrumbType } from '../model/BreadcrumbType';
+import { RawBreadcrumb } from '../model/RawBreadcrumb';
 
 export interface BreadcrumbsStorage extends BacktraceAttachment {
     /**
@@ -11,15 +9,7 @@ export interface BreadcrumbsStorage extends BacktraceAttachment {
 
     /**
      * Adds breadcrumb to the storage
-     * @param message message
-     * @param level log level
-     * @param type type
-     * @param attributes attributes
+     * @param rawBreadcrumb breadcrumb data
      */
-    add(
-        message: string,
-        level: BreadcrumbLogLevel,
-        type: BreadcrumbType,
-        attributes?: Record<string, AttributeType>,
-    ): number;
+    add(rawBreadcrumb: RawBreadcrumb): number;
 }

--- a/packages/sdk-core/src/modules/breadcrumbs/storage/InMemoryBreadcrumbsStorage.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/storage/InMemoryBreadcrumbsStorage.ts
@@ -1,10 +1,10 @@
 import { jsonEscaper } from '../../../common/jsonEscaper';
 import { TimeHelper } from '../../../common/TimeHelper';
 import { OverwritingArray } from '../../../dataStructures/OverwritingArray';
-import { AttributeType } from '../../../model/data/BacktraceData';
 import { Breadcrumb } from '../model/Breadcrumb';
 import { BreadcrumbLogLevel } from '../model/BreadcrumbLogLevel';
 import { BreadcrumbType } from '../model/BreadcrumbType';
+import { RawBreadcrumb } from '../model/RawBreadcrumb';
 import { BreadcrumbsStorage } from './BreadcrumbsStorage';
 
 export class InMemoryBreadcrumbsStorage implements BreadcrumbsStorage {
@@ -31,24 +31,19 @@ export class InMemoryBreadcrumbsStorage implements BreadcrumbsStorage {
         return JSON.stringify([...this._breadcrumbs.values()], jsonEscaper());
     }
 
-    public add(
-        message: string,
-        level: BreadcrumbLogLevel,
-        type: BreadcrumbType,
-        attributes?: Record<string, AttributeType> | undefined,
-    ): number {
+    public add(rawBreadcrumb: RawBreadcrumb): number {
         this._lastBreadcrumbId++;
         const id = this._lastBreadcrumbId;
         const breadcrumb: Breadcrumb = {
             id,
-            message,
+            message: rawBreadcrumb.message,
             timestamp: TimeHelper.now(),
-            type: BreadcrumbType[type].toLowerCase(),
-            level: BreadcrumbLogLevel[level].toLowerCase(),
+            type: BreadcrumbType[rawBreadcrumb.type].toLowerCase(),
+            level: BreadcrumbLogLevel[rawBreadcrumb.level].toLowerCase(),
         };
 
-        if (attributes) {
-            breadcrumb.attributes = attributes;
+        if (rawBreadcrumb.attributes) {
+            breadcrumb.attributes = rawBreadcrumb.attributes;
         }
 
         this._breadcrumbs.add(breadcrumb);

--- a/packages/sdk-core/tests/breadcrumbs/breadcrumbsCreationTests.spec.ts
+++ b/packages/sdk-core/tests/breadcrumbs/breadcrumbsCreationTests.spec.ts
@@ -2,7 +2,7 @@ import { BreadcrumbLogLevel, BreadcrumbType } from '../../lib/modules/breadcrumb
 import { BreadcrumbsManager } from '../../lib/modules/breadcrumbs/BreadcrumbsManager';
 
 describe('Breadcrumbs creation tests', () => {
-    describe('Last breadcrumb id attribute should be equal to last bredcrumb id in the array', () => {
+    it('Last breadcrumb id attribute should be equal to last bredcrumb id in the array', () => {
         const breadcrumbsManager = new BreadcrumbsManager();
         breadcrumbsManager.info('test');
 

--- a/packages/sdk-core/tests/breadcrumbs/breadcrumbsInterceptorTests.spec.ts
+++ b/packages/sdk-core/tests/breadcrumbs/breadcrumbsInterceptorTests.spec.ts
@@ -1,0 +1,26 @@
+import { BreadcrumbsManager } from '../../src/modules/breadcrumbs/BreadcrumbsManager';
+import { Breadcrumb } from '../../src/modules/breadcrumbs/model/Breadcrumb';
+describe('Breadcrumbs interceptor tests', () => {
+    it('Should filter out the breadcrumb', () => {
+        const breadcrumbsManager = new BreadcrumbsManager({
+            intercept: () => undefined,
+        });
+        breadcrumbsManager.info('test');
+        const breadcrumbs = JSON.parse(breadcrumbsManager.breadcrumbsStorage.get() as string) as Breadcrumb[];
+        expect(breadcrumbs.length).toBe(0);
+    });
+
+    it('Should remove pii information from breadcrumb', () => {
+        const expectedBreadcrumbMessage = 'bar';
+        const breadcrumbsManager = new BreadcrumbsManager({
+            intercept: (breadcrumb) => {
+                breadcrumb.message = expectedBreadcrumbMessage;
+                return breadcrumb;
+            },
+        });
+        breadcrumbsManager.info('test');
+
+        const [breadcrumb] = JSON.parse(breadcrumbsManager.breadcrumbsStorage.get() as string) as Breadcrumb[];
+        expect(breadcrumb.message).toEqual(expectedBreadcrumbMessage);
+    });
+});


### PR DESCRIPTION
# Why

In the case of breadcrumbs containing PII information that needed to be filtered out, now we allow users to modify breadcrumb or remove it. 

Right now users can remove any content of the breadcrumb or modify it to their needs.