### PR TITLE
cli: fix sourcemap upload issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -737,7 +737,7 @@
                 "node": ">=10.0.0"
             }
         },
-        "node_modules/@esbuild/darwin-x64": {
+        "node_modules/@esbuild/linux-x64": {
             "version": "0.18.20",
             "cpu": [
                 "x64"
@@ -745,7 +745,7 @@
             "license": "MIT",
             "optional": true,
             "os": [
-                "darwin"
+                "linux"
             ],
             "peer": true,
             "engines": {
@@ -1507,14 +1507,6 @@
                 "node": ">= 10"
             }
         },
-        "node_modules/@types/archiver": {
-            "version": "5.3.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/readdir-glob": "*"
-            }
-        },
         "node_modules/@types/aria-query": {
             "version": "5.0.1",
             "dev": true,
@@ -1708,14 +1700,6 @@
                 "@types/react": "*"
             }
         },
-        "node_modules/@types/readdir-glob": {
-            "version": "1.1.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/scheduler": {
             "version": "0.16.3",
             "dev": true,
@@ -1735,6 +1719,14 @@
             "version": "2.0.1",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/tar-stream": {
+            "version": "2.2.2",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/tough-cookie": {
             "version": "4.0.2",
@@ -2362,83 +2354,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/archiver": {
-            "version": "5.3.2",
-            "license": "MIT",
-            "dependencies": {
-                "archiver-utils": "^2.1.0",
-                "async": "^3.2.4",
-                "buffer-crc32": "^0.2.1",
-                "readable-stream": "^3.6.0",
-                "readdir-glob": "^1.1.2",
-                "tar-stream": "^2.2.0",
-                "zip-stream": "^4.1.0"
-            },
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/archiver-utils": {
-            "version": "2.1.0",
-            "license": "MIT",
-            "dependencies": {
-                "glob": "^7.1.4",
-                "graceful-fs": "^4.2.0",
-                "lazystream": "^1.0.0",
-                "lodash.defaults": "^4.2.0",
-                "lodash.difference": "^4.5.0",
-                "lodash.flatten": "^4.4.0",
-                "lodash.isplainobject": "^4.0.6",
-                "lodash.union": "^4.6.0",
-                "normalize-path": "^3.0.0",
-                "readable-stream": "^2.0.0"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/archiver-utils/node_modules/glob": {
-            "version": "7.2.3",
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/archiver-utils/node_modules/isarray": {
-            "version": "1.0.0",
-            "license": "MIT"
-        },
-        "node_modules/archiver-utils/node_modules/readable-stream": {
-            "version": "2.3.8",
-            "license": "MIT",
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            }
-        },
-        "node_modules/archiver-utils/node_modules/string_decoder": {
-            "version": "1.1.1",
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "~5.1.0"
-            }
-        },
         "node_modules/argparse": {
             "version": "2.0.1",
             "dev": true,
@@ -2646,10 +2561,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/async": {
-            "version": "3.2.4",
-            "license": "MIT"
-        },
         "node_modules/async-each": {
             "version": "1.0.6",
             "dev": true,
@@ -2687,6 +2598,10 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/b4a": {
+            "version": "1.6.4",
+            "license": "ISC"
         },
         "node_modules/babel-jest": {
             "version": "29.6.4",
@@ -2831,6 +2746,7 @@
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -2864,24 +2780,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/bindings": {
-            "version": "1.5.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "file-uri-to-path": "1.0.0"
-            }
-        },
-        "node_modules/bl": {
-            "version": "4.1.0",
-            "license": "MIT",
-            "dependencies": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-            }
-        },
         "node_modules/bluebird": {
             "version": "3.7.2",
             "dev": true,
@@ -2894,6 +2792,7 @@
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -3053,6 +2952,7 @@
         },
         "node_modules/buffer": {
             "version": "5.7.1",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -3089,6 +2989,7 @@
         },
         "node_modules/buffer-crc32": {
             "version": "0.2.13",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "*"
@@ -3565,21 +3466,9 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/compress-commons": {
-            "version": "4.1.1",
-            "license": "MIT",
-            "dependencies": {
-                "buffer-crc32": "^0.2.13",
-                "crc32-stream": "^4.0.2",
-                "normalize-path": "^3.0.0",
-                "readable-stream": "^3.6.0"
-            },
-            "engines": {
-                "node": ">= 10"
-            }
-        },
         "node_modules/concat-map": {
             "version": "0.0.1",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/console-browserify": {
@@ -3649,28 +3538,8 @@
         },
         "node_modules/core-util-is": {
             "version": "1.0.3",
+            "dev": true,
             "license": "MIT"
-        },
-        "node_modules/crc-32": {
-            "version": "1.2.2",
-            "license": "Apache-2.0",
-            "bin": {
-                "crc32": "bin/crc32.njs"
-            },
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
-        "node_modules/crc32-stream": {
-            "version": "4.0.2",
-            "license": "MIT",
-            "dependencies": {
-                "crc-32": "^1.2.0",
-                "readable-stream": "^3.4.0"
-            },
-            "engines": {
-                "node": ">= 10"
-            }
         },
         "node_modules/create-ecdh": {
             "version": "4.0.4",
@@ -4224,6 +4093,7 @@
         },
         "node_modules/end-of-stream": {
             "version": "1.4.4",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "once": "^1.4.0"
@@ -5056,6 +4926,10 @@
             "version": "3.1.3",
             "license": "MIT"
         },
+        "node_modules/fast-fifo": {
+            "version": "1.3.2",
+            "license": "MIT"
+        },
         "node_modules/fast-glob": {
             "version": "3.3.1",
             "dev": true,
@@ -5150,12 +5024,6 @@
             "engines": {
                 "node": ">=4"
             }
-        },
-        "node_modules/file-uri-to-path": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/fill-range": {
             "version": "7.0.1",
@@ -5478,6 +5346,7 @@
         },
         "node_modules/fs-constants": {
             "version": "1.0.0",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/fs-write-stream-atomic": {
@@ -5520,18 +5389,8 @@
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
+            "dev": true,
             "license": "ISC"
-        },
-        "node_modules/fsevents": {
-            "version": "2.3.3",
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
         },
         "node_modules/function-bind": {
             "version": "1.1.1",
@@ -5996,6 +5855,7 @@
         },
         "node_modules/ieee754": {
             "version": "1.2.1",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -6082,6 +5942,7 @@
         },
         "node_modules/inflight": {
             "version": "1.0.6",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "once": "^1.3.0",
@@ -6090,6 +5951,7 @@
         },
         "node_modules/inherits": {
             "version": "2.0.4",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/internal-slot": {
@@ -7698,40 +7560,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/lazystream": {
-            "version": "1.0.1",
-            "license": "MIT",
-            "dependencies": {
-                "readable-stream": "^2.0.5"
-            },
-            "engines": {
-                "node": ">= 0.6.3"
-            }
-        },
-        "node_modules/lazystream/node_modules/isarray": {
-            "version": "1.0.0",
-            "license": "MIT"
-        },
-        "node_modules/lazystream/node_modules/readable-stream": {
-            "version": "2.3.8",
-            "license": "MIT",
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            }
-        },
-        "node_modules/lazystream/node_modules/string_decoder": {
-            "version": "1.1.1",
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "~5.1.0"
-            }
-        },
         "node_modules/leven": {
             "version": "3.1.0",
             "dev": true,
@@ -7815,22 +7643,6 @@
             "version": "4.3.0",
             "license": "MIT"
         },
-        "node_modules/lodash.defaults": {
-            "version": "4.2.0",
-            "license": "MIT"
-        },
-        "node_modules/lodash.difference": {
-            "version": "4.5.0",
-            "license": "MIT"
-        },
-        "node_modules/lodash.flatten": {
-            "version": "4.4.0",
-            "license": "MIT"
-        },
-        "node_modules/lodash.isplainobject": {
-            "version": "4.0.6",
-            "license": "MIT"
-        },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
             "dev": true,
@@ -7839,10 +7651,6 @@
         "node_modules/lodash.merge": {
             "version": "4.6.2",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/lodash.union": {
-            "version": "4.6.0",
             "license": "MIT"
         },
         "node_modules/loose-envify": {
@@ -8046,6 +7854,7 @@
         },
         "node_modules/minimatch": {
             "version": "3.1.2",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -8207,12 +8016,6 @@
             "version": "2.1.2",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/nan": {
-            "version": "2.17.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/nanoid": {
             "version": "3.3.6",
@@ -8380,6 +8183,7 @@
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -8602,6 +8406,7 @@
         },
         "node_modules/once": {
             "version": "1.4.0",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
@@ -8800,6 +8605,7 @@
         },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -9059,6 +8865,7 @@
         },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/promise-inflight": {
@@ -9209,6 +9016,10 @@
             ],
             "license": "MIT"
         },
+        "node_modules/queue-tick": {
+            "version": "1.0.1",
+            "license": "MIT"
+        },
         "node_modules/randombytes": {
             "version": "2.1.0",
             "license": "MIT",
@@ -9256,6 +9067,7 @@
         },
         "node_modules/readable-stream": {
             "version": "3.6.2",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "inherits": "^2.0.3",
@@ -9264,30 +9076,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "node_modules/readdir-glob": {
-            "version": "1.1.3",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "minimatch": "^5.1.0"
-            }
-        },
-        "node_modules/readdir-glob/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/readdir-glob/node_modules/minimatch": {
-            "version": "5.1.6",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/readdirp": {
@@ -10253,8 +10041,17 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/streamx": {
+            "version": "2.15.1",
+            "license": "MIT",
+            "dependencies": {
+                "fast-fifo": "^1.1.0",
+                "queue-tick": "^1.0.1"
+            }
+        },
         "node_modules/string_decoder": {
             "version": "1.3.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safe-buffer": "~5.2.0"
@@ -10262,6 +10059,7 @@
         },
         "node_modules/string_decoder/node_modules/safe-buffer": {
             "version": "5.2.1",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -10504,20 +10302,6 @@
         "node_modules/tapable": {
             "version": "2.2.1",
             "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/tar-stream": {
-            "version": "2.2.0",
-            "license": "MIT",
-            "dependencies": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
-            },
             "engines": {
                 "node": ">=6"
             }
@@ -11296,6 +11080,7 @@
         },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/util/node_modules/inherits": {
@@ -11525,23 +11310,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/watchpack-chokidar2/node_modules/fsevents": {
-            "version": "1.2.13",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "dependencies": {
-                "bindings": "^1.5.0",
-                "nan": "^2.12.1"
-            },
-            "engines": {
-                "node": ">= 4.0"
             }
         },
         "node_modules/watchpack-chokidar2/node_modules/glob-parent": {
@@ -12604,6 +12372,7 @@
         },
         "node_modules/wrappy": {
             "version": "1.0.2",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/write-file-atomic": {
@@ -12695,18 +12464,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/zip-stream": {
-            "version": "4.1.0",
-            "license": "MIT",
-            "dependencies": {
-                "archiver-utils": "^2.1.0",
-                "compress-commons": "^4.1.0",
-                "readable-stream": "^3.6.0"
-            },
-            "engines": {
-                "node": ">= 10"
             }
         },
         "packages/browser": {
@@ -12830,13 +12587,13 @@
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
-                "archiver": "^5.3.1",
-                "source-map": "^0.7.4"
+                "source-map": "^0.7.4",
+                "tar-stream": "^3.1.6"
             },
             "devDependencies": {
-                "@types/archiver": "^5.3.2",
                 "@types/decompress": "^4.2.4",
                 "@types/jest": "^29.5.1",
+                "@types/tar-stream": "^2.2.2",
                 "decompress": "^4.2.1",
                 "jest": "^29.5.0",
                 "nock": "^13.3.1",
@@ -12845,6 +12602,15 @@
             },
             "engines": {
                 "node": ">=14"
+            }
+        },
+        "tools/sourcemap-tools/node_modules/tar-stream": {
+            "version": "3.1.6",
+            "license": "MIT",
+            "dependencies": {
+                "b4a": "^1.6.4",
+                "fast-fifo": "^1.2.0",
+                "streamx": "^2.15.0"
             }
         },
         "tools/vite-plugin": {
@@ -13401,16 +13167,26 @@
         "@backtrace-labs/sourcemap-tools": {
             "version": "file:tools/sourcemap-tools",
             "requires": {
-                "@types/archiver": "^5.3.2",
                 "@types/decompress": "^4.2.4",
                 "@types/jest": "^29.5.1",
-                "archiver": "^5.3.1",
+                "@types/tar-stream": "^2.2.2",
                 "decompress": "^4.2.1",
                 "jest": "^29.5.0",
                 "nock": "^13.3.1",
                 "source-map": "^0.7.4",
+                "tar-stream": "^3.1.6",
                 "ts-jest": "^29.1.0",
                 "typescript": "^5.0.4"
+            },
+            "dependencies": {
+                "tar-stream": {
+                    "version": "3.1.6",
+                    "requires": {
+                        "b4a": "^1.6.4",
+                        "fast-fifo": "^1.2.0",
+                        "streamx": "^2.15.0"
+                    }
+                }
             }
         },
         "@backtrace-labs/vite-plugin": {
@@ -13445,7 +13221,7 @@
             "version": "0.5.7",
             "dev": true
         },
-        "@esbuild/darwin-x64": {
+        "@esbuild/linux-x64": {
             "version": "0.18.20",
             "optional": true,
             "peer": true
@@ -13942,13 +13718,6 @@
             "version": "2.0.0",
             "dev": true
         },
-        "@types/archiver": {
-            "version": "5.3.2",
-            "dev": true,
-            "requires": {
-                "@types/readdir-glob": "*"
-            }
-        },
         "@types/aria-query": {
             "version": "5.0.1",
             "dev": true
@@ -14109,13 +13878,6 @@
                 "@types/react": "*"
             }
         },
-        "@types/readdir-glob": {
-            "version": "1.1.1",
-            "dev": true,
-            "requires": {
-                "@types/node": "*"
-            }
-        },
         "@types/scheduler": {
             "version": "0.16.3",
             "dev": true
@@ -14131,6 +13893,13 @@
         "@types/stack-utils": {
             "version": "2.0.1",
             "dev": true
+        },
+        "@types/tar-stream": {
+            "version": "2.2.2",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
         },
         "@types/tough-cookie": {
             "version": "4.0.2",
@@ -14544,67 +14313,6 @@
             "version": "1.2.0",
             "dev": true
         },
-        "archiver": {
-            "version": "5.3.2",
-            "requires": {
-                "archiver-utils": "^2.1.0",
-                "async": "^3.2.4",
-                "buffer-crc32": "^0.2.1",
-                "readable-stream": "^3.6.0",
-                "readdir-glob": "^1.1.2",
-                "tar-stream": "^2.2.0",
-                "zip-stream": "^4.1.0"
-            }
-        },
-        "archiver-utils": {
-            "version": "2.1.0",
-            "requires": {
-                "glob": "^7.1.4",
-                "graceful-fs": "^4.2.0",
-                "lazystream": "^1.0.0",
-                "lodash.defaults": "^4.2.0",
-                "lodash.difference": "^4.5.0",
-                "lodash.flatten": "^4.4.0",
-                "lodash.isplainobject": "^4.0.6",
-                "lodash.union": "^4.6.0",
-                "normalize-path": "^3.0.0",
-                "readable-stream": "^2.0.0"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "7.2.3",
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.1.1",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "isarray": {
-                    "version": "1.0.0"
-                },
-                "readable-stream": {
-                    "version": "2.3.8",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
-                }
-            }
-        },
         "argparse": {
             "version": "2.0.1",
             "dev": true
@@ -14742,9 +14450,6 @@
             "version": "1.0.0",
             "dev": true
         },
-        "async": {
-            "version": "3.2.4"
-        },
         "async-each": {
             "version": "1.0.6",
             "dev": true,
@@ -14760,6 +14465,9 @@
         "available-typed-arrays": {
             "version": "1.0.5",
             "dev": true
+        },
+        "b4a": {
+            "version": "1.6.4"
         },
         "babel-jest": {
             "version": "29.6.4",
@@ -14864,7 +14572,8 @@
             }
         },
         "base64-js": {
-            "version": "1.5.1"
+            "version": "1.5.1",
+            "dev": true
         },
         "big.js": {
             "version": "5.2.2",
@@ -14874,22 +14583,6 @@
             "version": "2.2.0",
             "dev": true,
             "optional": true
-        },
-        "bindings": {
-            "version": "1.5.0",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "file-uri-to-path": "1.0.0"
-            }
-        },
-        "bl": {
-            "version": "4.1.0",
-            "requires": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-            }
         },
         "bluebird": {
             "version": "3.7.2",
@@ -14901,6 +14594,7 @@
         },
         "brace-expansion": {
             "version": "1.1.11",
+            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -15009,6 +14703,7 @@
         },
         "buffer": {
             "version": "5.7.1",
+            "dev": true,
             "requires": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.1.13"
@@ -15027,7 +14722,8 @@
             "dev": true
         },
         "buffer-crc32": {
-            "version": "0.2.13"
+            "version": "0.2.13",
+            "dev": true
         },
         "buffer-fill": {
             "version": "1.0.0",
@@ -15338,17 +15034,9 @@
             "version": "1.3.0",
             "dev": true
         },
-        "compress-commons": {
-            "version": "4.1.1",
-            "requires": {
-                "buffer-crc32": "^0.2.13",
-                "crc32-stream": "^4.0.2",
-                "normalize-path": "^3.0.0",
-                "readable-stream": "^3.6.0"
-            }
-        },
         "concat-map": {
-            "version": "0.0.1"
+            "version": "0.0.1",
+            "dev": true
         },
         "console-browserify": {
             "version": "1.2.0",
@@ -15400,17 +15088,8 @@
             "dev": true
         },
         "core-util-is": {
-            "version": "1.0.3"
-        },
-        "crc-32": {
-            "version": "1.2.2"
-        },
-        "crc32-stream": {
-            "version": "4.0.2",
-            "requires": {
-                "crc-32": "^1.2.0",
-                "readable-stream": "^3.4.0"
-            }
+            "version": "1.0.3",
+            "dev": true
         },
         "create-ecdh": {
             "version": "4.0.4",
@@ -15825,6 +15504,7 @@
         },
         "end-of-stream": {
             "version": "1.4.4",
+            "dev": true,
             "requires": {
                 "once": "^1.4.0"
             }
@@ -16392,6 +16072,9 @@
         "fast-deep-equal": {
             "version": "3.1.3"
         },
+        "fast-fifo": {
+            "version": "1.3.2"
+        },
         "fast-glob": {
             "version": "3.3.1",
             "dev": true,
@@ -16461,11 +16144,6 @@
         "file-type": {
             "version": "5.2.0",
             "dev": true
-        },
-        "file-uri-to-path": {
-            "version": "1.0.0",
-            "dev": true,
-            "optional": true
         },
         "fill-range": {
             "version": "7.0.1",
@@ -16690,7 +16368,8 @@
             }
         },
         "fs-constants": {
-            "version": "1.0.0"
+            "version": "1.0.0",
+            "dev": true
         },
         "fs-write-stream-atomic": {
             "version": "1.0.10",
@@ -16729,11 +16408,8 @@
             }
         },
         "fs.realpath": {
-            "version": "1.0.0"
-        },
-        "fsevents": {
-            "version": "2.3.3",
-            "optional": true
+            "version": "1.0.0",
+            "dev": true
         },
         "function-bind": {
             "version": "1.1.1",
@@ -17016,7 +16692,8 @@
             "dev": true
         },
         "ieee754": {
-            "version": "1.2.1"
+            "version": "1.2.1",
+            "dev": true
         },
         "iferr": {
             "version": "0.1.5",
@@ -17056,13 +16733,15 @@
         },
         "inflight": {
             "version": "1.0.6",
+            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
             }
         },
         "inherits": {
-            "version": "2.0.4"
+            "version": "2.0.4",
+            "dev": true
         },
         "internal-slot": {
             "version": "1.0.5",
@@ -18104,35 +17783,6 @@
             "version": "3.0.3",
             "dev": true
         },
-        "lazystream": {
-            "version": "1.0.1",
-            "requires": {
-                "readable-stream": "^2.0.5"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "1.0.0"
-                },
-                "readable-stream": {
-                    "version": "2.3.8",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
-                }
-            }
-        },
         "leven": {
             "version": "3.1.0",
             "dev": true
@@ -18184,18 +17834,6 @@
         "lodash.camelcase": {
             "version": "4.3.0"
         },
-        "lodash.defaults": {
-            "version": "4.2.0"
-        },
-        "lodash.difference": {
-            "version": "4.5.0"
-        },
-        "lodash.flatten": {
-            "version": "4.4.0"
-        },
-        "lodash.isplainobject": {
-            "version": "4.0.6"
-        },
         "lodash.memoize": {
             "version": "4.1.2",
             "dev": true
@@ -18203,9 +17841,6 @@
         "lodash.merge": {
             "version": "4.6.2",
             "dev": true
-        },
-        "lodash.union": {
-            "version": "4.6.0"
         },
         "loose-envify": {
             "version": "1.4.0",
@@ -18351,6 +17986,7 @@
         },
         "minimatch": {
             "version": "3.1.2",
+            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -18471,11 +18107,6 @@
         "ms": {
             "version": "2.1.2",
             "dev": true
-        },
-        "nan": {
-            "version": "2.17.0",
-            "dev": true,
-            "optional": true
         },
         "nanoid": {
             "version": "3.3.6",
@@ -18604,7 +18235,8 @@
             "version": "2.0.13"
         },
         "normalize-path": {
-            "version": "3.0.0"
+            "version": "3.0.0",
+            "dev": true
         },
         "npm-run-path": {
             "version": "4.0.1",
@@ -18745,6 +18377,7 @@
         },
         "once": {
             "version": "1.4.0",
+            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -18882,7 +18515,8 @@
             "dev": true
         },
         "path-is-absolute": {
-            "version": "1.0.1"
+            "version": "1.0.1",
+            "dev": true
         },
         "path-key": {
             "version": "3.1.1"
@@ -19022,7 +18656,8 @@
             "dev": true
         },
         "process-nextick-args": {
-            "version": "2.0.1"
+            "version": "2.0.1",
+            "dev": true
         },
         "promise-inflight": {
             "version": "1.0.1",
@@ -19119,6 +18754,9 @@
             "version": "1.2.3",
             "dev": true
         },
+        "queue-tick": {
+            "version": "1.0.1"
+        },
         "randombytes": {
             "version": "2.1.0",
             "requires": {
@@ -19155,30 +18793,11 @@
         },
         "readable-stream": {
             "version": "3.6.2",
+            "dev": true,
             "requires": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
                 "util-deprecate": "^1.0.1"
-            }
-        },
-        "readdir-glob": {
-            "version": "1.1.3",
-            "requires": {
-                "minimatch": "^5.1.0"
-            },
-            "dependencies": {
-                "brace-expansion": {
-                    "version": "2.0.1",
-                    "requires": {
-                        "balanced-match": "^1.0.0"
-                    }
-                },
-                "minimatch": {
-                    "version": "5.1.6",
-                    "requires": {
-                        "brace-expansion": "^2.0.1"
-                    }
-                }
             }
         },
         "readdirp": {
@@ -19841,14 +19460,23 @@
             "version": "1.0.1",
             "dev": true
         },
+        "streamx": {
+            "version": "2.15.1",
+            "requires": {
+                "fast-fifo": "^1.1.0",
+                "queue-tick": "^1.0.1"
+            }
+        },
         "string_decoder": {
             "version": "1.3.0",
+            "dev": true,
             "requires": {
                 "safe-buffer": "~5.2.0"
             },
             "dependencies": {
                 "safe-buffer": {
-                    "version": "5.2.1"
+                    "version": "5.2.1",
+                    "dev": true
                 }
             }
         },
@@ -19985,16 +19613,6 @@
         },
         "tapable": {
             "version": "2.2.1"
-        },
-        "tar-stream": {
-            "version": "2.2.0",
-            "requires": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
-            }
         },
         "terser": {
             "version": "5.19.2",
@@ -20487,7 +20105,8 @@
             }
         },
         "util-deprecate": {
-            "version": "1.0.2"
+            "version": "1.0.2",
+            "dev": true
         },
         "v8-to-istanbul": {
             "version": "9.1.0",
@@ -20630,15 +20249,6 @@
                                 "is-extendable": "^0.1.0"
                             }
                         }
-                    }
-                },
-                "fsevents": {
-                    "version": "1.2.13",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "bindings": "^1.5.0",
-                        "nan": "^2.12.1"
                     }
                 },
                 "glob-parent": {
@@ -21380,7 +20990,8 @@
             }
         },
         "wrappy": {
-            "version": "1.0.2"
+            "version": "1.0.2",
+            "dev": true
         },
         "write-file-atomic": {
             "version": "4.0.2",
@@ -21432,14 +21043,6 @@
         "yocto-queue": {
             "version": "0.1.0",
             "dev": true
-        },
-        "zip-stream": {
-            "version": "4.1.0",
-            "requires": {
-                "archiver-utils": "^2.1.0",
-                "compress-commons": "^4.1.0",
-                "readable-stream": "^3.6.0"
-            }
         }
     }
 }

--- a/tools/cli/src/sourcemaps/upload.ts
+++ b/tools/cli/src/sourcemaps/upload.ts
@@ -205,8 +205,15 @@ export const uploadCmd = new Command<UploadOptions>({
                           const uploader = uploadArchive(
                               new SymbolUploader(uploadUrl, { ignoreSsl: opts.insecure ?? false }),
                           );
+
+                          // We first create the upload request, which pipes the archive to itself
                           const promise = uploader(archive);
+
+                          // Next we finalize the archive, which causes the assets to be written to the archive,
+                          // and consequently to the request
                           await finalizeArchive({ assets, archive });
+
+                          // Finally, we return the upload request promise
                           return promise;
                       })
                       .then(logDebug(`archive uploaded to ${uploadUrl}`)).inner

--- a/tools/rollup-plugin/src/index.ts
+++ b/tools/rollup-plugin/src/index.ts
@@ -23,8 +23,7 @@ export function BacktracePlugin(options?: BacktracePluginOptions): Plugin {
                 assetFinished: (asset) => info(`[${asset.asset.name}] asset processed successfully`),
                 assetError: (asset) => this.warn(`[${asset.asset.name}] ${asset.error}`),
 
-                beforeArchive: (paths) => this.debug(`creating archive to upload from ${paths.length} files`),
-                beforeUpload: () => info(`uploading sourcemaps...`),
+                beforeUpload: (paths) => info(`uploading ${paths.length} sourcemaps...`),
                 afterUpload: (result) => info(`sourcemaps uploaded to Backtrace: ${result.rxid}`),
                 uploadError: (error) => this.warn(`failed to upload sourcemaps: ${error}`),
             });

--- a/tools/sourcemap-tools/package.json
+++ b/tools/sourcemap-tools/package.json
@@ -37,9 +37,9 @@
     },
     "homepage": "https://github.com/backtrace-labs/backtrace-javascript#readme",
     "devDependencies": {
-        "@types/archiver": "^5.3.2",
         "@types/decompress": "^4.2.4",
         "@types/jest": "^29.5.1",
+        "@types/tar-stream": "^2.2.2",
         "decompress": "^4.2.1",
         "jest": "^29.5.0",
         "nock": "^13.3.1",
@@ -47,7 +47,7 @@
         "typescript": "^5.0.4"
     },
     "dependencies": {
-        "archiver": "^5.3.1",
-        "source-map": "^0.7.4"
+        "source-map": "^0.7.4",
+        "tar-stream": "^3.1.6"
     }
 }

--- a/tools/sourcemap-tools/src/SymbolUploader.ts
+++ b/tools/sourcemap-tools/src/SymbolUploader.ts
@@ -34,7 +34,7 @@ export class SymbolUploader {
      * Uploads the symbol to Backtrace.
      * @param content Symbol stream.
      */
-    public async uploadSymbol(readable: Readable): ResultPromise<UploadResult, string> {
+    public async uploadSymbol(readable: Pick<Readable, 'pipe'>): ResultPromise<UploadResult, string> {
         const protocol = this._url.protocol === 'https:' ? https : http;
 
         return new Promise<Result<UploadResult, string>>((resolve, reject) => {

--- a/tools/sourcemap-tools/src/ZipArchive.ts
+++ b/tools/sourcemap-tools/src/ZipArchive.ts
@@ -13,7 +13,7 @@ export class ZipArchive {
         this._pack.pipe(this._gz);
     }
 
-    public async append(name: string, sourceMap: string) {
+    public append(name: string, sourceMap: string) {
         this._pack.entry({ name }, sourceMap);
         return this;
     }

--- a/tools/sourcemap-tools/src/ZipArchive.ts
+++ b/tools/sourcemap-tools/src/ZipArchive.ts
@@ -1,32 +1,38 @@
-import archiver from 'archiver';
-import { Readable, Transform, TransformCallback, TransformOptions } from 'stream';
+import zlib from 'node:zlib';
+import { TransformOptions } from 'stream';
+import tar from 'tar-stream';
 
-export class ZipArchive extends Transform {
-    private readonly _archive: archiver.Archiver;
+export class ZipArchive {
+    private readonly _pack: tar.Pack;
+    private readonly _gz: zlib.Gzip;
 
     constructor(opts?: TransformOptions) {
-        super(opts);
-        this._archive = archiver('zip');
+        this._pack = tar.pack(opts);
+        this._gz = zlib.createGzip();
+
+        this._pack.pipe(this._gz);
     }
 
-    public append(name: string, sourceMap: string | Readable | Buffer) {
-        this._archive.append(sourceMap, { name });
+    public async append(name: string, sourceMap: string) {
+        this._pack.entry({ name }, sourceMap);
         return this;
     }
 
     public finalize() {
-        return this._archive.finalize();
+        this._pack.finalize();
+
+        return new Promise<ZipArchive>((resolve, reject) => {
+            this._gz.on('close', () => resolve(this));
+            this._gz.on('error', reject);
+        });
     }
 
-    public override pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean }): T {
-        return this._archive.pipe(destination, options);
+    public on(event: string, listener: (...args: unknown[]) => void): this {
+        this._pack.on(event, listener);
+        return this;
     }
 
-    public override _transform(chunk: unknown, encoding: BufferEncoding, callback: TransformCallback): void {
-        return this._archive._transform(chunk, encoding, callback);
-    }
-
-    public override _flush(callback: TransformCallback): void {
-        return this._archive._flush(callback);
+    public pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean }): T {
+        return this._gz.pipe(destination, options);
     }
 }

--- a/tools/sourcemap-tools/src/commands/processAndUploadAssetsCommand.ts
+++ b/tools/sourcemap-tools/src/commands/processAndUploadAssetsCommand.ts
@@ -122,8 +122,13 @@ export function processAndUploadAssetsCommand(
             .then(options?.beforeUpload ? inspect(options.beforeUpload) : pass)
             .then(createArchive(sourceProcessor))
             .then(async ({ assets, archive }) => {
+                // We first create the upload request, which pipes the archive to itself
                 const promise = uploadCommand(archive);
+
+                // Next we finalize the archive, which causes the assets to be written to the archive, and consequently to the request
                 await finalizeArchive({ assets, archive });
+
+                // Finally, we return the upload request promise
                 return promise;
             })
             .then(options?.afterUpload ? inspect(options.afterUpload) : pass)

--- a/tools/sourcemap-tools/src/helpers/common.ts
+++ b/tools/sourcemap-tools/src/helpers/common.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
-import { Readable } from 'stream';
-import { Logger, LogLevel } from '../Logger';
+import { EventEmitter, Readable } from 'stream';
+import { LogLevel, Logger } from '../Logger';
 import { ResultPromise } from '../models/AsyncResult';
 import { Err, Ok, Result } from '../models/Result';
 
@@ -22,6 +22,14 @@ export async function writeFile(file: ContentFile) {
         return Ok(file);
     } catch (err) {
         return Err(`failed to write file: ${err instanceof Error ? err.message : 'unknown error'}`);
+    }
+}
+
+export async function createWriteStream(path: string) {
+    try {
+        return Ok(fs.createWriteStream(path));
+    } catch (err) {
+        return Err(`failed to create write stream to file: ${err instanceof Error ? err.message : 'unknown error'}`);
     }
 }
 
@@ -82,5 +90,19 @@ export function inspect<T>(fn: (t: T) => unknown) {
     return function inspect(t: T): T {
         fn(t);
         return t;
+    };
+}
+
+export function waitOn(event: string) {
+    return function waitOn<T extends EventEmitter>(ee: T) {
+        return new Promise<T>((resolve, reject) => {
+            ee.once(event, (err) => {
+                if (err instanceof Error) {
+                    reject(err);
+                } else {
+                    resolve(ee);
+                }
+            });
+        });
     };
 }

--- a/tools/sourcemap-tools/src/helpers/common.ts
+++ b/tools/sourcemap-tools/src/helpers/common.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { EventEmitter, Readable } from 'stream';
+import { EventEmitter, Readable, Writable } from 'stream';
 import { LogLevel, Logger } from '../Logger';
 import { ResultPromise } from '../models/AsyncResult';
 import { Err, Ok, Result } from '../models/Result';
@@ -25,12 +25,18 @@ export async function writeFile(file: ContentFile) {
     }
 }
 
-export async function createWriteStream(path: string) {
+export function createWriteStream(path: string) {
     try {
         return Ok(fs.createWriteStream(path));
     } catch (err) {
         return Err(`failed to create write stream to file: ${err instanceof Error ? err.message : 'unknown error'}`);
     }
+}
+
+export function pipeStream(readable: Pick<Readable, 'pipe'>) {
+    return function pipeStream(writable: Writable) {
+        return readable.pipe(writable);
+    };
 }
 
 export async function writeStream(file: StreamFile) {

--- a/tools/sourcemap-tools/src/helpers/common.ts
+++ b/tools/sourcemap-tools/src/helpers/common.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { EventEmitter, Readable, Writable } from 'stream';
+import { Readable, Writable } from 'stream';
 import { LogLevel, Logger } from '../Logger';
 import { ResultPromise } from '../models/AsyncResult';
 import { Err, Ok, Result } from '../models/Result';
@@ -96,19 +96,5 @@ export function inspect<T>(fn: (t: T) => unknown) {
     return function inspect(t: T): T {
         fn(t);
         return t;
-    };
-}
-
-export function waitOn(event: string) {
-    return function waitOn<T extends EventEmitter>(ee: T) {
-        return new Promise<T>((resolve, reject) => {
-            ee.once(event, (err) => {
-                if (err instanceof Error) {
-                    reject(err);
-                } else {
-                    resolve(ee);
-                }
-            });
-        });
     };
 }

--- a/tools/sourcemap-tools/tests/ZipArchive.spec.ts
+++ b/tools/sourcemap-tools/tests/ZipArchive.spec.ts
@@ -23,8 +23,8 @@ describe('ZipArchive', () => {
         archive.pipe(outputStream);
 
         const entries = [
-            ['entry1', Buffer.from('entry1')],
-            ['entry2', Buffer.from('entry2')],
+            ['entry1', 'entry1Data'],
+            ['entry2', 'entry2Data'],
         ] as const;
 
         for (const [name, buf] of entries) {
@@ -40,7 +40,7 @@ describe('ZipArchive', () => {
             const entry = entries.find(([e]) => e === file.path);
             assert(entry);
 
-            expect(entry[1]).toEqual(file.data);
+            expect(file.data.toString('utf-8')).toEqual(entry[1]);
         }
     });
 });

--- a/tools/webpack-plugin/src/BacktracePlugin.ts
+++ b/tools/webpack-plugin/src/BacktracePlugin.ts
@@ -29,8 +29,7 @@ export class BacktracePlugin implements WebpackPluginInstance {
                 assetFinished: (asset) => logger.info(`[${asset.asset.name}] asset processed successfully`),
                 assetError: (asset) => logger.error(`[${asset.asset.name}] ${asset.error}`),
 
-                beforeArchive: (paths) => logger.log(`creating archive to upload from ${paths.length} files`),
-                beforeUpload: () => logger.log(`uploading sourcemaps...`),
+                beforeUpload: (paths) => logger.log(`uploading ${paths.length} sourcemaps...`),
                 afterUpload: (result) => logger.info(`sourcemaps uploaded to Backtrace: ${result.rxid}`),
                 uploadError: (error) => logger.error(`failed to upload sourcemaps: ${error}`),
             });


### PR DESCRIPTION
This PR fixes sourcemap uploads in cases of large files:
* `archiver` has been replaced with `tar` and `zlib`
* `.tar.gz` archives are now being output instead of `.zip` - confirmed that this works with the backend
* `pipe` to output (upload, archive file) is now being done before appending any sourcemaps.