### PR TITLE
Detect missing information about the agent and fallback to the default

### DIFF
--- a/packages/browser/src/engineDetector.ts
+++ b/packages/browser/src/engineDetector.ts
@@ -1,6 +1,9 @@
 import { JavaScriptEngine } from '@backtrace/sdk-core/lib/model/data/JavaScriptEngine';
 
 export function getEngine(): JavaScriptEngine {
+    if (!navigator.userAgent) {
+        return 'v8';
+    }
     const normalizedUserAgent = navigator.userAgent.toLowerCase();
 
     if (normalizedUserAgent.includes('firefox')) {


### PR DESCRIPTION
# Why

This diff handles a situation when the useragent information is not available. This is important if someone decides to integrate our backtrace-browser library inside electron/react-native where the useragent is not available. 