### PR TITLE
Detect unexpected message type and convert it to string

### DIFF
--- a/packages/sdk-core/src/model/report/BacktraceReport.ts
+++ b/packages/sdk-core/src/model/report/BacktraceReport.ts
@@ -1,3 +1,4 @@
+import { jsonEscaper } from '../../common/jsonEscaper';
 import { TimeHelper } from '../../common/TimeHelper';
 import { BacktraceAttachment } from '../attachment';
 import { BacktraceStackFrame } from '../data/BacktraceStackTrace';
@@ -87,10 +88,10 @@ export class BacktraceReport {
                 this.innerReport.push((data as { cause?: unknown }).cause);
             }
         } else {
-            this.message = data;
+            this.message = typeof data === 'object' ? JSON.stringify(data, jsonEscaper()) : data.toString();
             this.stackTrace['main'] = {
                 stack: new Error().stack ?? '',
-                message: data,
+                message: this.message,
             };
             this.classifiers = ['Message'];
             errorType = 'Message';

--- a/packages/sdk-core/src/model/report/BacktraceReport.ts
+++ b/packages/sdk-core/src/model/report/BacktraceReport.ts
@@ -70,9 +70,10 @@ export class BacktraceReport {
         this.skipFrames = options?.skipFrames ?? 0;
         let errorType: BacktraceErrorType = 'Exception';
         if (data instanceof Error) {
+            this.message = this.generateErrorMessage(data.message);
             this.annotations['error'] = {
                 ...data,
-                message: data.message,
+                message: this.message,
                 name: data.name,
                 stack: data.stack,
             };
@@ -80,7 +81,7 @@ export class BacktraceReport {
             this.message = data.message;
             this.stackTrace['main'] = {
                 stack: data.stack ?? '',
-                message: data.message,
+                message: this.message,
             };
 
             // Supported in ES2022
@@ -88,7 +89,7 @@ export class BacktraceReport {
                 this.innerReport.push((data as { cause?: unknown }).cause);
             }
         } else {
-            this.message = typeof data === 'object' ? JSON.stringify(data, jsonEscaper()) : data.toString();
+            this.message = this.generateErrorMessage(data);
             this.stackTrace['main'] = {
                 stack: new Error().stack ?? '',
                 message: this.message,
@@ -109,5 +110,9 @@ export class BacktraceReport {
         if (options?.classifiers) {
             this.classifiers.unshift(...options.classifiers);
         }
+    }
+
+    private generateErrorMessage(data: unknown) {
+        return typeof data === 'object' ? JSON.stringify(data, jsonEscaper()) : data?.toString() ?? '';
     }
 }

--- a/packages/sdk-core/tests/client/clientTests.spec.ts
+++ b/packages/sdk-core/tests/client/clientTests.spec.ts
@@ -14,8 +14,15 @@ describe('Client tests', () => {
             expect(client.requestHandler.postError).toBeCalled();
         });
 
-        it(`Should not throw when sending a report with unexpected payload`, async () => {
+        it(`Should not throw when sending data with unexpected payload`, async () => {
             expect(async () => await client.send([{ foo: 'bar' }, { bar: 'baz' }] as unknown as string)).not.toThrow();
+            expect(client.requestHandler.postError).toBeCalled();
+        });
+
+        it(`Should not throw when sending an error with unexpected payload`, async () => {
+            expect(
+                async () => await client.send(new Error([{ foo: 'bar' }, { bar: 'baz' }] as unknown as string)),
+            ).not.toThrow();
             expect(client.requestHandler.postError).toBeCalled();
         });
 

--- a/packages/sdk-core/tests/client/clientTests.spec.ts
+++ b/packages/sdk-core/tests/client/clientTests.spec.ts
@@ -14,6 +14,11 @@ describe('Client tests', () => {
             expect(client.requestHandler.postError).toBeCalled();
         });
 
+        it(`Should not throw when sending a report with unexpected payload`, async () => {
+            expect(async () => await client.send([{ foo: 'bar' }, { bar: 'baz' }] as unknown as string)).not.toThrow();
+            expect(client.requestHandler.postError).toBeCalled();
+        });
+
         it(`Should not throw when sending a report`, async () => {
             expect(async () => await client.send(new BacktraceReport(new Error('test')))).not.toThrow();
             expect(client.requestHandler.postError).toBeCalled();


### PR DESCRIPTION
# Why

We are all using javascript. Expect unexpected. In this situation, we discovered a possible error with an object error message. We need to handle this situation better. This diff making sure the message is always a string