### PR TITLE
sdk-core: fix skipping stack frame with message reports

### DIFF
--- a/packages/sdk-core/src/modules/converter/V8StackTraceConverter.ts
+++ b/packages/sdk-core/src/modules/converter/V8StackTraceConverter.ts
@@ -16,6 +16,8 @@ export class V8StackTraceConverter implements BacktraceStackTraceConverter {
         // remove error header from stack trace - if the error header exists
         if (stackFrames[0].indexOf(errorHeader[0]) !== -1) {
             stackFrames = stackFrames.slice(errorHeader.length);
+        } else {
+            stackFrames = stackFrames.slice(1);
         }
         for (const stackFrame of stackFrames) {
             const normalizedStackFrame = stackFrame.trim();


### PR DESCRIPTION
When creating a report using `BacktraceClient.send('message')`, there were some problems with stack frames:
* on V8, the first frame was being seen as "Error"
* in React there were some problems with async state machines being included in the report - removing `async` from `send` fixed the issue