### PR TITLE
Bin starting path

### DIFF
--- a/packages/node/src/attributes/ApplicationInformationAttributeProvider.ts
+++ b/packages/node/src/attributes/ApplicationInformationAttributeProvider.ts
@@ -48,21 +48,8 @@ export class ApplicationInformationAttributeProvider implements BacktraceAttribu
         };
     }
 
-    private generatePathBasedOnTheDirName() {
-        const nodeModulesIndex = __dirname.lastIndexOf('node_modules');
-        if (nodeModulesIndex === -1) {
-            return __dirname;
-        }
-
-        return __dirname.substring(0, nodeModulesIndex);
-    }
-
     private generateDefaultApplicationSearchPaths() {
-        const possibleSourcePaths = [process.cwd()];
-        const dirNamePath = this.generatePathBasedOnTheDirName();
-        if (dirNamePath) {
-            possibleSourcePaths.push(dirNamePath);
-        }
+        const possibleSourcePaths = [process.cwd(), this.generatePathBasedOnTheDirName()];
         const potentialCommandLineStartupFile = process.argv[1];
         if (potentialCommandLineStartupFile) {
             const potentialCommandLineStartupFilePath = path.resolve(potentialCommandLineStartupFile);
@@ -74,6 +61,15 @@ export class ApplicationInformationAttributeProvider implements BacktraceAttribu
             possibleSourcePaths.unshift(path.dirname(require.main.path));
         }
         return possibleSourcePaths;
+    }
+
+    private generatePathBasedOnTheDirName() {
+        const nodeModulesIndex = __dirname.lastIndexOf('node_modules');
+        if (nodeModulesIndex === -1) {
+            return __dirname;
+        }
+
+        return __dirname.substring(0, nodeModulesIndex);
     }
 
     private readApplicationInformation(): Record<string, unknown> | undefined {

--- a/packages/node/src/attributes/ApplicationInformationAttributeProvider.ts
+++ b/packages/node/src/attributes/ApplicationInformationAttributeProvider.ts
@@ -8,22 +8,26 @@ export class ApplicationInformationAttributeProvider implements BacktraceAttribu
     public readonly APPLICATION_ATTRIBUTE = 'application';
     public readonly APPLICATION_VERSION_ATTRIBUTE = 'application.version';
 
-    private _application?: string = process.env.npm_package_name;
-    private _applicationVersion?: string = process.env.npm_package_version;
+    private _application?: string;
+    private _applicationVersion?: string;
 
     public readonly applicationSearchPaths: string[];
     public get type(): 'scoped' | 'dynamic' {
         return 'scoped';
     }
 
-    constructor(options: BacktraceConfiguration, applicationSearchPaths?: string[]) {
-        if (
-            options.userAttributes?.[this.APPLICATION_ATTRIBUTE] &&
-            options.userAttributes?.[this.APPLICATION_VERSION_ATTRIBUTE]
-        ) {
-            this._application = options.userAttributes[this.APPLICATION_ATTRIBUTE] as string;
-            this._applicationVersion = options.userAttributes[this.APPLICATION_VERSION_ATTRIBUTE] as string;
-        }
+    constructor(
+        options: BacktraceConfiguration,
+        applicationSearchPaths?: string[],
+        nodeConfiguration: { application?: string; version?: string } = {
+            application: process.env?.npm_package_name,
+            version: process.env?.npm_package_version,
+        },
+    ) {
+        this._application =
+            (options.userAttributes?.[this.APPLICATION_ATTRIBUTE] as string) ?? nodeConfiguration?.application;
+        this._applicationVersion =
+            (options.userAttributes?.[this.APPLICATION_VERSION_ATTRIBUTE] as string) ?? nodeConfiguration?.version;
 
         this.applicationSearchPaths = applicationSearchPaths ?? this.generateDefaultApplicationSearchPaths();
     }

--- a/packages/node/src/attributes/ApplicationInformationAttributeProvider.ts
+++ b/packages/node/src/attributes/ApplicationInformationAttributeProvider.ts
@@ -8,7 +8,7 @@ export class ApplicationInformationAttributeProvider implements BacktraceAttribu
     public readonly APPLICATION_ATTRIBUTE = 'application';
     public readonly APPLICATION_VERSION_ATTRIBUTE = 'application.version';
 
-    private _application?: string;
+    private _application?: string = process.env.npm_package_name;
     private _applicationVersion?: string = process.env.npm_package_version;
 
     public readonly applicationSearchPaths: string[];
@@ -48,8 +48,21 @@ export class ApplicationInformationAttributeProvider implements BacktraceAttribu
         };
     }
 
+    private generatePathBasedOnTheDirName() {
+        const nodeModulesIndex = __dirname.lastIndexOf('node_modules');
+        if (nodeModulesIndex === -1) {
+            return __dirname;
+        }
+
+        return __dirname.substring(0, nodeModulesIndex);
+    }
+
     private generateDefaultApplicationSearchPaths() {
         const possibleSourcePaths = [process.cwd()];
+        const dirNamePath = this.generatePathBasedOnTheDirName();
+        if (dirNamePath) {
+            possibleSourcePaths.push(dirNamePath);
+        }
         const potentialCommandLineStartupFile = process.argv[1];
         if (potentialCommandLineStartupFile) {
             const potentialCommandLineStartupFilePath = path.resolve(potentialCommandLineStartupFile);

--- a/packages/node/tests/attributes/applicationInformationAttributeProviderTests.spec.ts
+++ b/packages/node/tests/attributes/applicationInformationAttributeProviderTests.spec.ts
@@ -50,9 +50,11 @@ describe('Application information attribute provider tests', () => {
 
         it('Should throw an error when the package.json information does not exist', () => {
             const testedPackageDir = path.join('/foo', 'bar', 'baz', '123', 'foo', 'bar');
-            const provider = new ApplicationInformationAttributeProvider({} as BacktraceConfiguration, [
-                testedPackageDir,
-            ]);
+            const provider = new ApplicationInformationAttributeProvider(
+                {} as BacktraceConfiguration,
+                [testedPackageDir],
+                {},
+            );
 
             expect(() => provider.get()).toThrow(Error);
         });


### PR DESCRIPTION
# Why

For CLI tools such as our backtrace-js, the way how we try to read the application information is not good enough. Because of this, we cannot read the version/name and we throw an error on the startup. It's not bad, but we can do better. This diff allows to read __dirname and determine the path based on the __dirname