### PR TITLE
add deferred user attributes

### DIFF
--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -39,7 +39,7 @@ $ npm install @backtrace-labs/browser
 Add the following code to your application before all other scripts to report client-side errors to Backtrace.
 
 ```ts
-// Import the BacktraceClient from @backtrace-labs/browser with your favoriate package manager.
+// Import the BacktraceClient from @backtrace-labs/browser with your favorite package manager.
 import { BacktraceClient, BacktraceConfiguration } from '@backtrace-labs/browser';
 
 // Configure client options
@@ -108,6 +108,25 @@ const options: BacktraceConfiguration = {
 const client = BacktraceClient.initialize(options);
 ```
 
+You can also include attributes that will be resolved when creating a report:
+
+```ts
+// BacktraceClientOptions
+const options: BacktraceConfiguration = {
+    name: 'MyWebPage',
+    version: '1.2.3',
+    url: 'https://submit.backtrace.io/<universe>/<token>/json',
+
+    // Attach the attributes object
+    userAttributes: () => ({
+        user: getCurrentUser(),
+    }),
+};
+
+// Initialize the client
+const client = BacktraceClient.initialize(options);
+```
+
 #### Add attributes during application runtime
 
 Global attributes can be set during the runtime once specific data has be loaded (e.g. a user has logged in).
@@ -119,6 +138,17 @@ const client = BacktraceClient.initialize(options);
 client.addAttribute({
     "clientID": "de6faf4d-d5b5-486c-9789-318f58a14476"
 })
+```
+
+You can also add attributes that will be resolved when creating a report:
+
+```ts
+const client = BacktraceClient.initialize(options);
+...
+
+client.addAttribute(() => ({
+    "clientID": resolveCurrentClientId()
+}))
 ```
 
 #### Add attributes to an error report

--- a/packages/browser/src/attributes/UserIdentifierAttributeProvider.ts
+++ b/packages/browser/src/attributes/UserIdentifierAttributeProvider.ts
@@ -1,23 +1,15 @@
-import { BacktraceAttributeProvider, BacktraceConfiguration, IdGenerator } from '@backtrace-labs/sdk-core';
+import { BacktraceAttributeProvider, IdGenerator } from '@backtrace-labs/sdk-core';
 
 export class UserIdentifierAttributeProvider implements BacktraceAttributeProvider {
     public readonly USER_IDENTIFIER = 'backtrace-guid';
-    private _guid: string | undefined;
-
-    constructor(options: BacktraceConfiguration) {
-        this._guid = options.userAttributes?.['guid'] as string;
-    }
 
     public get type(): 'scoped' | 'dynamic' {
         return 'scoped';
     }
-    public get(): Record<string, unknown> {
-        if (!this._guid) {
-            this._guid = this.generateUuidToLocalStorage() ?? IdGenerator.uuid();
-        }
 
+    public get(): Record<string, unknown> {
         return {
-            guid: this._guid,
+            guid: this.generateUuidToLocalStorage() ?? IdGenerator.uuid(),
         };
     }
 

--- a/packages/browser/src/builder/BacktraceClientBuilder.ts
+++ b/packages/browser/src/builder/BacktraceClientBuilder.ts
@@ -6,15 +6,15 @@ import {
     BreadcrumbsEventSubscriber,
 } from '@backtrace-labs/sdk-core';
 import { V8StackTraceConverter } from '@backtrace-labs/sdk-core/lib/modules/converter/V8StackTraceConverter';
+import { BacktraceBrowserRequestHandler } from '../BacktraceBrowserRequestHandler';
+import { BacktraceBrowserSessionProvider } from '../BacktraceBrowserSessionProvider';
+import { BacktraceClient } from '../BacktraceClient';
+import { BacktraceConfiguration } from '../BacktraceConfiguration';
 import { ApplicationInformationAttributeProvider } from '../attributes/ApplicationInformationAttributeProvider';
 import { UserAgentAttributeProvider } from '../attributes/UserAgentAttributeProvider';
 import { UserIdentifierAttributeProvider } from '../attributes/UserIdentifierAttributeProvider';
 import { WebsiteAttributeProvider } from '../attributes/WebsiteAttributeProvider';
 import { WindowAttributeProvider } from '../attributes/WindowAttributeProvider';
-import { BacktraceBrowserRequestHandler } from '../BacktraceBrowserRequestHandler';
-import { BacktraceBrowserSessionProvider } from '../BacktraceBrowserSessionProvider';
-import { BacktraceClient } from '../BacktraceClient';
-import { BacktraceConfiguration } from '../BacktraceConfiguration';
 import { DocumentEventSubscriber } from '../breadcrumbs/DocumentEventSubscriber';
 import { HistoryEventSubscriber } from '../breadcrumbs/HistoryEventSubscriber';
 import { WebRequestEventSubscriber } from '../breadcrumbs/WebRequestEventSubscriber';
@@ -29,7 +29,7 @@ export class BacktraceClientBuilder extends BacktraceCoreClientBuilder<Backtrace
             new UserAgentAttributeProvider(),
             new WebsiteAttributeProvider(),
             new WindowAttributeProvider(),
-            new UserIdentifierAttributeProvider(options),
+            new UserIdentifierAttributeProvider(),
             new ApplicationInformationAttributeProvider(options),
         ],
         breadcrumbsSubscribers: BreadcrumbsEventSubscriber[] = [

--- a/packages/browser/tests/attributes/userIdAttributeProviderTests.spec.ts
+++ b/packages/browser/tests/attributes/userIdAttributeProviderTests.spec.ts
@@ -1,31 +1,20 @@
-import { BacktraceConfiguration } from '@backtrace-labs/sdk-core';
 import { UserIdentifierAttributeProvider } from '../../src/attributes/UserIdentifierAttributeProvider';
 describe('User id attribute provider test', () => {
     it(`Should always set user id attribute`, () => {
-        const userIdentifier = new UserIdentifierAttributeProvider({} as BacktraceConfiguration);
+        const userIdentifier = new UserIdentifierAttributeProvider();
 
         expect(userIdentifier.get()['guid']).toBeDefined();
     });
 
-    it(`Should always use guid from the user attributes`, () => {
-        const test = 'test';
-        const userIdentifier = new UserIdentifierAttributeProvider({
-            url: 'https://submit.backtrace.io/foo/bar/baz',
-            userAttributes: { guid: test },
-        } as BacktraceConfiguration);
-
-        expect(userIdentifier.get()['guid']).toEqual(test);
-    });
-
     it(`Should store value in the local storage if the guid is not provider`, () => {
-        const userIdentifier = new UserIdentifierAttributeProvider({} as BacktraceConfiguration);
+        const userIdentifier = new UserIdentifierAttributeProvider();
 
         expect(window.localStorage.getItem(userIdentifier.USER_IDENTIFIER)).toBeDefined();
     });
 
     it(`Should always generate the same value`, () => {
-        const userIdentifier1 = new UserIdentifierAttributeProvider({} as BacktraceConfiguration);
-        const userIdentifier2 = new UserIdentifierAttributeProvider({} as BacktraceConfiguration);
+        const userIdentifier1 = new UserIdentifierAttributeProvider();
+        const userIdentifier2 = new UserIdentifierAttributeProvider();
 
         expect(userIdentifier1.get()['guid']).toEqual(userIdentifier2.get()['guid']);
     });

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -44,7 +44,7 @@ $ npm install @backtrace-labs/node
 Add the following code to your application before all other scripts to report node errors to Backtrace.
 
 ```ts
-// Import the BacktraceClient from @backtrace-labs/node with your favoriate package manager.
+// Import the BacktraceClient from @backtrace-labs/node with your favorite package manager.
 import { BacktraceClient, BacktraceConfiguration } from '@backtrace-labs/node';
 
 // Configure client options
@@ -109,6 +109,23 @@ const options: BacktraceConfiguration = {
 const client = BacktraceClient.initialize(options);
 ```
 
+You can also include attributes that will be resolved when creating a report:
+
+```ts
+// BacktraceClientOptions
+const options: BacktraceConfiguration = {
+    url: 'https://submit.backtrace.io/<universe>/<token>/json',
+
+    // Attach the attributes object
+    userAttributes: () => ({
+        attribute: getAttributeValue(),
+    }),
+};
+
+// Initialize the client
+const client = BacktraceClient.initialize(options);
+```
+
 #### Add attributes during application runtime
 
 Global attributes can be set during the runtime once specific data has be loaded (e.g. a user has logged in).
@@ -120,6 +137,17 @@ const client = BacktraceClient.initialize(options);
 client.addAttribute({
     "clientID": "de6faf4d-d5b5-486c-9789-318f58a14476"
 })
+```
+
+You can also add attributes that will be resolved when creating a report:
+
+```ts
+const client = BacktraceClient.initialize(options);
+...
+
+client.addAttribute(() => ({
+    "clientID": resolveCurrentClientId()
+}))
 ```
 
 #### Add attributes to an error report

--- a/packages/node/src/attributes/ApplicationInformationAttributeProvider.ts
+++ b/packages/node/src/attributes/ApplicationInformationAttributeProvider.ts
@@ -2,7 +2,6 @@ import { BacktraceAttributeProvider } from '@backtrace-labs/sdk-core';
 import fs from 'fs';
 import path from 'path';
 import process from 'process';
-import { BacktraceConfiguration } from '../BacktraceConfiguration';
 
 export class ApplicationInformationAttributeProvider implements BacktraceAttributeProvider {
     public readonly APPLICATION_ATTRIBUTE = 'application';
@@ -17,17 +16,14 @@ export class ApplicationInformationAttributeProvider implements BacktraceAttribu
     }
 
     constructor(
-        options: BacktraceConfiguration,
         applicationSearchPaths?: string[],
         nodeConfiguration: { application?: string; version?: string } = {
             application: process.env?.npm_package_name,
             version: process.env?.npm_package_version,
         },
     ) {
-        this._application =
-            (options.userAttributes?.[this.APPLICATION_ATTRIBUTE] as string) ?? nodeConfiguration?.application;
-        this._applicationVersion =
-            (options.userAttributes?.[this.APPLICATION_VERSION_ATTRIBUTE] as string) ?? nodeConfiguration?.version;
+        this._application = nodeConfiguration?.application;
+        this._applicationVersion = nodeConfiguration?.version;
 
         this.applicationSearchPaths = applicationSearchPaths ?? this.generateDefaultApplicationSearchPaths();
     }

--- a/packages/node/src/builder/BacktraceClientBuilder.ts
+++ b/packages/node/src/builder/BacktraceClientBuilder.ts
@@ -5,6 +5,9 @@ import {
     BacktraceSessionProvider,
     BreadcrumbsEventSubscriber,
 } from '@backtrace-labs/sdk-core';
+import { BacktraceClient } from '../BacktraceClient';
+import { BacktraceConfiguration } from '../BacktraceConfiguration';
+import { BacktraceNodeRequestHandler } from '../BacktraceNodeRequestHandler';
 import { BacktraceFileAttachment } from '../attachment';
 import {
     ApplicationInformationAttributeProvider,
@@ -14,15 +17,12 @@ import {
     ProcessInformationAttributeProvider,
     ProcessStatusAttributeProvider,
 } from '../attributes';
-import { BacktraceClient } from '../BacktraceClient';
-import { BacktraceConfiguration } from '../BacktraceConfiguration';
-import { BacktraceNodeRequestHandler } from '../BacktraceNodeRequestHandler';
 
 export class BacktraceClientBuilder extends BacktraceCoreClientBuilder<BacktraceClient> {
     constructor(
         private readonly _options: BacktraceConfiguration,
         attributeProvider: BacktraceAttributeProvider[] = [
-            new ApplicationInformationAttributeProvider(_options),
+            new ApplicationInformationAttributeProvider(),
             new ProcessStatusAttributeProvider(),
             new MachineAttributeProvider(),
             new ProcessInformationAttributeProvider(),

--- a/packages/node/tests/attributes/applicationInformationAttributeProviderTests.spec.ts
+++ b/packages/node/tests/attributes/applicationInformationAttributeProviderTests.spec.ts
@@ -1,37 +1,15 @@
 import fs from 'fs';
 import path from 'path';
-import { BacktraceConfiguration } from '../../src';
 import { ApplicationInformationAttributeProvider } from '../../src/attributes/ApplicationInformationAttributeProvider';
 
 describe('Application information attribute provider tests', () => {
-    it('Should allow to set application and application.version attribute via attribute system', () => {
-        const expectedApplicationName = 'test';
-        const applicationKey = 'application';
-        const expectedApplicationVersion = '1.0.0';
-        const applicationVersionKey = 'application.version';
-        const provider = new ApplicationInformationAttributeProvider({
-            url: 'not-used',
-            userAttributes: {
-                [applicationKey]: expectedApplicationName,
-                [applicationVersionKey]: expectedApplicationVersion,
-            },
-        } as BacktraceConfiguration);
-
-        const attributes = provider.get();
-
-        expect(attributes[applicationKey]).toBe(expectedApplicationName);
-        expect(attributes[applicationVersionKey]).toBe(expectedApplicationVersion);
-    });
-
     describe('search path tests', () => {
         const sourceDir = path.dirname(path.dirname(__dirname));
         const libraryPackageJson = path.join(sourceDir, 'package.json');
         const expectedPackageJson = JSON.parse(fs.readFileSync(libraryPackageJson, 'utf8'));
         it('Should find a package.json file in the project structure', () => {
             const testedPackageDir = path.join(sourceDir, 'foo', 'bar', 'baz', '123', 'foo', 'bar');
-            const provider = new ApplicationInformationAttributeProvider({} as BacktraceConfiguration, [
-                testedPackageDir,
-            ]);
+            const provider = new ApplicationInformationAttributeProvider([testedPackageDir]);
             const attributes = provider.get();
 
             expect(attributes[provider.APPLICATION_ATTRIBUTE]).toBe(expectedPackageJson.name);
@@ -40,7 +18,7 @@ describe('Application information attribute provider tests', () => {
         });
 
         it('Should try to find a package.json in the current project', () => {
-            const provider = new ApplicationInformationAttributeProvider({} as BacktraceConfiguration);
+            const provider = new ApplicationInformationAttributeProvider();
             const attributes = provider.get();
 
             expect(attributes[provider.APPLICATION_ATTRIBUTE]).toBe(expectedPackageJson.name);
@@ -50,11 +28,7 @@ describe('Application information attribute provider tests', () => {
 
         it('Should throw an error when the package.json information does not exist', () => {
             const testedPackageDir = path.join('/foo', 'bar', 'baz', '123', 'foo', 'bar');
-            const provider = new ApplicationInformationAttributeProvider(
-                {} as BacktraceConfiguration,
-                [testedPackageDir],
-                {},
-            );
+            const provider = new ApplicationInformationAttributeProvider([testedPackageDir], {});
 
             expect(() => provider.get()).toThrow(Error);
         });

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -40,7 +40,7 @@ $ npm install @backtrace-labs/react
 Add the following code to your application before all other scripts to report client-side errors to Backtrace.
 
 ```ts
-// Import the BacktraceClient from @backtrace-labs/react with your favoriate package manager.
+// Import the BacktraceClient from @backtrace-labs/react with your favorite package manager.
 import { BacktraceClient, BacktraceConfiguration } from '@backtrace-labs/react';
 
 // Configure client options
@@ -137,6 +137,25 @@ const options: BacktraceConfiguration = {
 const client = BacktraceClient.initialize(options);
 ```
 
+You can also include attributes that will be resolved when creating a report:
+
+```ts
+// BacktraceClientOptions
+const options: BacktraceConfiguration = {
+    name: 'MyWebPage',
+    version: '1.2.3',
+    url: 'https://submit.backtrace.io/<universe>/<token>/json',
+
+    // Attach the attributes object
+    userAttributes: () => ({
+        user: getCurrentUser(),
+    }),
+};
+
+// Initialize the client
+const client = BacktraceClient.initialize(options);
+```
+
 #### Add attributes during application runtime
 
 Global attributes can be set during the runtime once specific data has be loaded (e.g. a user has logged in).
@@ -148,6 +167,17 @@ const client = BacktraceClient.initialize(options);
 client.addAttribute({
     "clientID": "de6faf4d-d5b5-486c-9789-318f58a14476"
 })
+```
+
+You can also add attributes that will be resolved when creating a report:
+
+```ts
+const client = BacktraceClient.initialize(options);
+...
+
+client.addAttribute(() => ({
+    "clientID": resolveCurrentClientId()
+}))
 ```
 
 #### Add attributes to an error report

--- a/packages/sdk-core/src/BacktraceCoreClient.ts
+++ b/packages/sdk-core/src/BacktraceCoreClient.ts
@@ -166,13 +166,13 @@ export abstract class BacktraceCoreClient {
      * @param attributes key-value object with attributes.
      */
     public addAttribute(attributes: Record<string, unknown>): void;
+    /**
+     * Add dynamic attributes to Backtrace Client reports.
+     * @param attributes function returning key-value object with attributes.
+     */
     public addAttribute(attributes: () => Record<string, unknown>): void;
     public addAttribute(attributes: Record<string, unknown> | (() => Record<string, unknown>)) {
-        if (typeof attributes === 'function') {
-            this._attributeManager.addProvider({ type: 'dynamic', get: attributes });
-        } else {
-            this._attributeManager.add(attributes);
-        }
+        this._attributeManager.add(attributes);
     }
 
     /**

--- a/packages/sdk-core/src/BacktraceCoreClient.ts
+++ b/packages/sdk-core/src/BacktraceCoreClient.ts
@@ -165,8 +165,14 @@ export abstract class BacktraceCoreClient {
      * Add attribute to Backtrace Client reports.
      * @param attributes key-value object with attributes.
      */
-    public addAttribute(attributes: Record<string, unknown>) {
-        this._attributeManager.add(attributes);
+    public addAttribute(attributes: Record<string, unknown>): void;
+    public addAttribute(attributes: () => Record<string, unknown>): void;
+    public addAttribute(attributes: Record<string, unknown> | (() => Record<string, unknown>)) {
+        if (typeof attributes === 'function') {
+            this._attributeManager.addProvider({ type: 'dynamic', get: attributes });
+        } else {
+            this._attributeManager.add(attributes);
+        }
     }
 
     /**

--- a/packages/sdk-core/src/BacktraceCoreClient.ts
+++ b/packages/sdk-core/src/BacktraceCoreClient.ts
@@ -105,12 +105,6 @@ export abstract class BacktraceCoreClient {
 
         const stackTraceConverter = this._setup.stackTraceConverter ?? new V8StackTraceConverter();
 
-        this._dataBuilder = new BacktraceDataBuilder(
-            this._sdkOptions,
-            stackTraceConverter,
-            new DebugIdProvider(stackTraceConverter, this._setup.debugIdMapProvider),
-        );
-
         this._reportSubmission = new BacktraceReportSubmission(this.options, this._setup.requestHandler);
 
         const attributeProviders: BacktraceAttributeProvider[] = [
@@ -126,6 +120,13 @@ export abstract class BacktraceCoreClient {
         }
 
         this._attributeManager = new AttributeManager(attributeProviders);
+
+        this._dataBuilder = new BacktraceDataBuilder(
+            this._sdkOptions,
+            stackTraceConverter,
+            this._attributeManager,
+            new DebugIdProvider(stackTraceConverter, this._setup.debugIdMapProvider),
+        );
 
         this.attachments = this.options.attachments ?? [];
 
@@ -270,8 +271,7 @@ export abstract class BacktraceCoreClient {
     }
 
     private generateSubmissionData(report: BacktraceReport): BacktraceData | undefined {
-        const { annotations, attributes } = this._attributeManager.get();
-        const backtraceData = this._dataBuilder.build(report, attributes, annotations);
+        const backtraceData = this._dataBuilder.build(report);
         if (!this.options.beforeSend) {
             return backtraceData;
         }

--- a/packages/sdk-core/src/model/configuration/BacktraceConfiguration.ts
+++ b/packages/sdk-core/src/model/configuration/BacktraceConfiguration.ts
@@ -111,7 +111,7 @@ export interface BacktraceConfiguration {
      * Attributes are additional metadata that can be attached to error and crash reports. You can use attributes to filter,
      * aggregate, analyze, and debug errors in the Backtrace console.
      */
-    userAttributes?: Record<string, unknown>;
+    userAttributes?: Record<string, unknown> | (() => Record<string, unknown>);
     /**
      * Attachments are additional files/data that can be send with error to Backtrace.
      */

--- a/packages/sdk-core/src/modules/attribute/ClientAttributeProvider.ts
+++ b/packages/sdk-core/src/modules/attribute/ClientAttributeProvider.ts
@@ -5,17 +5,17 @@ export class ClientAttributeProvider implements BacktraceAttributeProvider {
         private readonly _sdkName: string,
         private readonly _sdkVersion: string,
         private readonly _sessionId: string,
-        private readonly _userAttributes: Record<string, unknown>,
     ) {}
+
     public get type(): 'scoped' | 'dynamic' {
         return 'scoped';
     }
+
     public get(): Record<string, unknown> {
         return {
             'application.session': this._sessionId,
             'backtrace.agent': this._sdkName,
             'backtrace.version': this._sdkVersion,
-            ...this._userAttributes,
         };
     }
 }

--- a/packages/sdk-core/src/modules/attribute/UserAttributeProvider.ts
+++ b/packages/sdk-core/src/modules/attribute/UserAttributeProvider.ts
@@ -1,0 +1,21 @@
+import { BacktraceAttributeProvider } from './BacktraceAttributeProvider';
+
+export class UserAttributeProvider implements BacktraceAttributeProvider {
+    constructor(private readonly _source: Record<string, unknown> | (() => Record<string, unknown>)) {}
+
+    public get type(): 'scoped' | 'dynamic' {
+        return typeof this._source === 'function' ? 'dynamic' : 'scoped';
+    }
+
+    public get(): Record<string, unknown> {
+        if (typeof this._source === 'function') {
+            try {
+                return this._source();
+            } catch {
+                return {};
+            }
+        }
+
+        return this._source;
+    }
+}

--- a/packages/sdk-core/src/modules/attribute/UserAttributeProvider.ts
+++ b/packages/sdk-core/src/modules/attribute/UserAttributeProvider.ts
@@ -1,21 +1,15 @@
 import { BacktraceAttributeProvider } from './BacktraceAttributeProvider';
 
 export class UserAttributeProvider implements BacktraceAttributeProvider {
-    constructor(private readonly _source: Record<string, unknown> | (() => Record<string, unknown>)) {}
+    public readonly type: 'scoped' | 'dynamic';
+    private readonly _source: () => Record<string, unknown>;
 
-    public get type(): 'scoped' | 'dynamic' {
-        return typeof this._source === 'function' ? 'dynamic' : 'scoped';
+    constructor(source: Record<string, unknown> | (() => Record<string, unknown>)) {
+        this._source = typeof source === 'function' ? source : () => source;
+        this.type = typeof source === 'function' ? 'dynamic' : 'scoped';
     }
 
     public get(): Record<string, unknown> {
-        if (typeof this._source === 'function') {
-            try {
-                return this._source();
-            } catch {
-                return {};
-            }
-        }
-
-        return this._source;
+        return this._source();
     }
 }

--- a/packages/sdk-core/src/modules/data/BacktraceDataBuilder.ts
+++ b/packages/sdk-core/src/modules/data/BacktraceDataBuilder.ts
@@ -2,9 +2,10 @@ import { BacktraceStackTraceConverter, DebugIdProvider } from '../..';
 import { SdkOptions } from '../../builder/SdkOptions';
 import { IdGenerator } from '../../common/IdGenerator';
 import { TimeHelper } from '../../common/TimeHelper';
-import { AttributeType, BacktraceData } from '../../model/data/BacktraceData';
+import { BacktraceData } from '../../model/data/BacktraceData';
 import { BacktraceStackFrame, BacktraceStackTrace } from '../../model/data/BacktraceStackTrace';
 import { BacktraceReport } from '../../model/report/BacktraceReport';
+import { AttributeManager } from '../attribute/AttributeManager';
 import { ReportDataBuilder } from '../attribute/ReportDataBuilder';
 
 export class BacktraceDataBuilder {
@@ -13,14 +14,13 @@ export class BacktraceDataBuilder {
     constructor(
         private readonly _sdkOptions: SdkOptions,
         private readonly _stackTraceConverter: BacktraceStackTraceConverter,
+        private readonly _attributeManager: AttributeManager,
         private readonly _debugIdProvider: DebugIdProvider,
     ) {}
 
-    public build(
-        report: BacktraceReport,
-        clientAttributes: Record<string, AttributeType> = {},
-        clientAnnotations: Record<string, unknown> = {},
-    ): BacktraceData {
+    public build(report: BacktraceReport): BacktraceData {
+        const { annotations, attributes } = this._attributeManager.get();
+
         const reportData = ReportDataBuilder.build(report.attributes);
         const { threads, detectedDebugIdentifier } = this.getThreads(report);
 
@@ -35,12 +35,12 @@ export class BacktraceDataBuilder {
             mainThread: this.MAIN_THREAD_NAME,
             threads,
             annotations: {
-                ...clientAnnotations,
+                ...annotations,
                 ...reportData.annotations,
                 ...report.annotations,
             },
             attributes: {
-                ...clientAttributes,
+                ...attributes,
                 ...reportData.attributes,
             },
         };

--- a/packages/sdk-core/tests/attributes/attributeManager.spec.ts
+++ b/packages/sdk-core/tests/attributes/attributeManager.spec.ts
@@ -1,0 +1,356 @@
+import { BacktraceAttributeProvider } from '../../src';
+import { AttributeManager } from '../../src/modules/attribute/AttributeManager';
+
+describe('AttributeManager', () => {
+    function provider(type: BacktraceAttributeProvider['type'], get: BacktraceAttributeProvider['get']) {
+        return { type, get };
+    }
+
+    describe('providers', () => {
+        it('should resolve static provider when it is added via constructor', () => {
+            const fn = jest.fn().mockReturnValue({});
+
+            new AttributeManager([provider('scoped', fn)]);
+            expect(fn).toBeCalled();
+        });
+
+        it('should resolve static provider when it is added via addProvider', () => {
+            const fn = jest.fn().mockReturnValue({});
+
+            const attributeManager = new AttributeManager([]);
+            attributeManager.addProvider(provider('scoped', fn));
+            expect(fn).toBeCalled();
+        });
+
+        it('should resolve static provider only once', () => {
+            const fn = jest.fn().mockReturnValue({});
+
+            const attributeManager = new AttributeManager([provider('scoped', fn)]);
+
+            attributeManager.get();
+            attributeManager.get();
+
+            expect(fn).toBeCalledTimes(1);
+        });
+
+        it('should resolve dynamic provider added via constructor when get is called', () => {
+            const fn = jest.fn().mockReturnValue({});
+
+            const attributeManager = new AttributeManager([provider('dynamic', fn)]);
+            expect(fn).not.toBeCalled();
+
+            attributeManager.get();
+
+            expect(fn).toBeCalled();
+        });
+
+        it('should resolve dynamic provider added via addProvider when get is called', () => {
+            const fn = jest.fn().mockReturnValue({});
+
+            const attributeManager = new AttributeManager([]);
+            attributeManager.addProvider(provider('dynamic', fn));
+            expect(fn).not.toBeCalled();
+
+            attributeManager.get();
+
+            expect(fn).toBeCalled();
+        });
+
+        it('should resolve dynamic provider every time when get is called', () => {
+            const fn = jest.fn().mockReturnValue({});
+
+            const attributeManager = new AttributeManager([]);
+            attributeManager.addProvider(provider('dynamic', fn));
+
+            attributeManager.get();
+            attributeManager.get();
+            attributeManager.get();
+
+            expect(fn).toBeCalledTimes(3);
+        });
+    });
+
+    describe('add', () => {
+        it('should resolve added attributes in order', () => {
+            const attributes1 = {
+                foo: 'bar',
+                abc: 'xyz',
+            };
+
+            const attributes2 = {
+                foo: 'baz',
+                test: 'test',
+            };
+
+            const attributes3 = {
+                foo: 'foo',
+                test2: 'test2',
+            };
+
+            const expected = {
+                ...attributes1,
+                ...attributes2,
+                ...attributes3,
+            };
+
+            const attributeManager = new AttributeManager([]);
+            attributeManager.add(attributes1);
+            attributeManager.add(attributes2);
+            attributeManager.add(attributes3);
+
+            const { attributes } = attributeManager.get();
+            expect(attributes).toEqual(expected);
+        });
+
+        it('should resolve added annotations in order', () => {
+            const annotations1 = {
+                foo: { x: 'bar' },
+                abc: { x: 'xyz' },
+            };
+
+            const annotations2 = {
+                foo: { x: 'baz' },
+                test: { x: 'test' },
+            };
+
+            const annotations3 = {
+                foo: { x: 'foo' },
+                test2: { x: 'test2' },
+            };
+
+            const expected = {
+                ...annotations1,
+                ...annotations2,
+                ...annotations3,
+            };
+
+            const attributeManager = new AttributeManager([]);
+            attributeManager.add(annotations1);
+            attributeManager.add(annotations2);
+            attributeManager.add(annotations3);
+
+            const { annotations } = attributeManager.get();
+            expect(annotations).toEqual(expected);
+        });
+
+        it('should override provider attributes with added attributes', () => {
+            const providerAttributes = {
+                foo: 'bar',
+                abc: 'xyz',
+            };
+
+            const addedAttributes = {
+                foo: 'baz',
+                test: 'test',
+            };
+
+            const expected = {
+                ...providerAttributes,
+                ...addedAttributes,
+            };
+
+            const attributeManager = new AttributeManager([provider('scoped', () => providerAttributes)]);
+            attributeManager.add(addedAttributes);
+
+            const { attributes } = attributeManager.get();
+            expect(attributes).toEqual(expected);
+        });
+
+        it('should override provider annotations with added annotations', () => {
+            const providerAnnotations = {
+                foo: { x: 'bar' },
+                abc: { x: 'xyz' },
+            };
+
+            const addedAnnotations = {
+                foo: { x: 'baz' },
+                test: { x: 'test' },
+            };
+
+            const expected = {
+                ...providerAnnotations,
+                ...addedAnnotations,
+            };
+
+            const attributeManager = new AttributeManager([provider('scoped', () => providerAnnotations)]);
+            attributeManager.add(addedAnnotations);
+
+            const { annotations } = attributeManager.get();
+            expect(annotations).toEqual(expected);
+        });
+    });
+
+    describe('attribute priority', () => {
+        it('should resolve attributes in order of providers', () => {
+            const attributes1 = {
+                foo: 'bar',
+                abc: 'xyz',
+            };
+
+            const attributes2 = {
+                foo: 'baz',
+                test: 'test',
+            };
+
+            const attributes3 = {
+                foo: 'foo',
+                test2: 'test2',
+            };
+
+            const expected = {
+                ...attributes1,
+                ...attributes2,
+                ...attributes3,
+            };
+
+            const attributeManager = new AttributeManager([
+                provider('scoped', () => attributes1),
+                provider('scoped', () => attributes2),
+                provider('scoped', () => attributes3),
+            ]);
+
+            const { attributes } = attributeManager.get();
+
+            expect(attributes).toEqual(expected);
+        });
+
+        it('should override scoped provider with next dynamic provider', () => {
+            const staticAttributes = {
+                foo: 'bar',
+                abc: 'xyz',
+            };
+
+            const dynamicAttributes = {
+                foo: 'baz',
+                test: 'test',
+            };
+
+            const expected = {
+                ...staticAttributes,
+                ...dynamicAttributes,
+            };
+
+            const attributeManager = new AttributeManager([
+                provider('scoped', () => staticAttributes),
+                provider('dynamic', () => dynamicAttributes),
+            ]);
+
+            const { attributes } = attributeManager.get();
+
+            expect(attributes).toEqual(expected);
+        });
+
+        it('should override dynamic provider with next scoped provider', () => {
+            const dynamicAttributes = {
+                foo: 'bar',
+                abc: 'xyz',
+            };
+
+            const staticAttributes = {
+                foo: 'baz',
+                test: 'test',
+            };
+
+            const expected = {
+                ...dynamicAttributes,
+                ...staticAttributes,
+            };
+
+            const attributeManager = new AttributeManager([
+                provider('dynamic', () => dynamicAttributes),
+                provider('scoped', () => staticAttributes),
+            ]);
+
+            const { attributes } = attributeManager.get();
+
+            expect(attributes).toEqual(expected);
+        });
+    });
+
+    describe('annotation priority', () => {
+        it('should resolve annotations in order of providers', () => {
+            const annotations1 = {
+                foo: { x: 'bar' },
+                abc: { x: 'xyz' },
+            };
+
+            const annotations2 = {
+                foo: { x: 'baz' },
+                test: { x: 'test' },
+            };
+
+            const annotations3 = {
+                foo: { x: 'foo' },
+                test2: { x: 'test2' },
+            };
+
+            const expected = {
+                ...annotations1,
+                ...annotations2,
+                ...annotations3,
+            };
+
+            const attributeManager = new AttributeManager([
+                provider('scoped', () => annotations1),
+                provider('scoped', () => annotations2),
+                provider('scoped', () => annotations3),
+            ]);
+
+            const { annotations } = attributeManager.get();
+
+            expect(annotations).toEqual(expected);
+        });
+
+        it('should override scoped provider with next dynamic provider', () => {
+            const staticAnnotations = {
+                foo: { x: 'bar' },
+                abc: { x: 'xyz' },
+            };
+
+            const dynamicAnnotations = {
+                foo: { x: 'baz' },
+                test: { x: 'test' },
+            };
+
+            const expected = {
+                ...staticAnnotations,
+                ...dynamicAnnotations,
+            };
+
+            const attributeManager = new AttributeManager([
+                provider('scoped', () => staticAnnotations),
+                provider('dynamic', () => dynamicAnnotations),
+            ]);
+
+            const { annotations } = attributeManager.get();
+
+            expect(annotations).toEqual(expected);
+        });
+
+        it('should override dynamic provider with next scoped provider', () => {
+            const dynamicAnnotations = {
+                foo: { x: 'bar' },
+                abc: { x: 'xyz' },
+            };
+
+            const staticAnnotations = {
+                foo: { x: 'baz' },
+                test: { x: 'test' },
+            };
+
+            const expected = {
+                ...dynamicAnnotations,
+                ...staticAnnotations,
+            };
+
+            const attributeManager = new AttributeManager([
+                provider('dynamic', () => dynamicAnnotations),
+                provider('scoped', () => staticAnnotations),
+            ]);
+
+            const { annotations } = attributeManager.get();
+
+            expect(annotations).toEqual(expected);
+        });
+    });
+});

--- a/packages/sdk-core/tests/client/attributesTests.spec.ts
+++ b/packages/sdk-core/tests/client/attributesTests.spec.ts
@@ -74,9 +74,10 @@ describe('Attributes tests', () => {
             ]);
 
             expect(scopedAttributeGetFunction).not.toBeCalled();
-            expect(fakeClient.attributes[providerAttributeKey]).toBeUndefined();
+            // This causes a call to scopedAttributeGetFunction
+            expect(fakeClient.attributes[providerAttributeKey]).toEqual(providerAttributeValue);
             await fakeClient.send('foo');
-            expect(scopedAttributeGetFunction).toHaveBeenCalledTimes(1);
+            expect(scopedAttributeGetFunction).toHaveBeenCalledTimes(2);
         });
     });
 });

--- a/packages/sdk-core/tests/http/dataSerializationTests.spec.ts
+++ b/packages/sdk-core/tests/http/dataSerializationTests.spec.ts
@@ -1,5 +1,6 @@
 import { BacktraceReport, DebugIdProvider } from '../../src';
 import { jsonEscaper } from '../../src/common/jsonEscaper';
+import { AttributeManager } from '../../src/modules/attribute/AttributeManager';
 import { V8StackTraceConverter } from '../../src/modules/converter/V8StackTraceConverter';
 import { BacktraceDataBuilder } from '../../src/modules/data/BacktraceDataBuilder';
 
@@ -13,6 +14,7 @@ describe('Data serialization tests', () => {
     const dataBuilder = new BacktraceDataBuilder(
         sdkOptions,
         new V8StackTraceConverter(),
+        new AttributeManager([]),
         new DebugIdProvider(new V8StackTraceConverter()),
     );
 

--- a/packages/sdk-core/tests/metrics/summedEventTests.spec.ts
+++ b/packages/sdk-core/tests/metrics/summedEventTests.spec.ts
@@ -52,7 +52,7 @@ describe('Summed events tests', () => {
         const expectedJson = {
             application: APPLICATION,
             appversion: APPLICATION_VERSION,
-            summed_events: [new SummedEvent('Application Launches', attributeManager.attributes)],
+            summed_events: [new SummedEvent('Application Launches', attributeManager.get().attributes)],
             metadata: {
                 dropped_events: 0,
             },
@@ -90,7 +90,7 @@ describe('Summed events tests', () => {
         const expectedJson = {
             application: APPLICATION,
             appversion: APPLICATION_VERSION,
-            summed_events: [new SummedEvent('Application Launches', attributeManager.attributes)],
+            summed_events: [new SummedEvent('Application Launches', attributeManager.get().attributes)],
             metadata: {
                 dropped_events: 0,
             },
@@ -126,7 +126,7 @@ describe('Summed events tests', () => {
         const expectedJson = {
             application: APPLICATION,
             appversion: APPLICATION_VERSION,
-            summed_events: [new SummedEvent('Application Launches', attributeManager.attributes)],
+            summed_events: [new SummedEvent('Application Launches', attributeManager.get().attributes)],
             metadata: {
                 dropped_events: 0,
             },
@@ -134,7 +134,7 @@ describe('Summed events tests', () => {
 
         metrics.start();
 
-        expect(attributeManager.attributes).toMatchObject(customAttributes);
+        expect(attributeManager.get().attributes).toMatchObject(customAttributes);
         expect(testHttpClient.post).toBeCalledWith(expect.anything(), JSON.stringify(expectedJson));
     });
 

--- a/packages/sdk-core/tests/metrics/uniqueEventTests.spec.ts
+++ b/packages/sdk-core/tests/metrics/uniqueEventTests.spec.ts
@@ -4,8 +4,8 @@ import { AttributeType } from '../../src/model/data/BacktraceData';
 import { AttributeManager } from '../../src/modules/attribute/AttributeManager';
 import { MetricsBuilder } from '../../src/modules/metrics/MetricsBuilder';
 import { MetricsUrlInformation } from '../../src/modules/metrics/MetricsUrlInformation';
-import { UniqueEvent } from '../../src/modules/metrics/model/UniqueEvent';
 import { SingleSessionProvider } from '../../src/modules/metrics/SingleSessionProvider';
+import { UniqueEvent } from '../../src/modules/metrics/model/UniqueEvent';
 import { APPLICATION, APPLICATION_VERSION, TEST_SUBMISSION_URL } from '../mocks/BacktraceTestClient';
 import { testHttpClient } from '../mocks/testHttpClient';
 import { mockSubmissionQueue } from './mocks/mockSubmissionQueue';
@@ -53,7 +53,7 @@ describe('Unique events tests', () => {
         const expectedJson = {
             application: APPLICATION,
             appversion: APPLICATION_VERSION,
-            unique_events: [new UniqueEvent(attributeManager.attributes)],
+            unique_events: [new UniqueEvent(attributeManager.get().attributes)],
             metadata: {
                 dropped_events: 0,
             },
@@ -158,7 +158,7 @@ describe('Unique events tests', () => {
         const expectedJson = {
             application: APPLICATION,
             appversion: APPLICATION_VERSION,
-            unique_events: [new UniqueEvent(attributeManager.attributes)],
+            unique_events: [new UniqueEvent(attributeManager.get().attributes)],
             metadata: {
                 dropped_events: 0,
             },
@@ -166,7 +166,7 @@ describe('Unique events tests', () => {
 
         metrics.start();
 
-        expect(attributeManager.attributes).toMatchObject(customAttributes);
+        expect(attributeManager.get().attributes).toMatchObject(customAttributes);
         expect(testHttpClient.post).toBeCalledWith(uniqueEventsSubmissionUrl, JSON.stringify(expectedJson));
     });
 });


### PR DESCRIPTION
This PR adds a feature of deferred user attributes:
```ts
const client = BacktraceClient.initialize({
  userAttributes: () => { "a": 123 }
});

client.addAttributes(() => { "b": 456 });
```

Additionally, it changes the way the attributes are applied. Before this PR, the static attributes were always overridden by dynamic attributes, no matter the order. Now, the attributes are applied in the order as they are added:
* attribute providers
* user attributes
* report attributes