### PR TITLE
Fallback to default log function if the util function is not available

### DIFF
--- a/packages/sdk-core/src/common/textFormatter.ts
+++ b/packages/sdk-core/src/common/textFormatter.ts
@@ -1,0 +1,19 @@
+import { jsonEscaper } from './jsonEscaper';
+
+export function textFormatter(): (...params: unknown[]) => string {
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const util = require('util');
+        return util.format;
+    } catch {
+        return fallbackFormatter;
+    }
+}
+
+function fallbackFormatter(...params: unknown[]): string {
+    let result = '';
+    for (const param of params) {
+        result += typeof param === 'object' ? JSON.stringify(param, jsonEscaper()) : param?.toString();
+    }
+    return result;
+}

--- a/packages/sdk-core/src/modules/breadcrumbs/events/ConsoleEventSubscriber.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/events/ConsoleEventSubscriber.ts
@@ -1,4 +1,4 @@
-import { format } from 'util';
+import { textFormatter } from '../../../common/textFormatter';
 import { BreadcrumbsManager } from '../BreadcrumbsManager';
 import { BreadcrumbLogLevel } from '../model/BreadcrumbLogLevel';
 import { BreadcrumbType } from '../model/BreadcrumbType';
@@ -10,11 +10,13 @@ export class ConsoleEventSubscriber implements BreadcrumbsEventSubscriber {
      * All overriden console events
      */
     private readonly _events: Record<string, ConsoleMethod> = {};
-
+    private _formatter!: (...params: unknown[]) => string;
     public start(breadcrumbsManager: BreadcrumbsManager): void {
         if ((breadcrumbsManager.breadcrumbsType & BreadcrumbType.Log) !== BreadcrumbType.Log) {
             return;
         }
+
+        this._formatter = textFormatter();
 
         this.bindToConsoleMethod('log', BreadcrumbLogLevel.Info, breadcrumbsManager);
         this.bindToConsoleMethod('warn', BreadcrumbLogLevel.Warning, breadcrumbsManager);
@@ -40,7 +42,7 @@ export class ConsoleEventSubscriber implements BreadcrumbsEventSubscriber {
 
         (console[name] as ConsoleMethod) = (...args: unknown[]) => {
             defaultImplementation.apply(console, args);
-            const message = format(...args);
+            const message = this._formatter(...args);
             breadcrumbsManager.addBreadcrumb(message, level, BreadcrumbType.Log);
         };
         this._events[name] = originalMethod;


### PR DESCRIPTION
# Why

The breadcrumbs integration uses the util format method to format all console parameters. Util is the library available in the web browser or in node. However there is a chance the library won't be available in the sandbox env like in react-native. This diff adds a fallback function to format console logs when the util function is not available