### PR TITLE
cli: add `run` command executing everything in one go

### DIFF
--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -6,6 +6,7 @@ Backtrace utility for managing Javascript files.
 
 1. [Description](#description)
 1. [Usage](#usage)
+    - [`run`](#run)
     - [`process`](#process)
     - [`upload`](#upload)
     - [`add-sources`](#add-sources)
@@ -41,6 +42,44 @@ It is advisable to add these commands to your production build scripts. For exam
 ```
 
 `backtrace-js` exposes the following commands:
+
+## `run`
+
+A handy shortcut for executing all commands. Executes commands in order:
+
+1. [`process`](#process)
+1. [`add-sources`](#add-sources)
+1. [`upload`](#upload)
+
+Requires the config file to function. `run` accepts some common options, but command-specific options are taken from the
+config.
+
+### Options
+
+#### `--process`
+
+Runs the [`process`](#process) command.
+
+#### `--add-sources`
+
+Runs the [`add-sources`](#add-sources) command.
+
+#### `--upload`
+
+Runs the [`upload`](#upload) command.
+
+#### `<path>`, `--path <string>`, `-p <string>`
+
+Searches for files within provided paths. This is the default positional argument. If not provided, will search in the
+current directory.
+
+#### `--force`, `-f`
+
+Forces processing of already processed files. May result in duplicate appended data.
+
+#### `--pass-with-no-files`
+
+By default, `run` will return a non-zero exit code when no files are found. Pass this to return 0.
 
 ## `process`
 
@@ -269,6 +308,11 @@ An example of the file:
     },
     "add-sources": {
         "force": true
+    },
+    "run": {
+        "process": true,
+        "add-sources": false,
+        "upload": true
     }
 }
 ```

--- a/tools/cli/src/commands/Command.ts
+++ b/tools/cli/src/commands/Command.ts
@@ -1,7 +1,7 @@
 import { Err, Ok, Result } from '@backtrace-labs/sourcemap-tools';
 import commandLineArgs from 'command-line-args';
 import commandLineUsage, { Section } from 'command-line-usage';
-import { CliLogger, LoggerOptions, createLogger } from '../logger';
+import { CliLogger, CreateLoggerOptions, createLogger } from '../logger';
 import { CommandError } from '../models/CommandError';
 import { ExtendedOptionDefinition } from '../models/OptionDefinition';
 
@@ -83,7 +83,7 @@ export class Command<T extends object = object> {
             }
         }
 
-        const logger = createLogger(values as LoggerOptions);
+        const logger = createLogger(values as CreateLoggerOptions);
 
         if (values.help) {
             logger.output(Command.getHelpMessage(this, stack));

--- a/tools/cli/src/helpers/common.ts
+++ b/tools/cli/src/helpers/common.ts
@@ -1,0 +1,5 @@
+import { Asset } from '@backtrace-labs/sourcemap-tools';
+
+export function toAsset(file: string): Asset {
+    return { name: file, path: file };
+}

--- a/tools/cli/src/helpers/normalizePaths.ts
+++ b/tools/cli/src/helpers/normalizePaths.ts
@@ -1,9 +1,15 @@
+import path from 'path';
+
 export function normalizePaths(paths: string | string[] | undefined, defaults: string | string[]) {
     if (!paths || !paths.length) {
         return toArray(defaults);
     }
 
     return toArray(paths);
+}
+
+export function relativePaths(paths: string | string[], relative: string) {
+    return toArray(paths).map((p) => path.join(relative, p));
 }
 
 function toArray<T>(t: T | T[]) {

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -8,6 +8,7 @@ import { CreateLoggerOptions, createLogger } from './logger';
 import { DEFAULT_OPTIONS_PATH } from './options/loadOptions';
 import { addSourcesCmd } from './sourcemaps/add-sources';
 import { processCmd } from './sourcemaps/process';
+import { runCmd } from './sourcemaps/run';
 import { uploadCmd } from './sourcemaps/upload';
 
 export interface GlobalOptions extends CreateLoggerOptions {
@@ -22,6 +23,7 @@ export interface MainOptions {
 const mainCommand = new Command<GlobalOptions & MainOptions>({
     name: '',
 })
+    .subcommand(runCmd)
     .subcommand(processCmd)
     .subcommand(uploadCmd)
     .subcommand(addSourcesCmd)

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -4,13 +4,13 @@ import { AsyncResult, Err } from '@backtrace-labs/sourcemap-tools';
 import commandLineArgs from 'command-line-args';
 import { Command } from './commands/Command';
 import { loadVersion } from './helpers/version';
-import { LoggerOptions, createLogger } from './logger';
+import { CreateLoggerOptions, createLogger } from './logger';
 import { DEFAULT_OPTIONS_PATH } from './options/loadOptions';
 import { addSourcesCmd } from './sourcemaps/add-sources';
 import { processCmd } from './sourcemaps/process';
 import { uploadCmd } from './sourcemaps/upload';
 
-export interface GlobalOptions extends LoggerOptions {
+export interface GlobalOptions extends CreateLoggerOptions {
     readonly help: boolean;
     readonly config: string;
 }
@@ -91,7 +91,7 @@ const mainCommand = new Command<GlobalOptions & MainOptions>({
     if (result.isOk()) {
         process.exit(result.data);
     } else {
-        const loggerOptions = commandLineArgs(mainCommand.options, { partial: true }) as Partial<LoggerOptions>;
+        const loggerOptions = commandLineArgs(mainCommand.options, { partial: true }) as Partial<CreateLoggerOptions>;
         const logger = createLogger(loggerOptions);
         logger.error(result.data.error);
         process.exit(1);

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -25,8 +25,8 @@ const mainCommand = new Command<GlobalOptions & MainOptions>({
 })
     .subcommand(runCmd)
     .subcommand(processCmd)
-    .subcommand(uploadCmd)
     .subcommand(addSourcesCmd)
+    .subcommand(uploadCmd)
     .option({
         name: 'help',
         type: Boolean,

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -5,7 +5,7 @@ import commandLineArgs from 'command-line-args';
 import { Command } from './commands/Command';
 import { loadVersion } from './helpers/version';
 import { CreateLoggerOptions, createLogger } from './logger';
-import { DEFAULT_OPTIONS_PATH } from './options/loadOptions';
+import { DEFAULT_OPTIONS_FILENAME } from './options/loadOptions';
 import { addSourcesCmd } from './sourcemaps/add-sources';
 import { processCmd } from './sourcemaps/process';
 import { runCmd } from './sourcemaps/run';
@@ -59,7 +59,7 @@ const mainCommand = new Command<GlobalOptions & MainOptions>({
         name: 'config',
         type: String,
         global: true,
-        description: `Path to the config file. Default: ${DEFAULT_OPTIONS_PATH}`,
+        description: `Path to the config file. Default: ${DEFAULT_OPTIONS_FILENAME}`,
     })
     .option({
         name: 'version',

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -4,7 +4,7 @@ import { AsyncResult, Err } from '@backtrace-labs/sourcemap-tools';
 import commandLineArgs from 'command-line-args';
 import { Command } from './commands/Command';
 import { loadVersion } from './helpers/version';
-import { createLogger, LoggerOptions } from './logger';
+import { LoggerOptions, createLogger } from './logger';
 import { DEFAULT_OPTIONS_PATH } from './options/loadOptions';
 import { addSourcesCmd } from './sourcemaps/add-sources';
 import { processCmd } from './sourcemaps/process';
@@ -64,16 +64,16 @@ const mainCommand = new Command<GlobalOptions & MainOptions>({
         type: Boolean,
         description: 'Displays the version of backtrace-js',
     })
-    .execute(function (opts, command, stack, unknown) {
+    .execute(function ({ opts, getHelpMessage }) {
         const logger = createLogger(opts);
         if (opts.version) {
             return AsyncResult.equip(loadVersion())
                 .then((version) => logger.output(version))
                 .then(() => 0).inner;
         } else {
-            logger.info(Command.getHelpMessage(command, stack));
+            logger.info(getHelpMessage());
 
-            const unknownOption = unknown?.[0];
+            const unknownOption = opts._unknown?.[0];
             if (!unknownOption) {
                 return Err(`Unknown command.`);
             }

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -64,14 +64,14 @@ const mainCommand = new Command<GlobalOptions & MainOptions>({
         type: Boolean,
         description: 'Displays the version of backtrace-js',
     })
-    .execute(function (opts, stack, unknown) {
+    .execute(function (opts, command, stack, unknown) {
         const logger = createLogger(opts);
         if (opts.version) {
             return AsyncResult.equip(loadVersion())
                 .then((version) => logger.output(version))
                 .then(() => 0).inner;
         } else {
-            logger.info(this.getHelpMessage(stack));
+            logger.info(Command.getHelpMessage(command, stack));
 
             const unknownOption = unknown?.[0];
             if (!unknownOption) {

--- a/tools/cli/src/options/loadOptions.ts
+++ b/tools/cli/src/options/loadOptions.ts
@@ -5,11 +5,17 @@ import { CliOptions, CommandCliOptions } from './models/CliOptions';
 export const DEFAULT_OPTIONS_PATH = '.backtracejsrc';
 
 export function loadAndJoinOptions(path?: string) {
+    let readOptions: CliOptions | undefined;
+
     return async function loadAndJoinOptions<K extends keyof CommandCliOptions>(
         key: K,
         options: Partial<CommandCliOptions[K]>,
         defaults?: Partial<CommandCliOptions[K]>,
     ): ResultPromise<Partial<CommandCliOptions[K]>, string> {
+        if (readOptions) {
+            return Ok(joinOptions(key, options, defaults)(readOptions));
+        }
+
         const readResult = await readFile(path ?? DEFAULT_OPTIONS_PATH);
         if (readResult.isErr()) {
             return path ? readResult : Ok(options);
@@ -17,6 +23,7 @@ export function loadAndJoinOptions(path?: string) {
 
         return AsyncResult.equip(readResult)
             .then(parseJSONC<CliOptions>)
+            .then((opts) => (readOptions = opts))
             .then(joinOptions(key, options, defaults)).inner;
     };
 }

--- a/tools/cli/src/options/models/CliOptions.ts
+++ b/tools/cli/src/options/models/CliOptions.ts
@@ -3,20 +3,22 @@ import { AddSourcesOptions } from '../../sourcemaps/add-sources';
 import { ProcessOptions } from '../../sourcemaps/process';
 import { UploadOptions } from '../../sourcemaps/upload';
 
-export type CommonCliOptions = Omit<
-    {
-        [K in keyof UploadOptions & keyof AddSourcesOptions & keyof ProcessOptions]:
-            | UploadOptions[K]
-            | AddSourcesOptions[K]
-            | ProcessOptions[K];
-    },
-    keyof GlobalOptions
+export type CommonCliOptions = Partial<
+    Omit<
+        {
+            [K in keyof UploadOptions & keyof AddSourcesOptions & keyof ProcessOptions]:
+                | UploadOptions[K]
+                | AddSourcesOptions[K]
+                | ProcessOptions[K];
+        },
+        keyof GlobalOptions
+    >
 >;
 
 export interface CommandCliOptions {
-    readonly upload: UploadOptions;
-    readonly 'add-sources': AddSourcesOptions;
-    readonly process: ProcessOptions;
+    readonly upload: Partial<UploadOptions>;
+    readonly 'add-sources': Partial<AddSourcesOptions>;
+    readonly process: Partial<ProcessOptions>;
 }
 
 export interface RunCliOptions {

--- a/tools/cli/src/options/models/CliOptions.ts
+++ b/tools/cli/src/options/models/CliOptions.ts
@@ -19,4 +19,8 @@ export interface CommandCliOptions {
     readonly process: ProcessOptions;
 }
 
-export type CliOptions = Partial<CommonCliOptions & CommandCliOptions>;
+export interface RunCliOptions {
+    readonly run: (keyof CommandCliOptions)[] | Partial<Record<keyof CommandCliOptions, boolean>>;
+}
+
+export type CliOptions = Partial<CommonCliOptions & CommandCliOptions & RunCliOptions>;

--- a/tools/cli/src/sourcemaps/add-sources.ts
+++ b/tools/cli/src/sourcemaps/add-sources.ts
@@ -67,7 +67,7 @@ export const addSourcesCmd = new Command<AddSourcesOptions>({
         type: Boolean,
         description: 'Exits with zero exit code if no sourcemaps are found.',
     })
-    .execute(addSourcesToSourcemaps);
+    .execute((context) => AsyncResult.equip(addSourcesToSourcemaps(context)).then(map(output(context.logger))).inner);
 
 /**
  * Adds sources to sourcemaps found in path(s).
@@ -162,8 +162,7 @@ export async function addSourcesToSourcemaps({ opts, logger, getHelpMessage }: C
                 : failIfEmpty('no sourcemaps without sources found, use --force to overwrite sources'),
         )
         .then(map(addSourceCommand))
-        .then(opts['dry-run'] ? Ok : map(writeSourceMapCommand))
-        .then(map(output(logger))).inner;
+        .then(opts['dry-run'] ? Ok : map(writeSourceMapCommand)).inner;
 }
 
 function doesSourceMapHaveSources(sourceProcessor: SourceProcessor) {

--- a/tools/cli/src/sourcemaps/add-sources.ts
+++ b/tools/cli/src/sourcemaps/add-sources.ts
@@ -66,13 +66,14 @@ export const addSourcesCmd = new Command<AddSourcesOptions>({
         type: Boolean,
         description: 'Exits with zero exit code if no sourcemaps are found.',
     })
-    .execute(async function (opts, command, stack) {
+    .execute(async function ({ opts, getHelpMessage }) {
         const logger = createLogger(opts);
         const sourceProcessor = new SourceProcessor(new DebugIdGenerator());
 
         const optsResult = await loadAndJoinOptions(opts.config)('add-sources', opts, {
             path: process.cwd(),
         });
+
         if (optsResult.isErr()) {
             return optsResult;
         }
@@ -83,7 +84,7 @@ export const addSourcesCmd = new Command<AddSourcesOptions>({
 
         const searchPaths = normalizePaths(opts.path, process.cwd());
         if (!searchPaths.length) {
-            logger.info(Command.getHelpMessage(command, stack));
+            logger.info(getHelpMessage());
             return Err('path must be specified');
         }
 

--- a/tools/cli/src/sourcemaps/add-sources.ts
+++ b/tools/cli/src/sourcemaps/add-sources.ts
@@ -16,10 +16,11 @@ import {
 } from '@backtrace-labs/sourcemap-tools';
 import { GlobalOptions } from '..';
 import { Command, CommandContext } from '../commands/Command';
+import { toAsset } from '../helpers/common';
 import { find } from '../helpers/find';
 import { logAsset } from '../helpers/logs';
 import { normalizePaths } from '../helpers/normalizePaths';
-import { CliLogger, createLogger } from '../logger';
+import { CliLogger } from '../logger';
 import { loadAndJoinOptions } from '../options/loadOptions';
 
 export interface AddSourcesOptions extends GlobalOptions {
@@ -71,8 +72,7 @@ export const addSourcesCmd = new Command<AddSourcesOptions>({
 /**
  * Adds sources to sourcemaps found in path(s).
  */
-export async function addSourcesToSourcemaps({ opts, getHelpMessage }: CommandContext<AddSourcesOptions>) {
-    const logger = createLogger(opts);
+export async function addSourcesToSourcemaps({ opts, logger, getHelpMessage }: CommandContext<AddSourcesOptions>) {
     const sourceProcessor = new SourceProcessor(new DebugIdGenerator());
 
     const optsResult = await loadAndJoinOptions(opts.config)('add-sources', opts, {
@@ -163,12 +163,7 @@ export async function addSourcesToSourcemaps({ opts, getHelpMessage }: CommandCo
         )
         .then(map(addSourceCommand))
         .then(opts['dry-run'] ? Ok : map(writeSourceMapCommand))
-        .then(map(output(logger)))
-        .then(() => 0).inner;
-}
-
-function toAsset(file: string): Asset {
-    return { name: file, path: file };
+        .then(map(output(logger))).inner;
 }
 
 function doesSourceMapHaveSources(sourceProcessor: SourceProcessor) {

--- a/tools/cli/src/sourcemaps/add-sources.ts
+++ b/tools/cli/src/sourcemaps/add-sources.ts
@@ -66,7 +66,7 @@ export const addSourcesCmd = new Command<AddSourcesOptions>({
         type: Boolean,
         description: 'Exits with zero exit code if no sourcemaps are found.',
     })
-    .execute(async function (opts, stack) {
+    .execute(async function (opts, command, stack) {
         const logger = createLogger(opts);
         const sourceProcessor = new SourceProcessor(new DebugIdGenerator());
 
@@ -83,7 +83,7 @@ export const addSourcesCmd = new Command<AddSourcesOptions>({
 
         const searchPaths = normalizePaths(opts.path, process.cwd());
         if (!searchPaths.length) {
-            logger.info(this.getHelpMessage(stack));
+            logger.info(Command.getHelpMessage(command, stack));
             return Err('path must be specified');
         }
 

--- a/tools/cli/src/sourcemaps/add-sources.ts
+++ b/tools/cli/src/sourcemaps/add-sources.ts
@@ -14,14 +14,15 @@ import {
     SourceProcessor,
     writeFile,
 } from '@backtrace-labs/sourcemap-tools';
+import path from 'path';
 import { GlobalOptions } from '..';
 import { Command, CommandContext } from '../commands/Command';
 import { toAsset } from '../helpers/common';
 import { find } from '../helpers/find';
 import { logAsset } from '../helpers/logs';
-import { normalizePaths } from '../helpers/normalizePaths';
+import { normalizePaths, relativePaths } from '../helpers/normalizePaths';
 import { CliLogger } from '../logger';
-import { loadAndJoinOptions } from '../options/loadOptions';
+import { findConfig, loadOptionsForCommand } from '../options/loadOptions';
 
 export interface AddSourcesOptions extends GlobalOptions {
     readonly path: string | string[];
@@ -74,16 +75,20 @@ export const addSourcesCmd = new Command<AddSourcesOptions>({
  */
 export async function addSourcesToSourcemaps({ opts, logger, getHelpMessage }: CommandContext<AddSourcesOptions>) {
     const sourceProcessor = new SourceProcessor(new DebugIdGenerator());
-
-    const optsResult = await loadAndJoinOptions(opts.config)('add-sources', opts, {
-        path: process.cwd(),
-    });
-
-    if (optsResult.isErr()) {
-        return optsResult;
+    const configPath = opts.config ?? (await findConfig());
+    const configResult = await loadOptionsForCommand(configPath)('add-sources');
+    if (configResult.isErr()) {
+        return configResult;
     }
 
-    opts = optsResult.data;
+    const config = configResult.data;
+    opts = {
+        ...config,
+        ...opts,
+        path:
+            opts.path ??
+            (config.path && configPath ? relativePaths(config.path, path.dirname(configPath)) : process.cwd()),
+    };
 
     logger.trace(`resolved options: \n${JSON.stringify(opts, null, '  ')}`);
 

--- a/tools/cli/src/sourcemaps/process.ts
+++ b/tools/cli/src/sourcemaps/process.ts
@@ -58,7 +58,7 @@ export const processCmd = new Command<ProcessOptions>({
         type: Boolean,
         description: 'Exits with zero exit code if no files for processing are found.',
     })
-    .execute(async function (opts, stack) {
+    .execute(async function (opts, command, stack) {
         const logger = createLogger(opts);
         const sourceProcessor = new SourceProcessor(new DebugIdGenerator());
 
@@ -76,7 +76,7 @@ export const processCmd = new Command<ProcessOptions>({
 
         const searchPaths = normalizePaths(opts.path, process.cwd());
         if (!searchPaths) {
-            logger.info(this.getHelpMessage(stack));
+            logger.info(Command.getHelpMessage(command, stack));
             return Err('path must be specified');
         }
 

--- a/tools/cli/src/sourcemaps/process.ts
+++ b/tools/cli/src/sourcemaps/process.ts
@@ -59,7 +59,7 @@ export const processCmd = new Command<ProcessOptions>({
         type: Boolean,
         description: 'Exits with zero exit code if no files for processing are found.',
     })
-    .execute(processSources);
+    .execute((context) => AsyncResult.equip(processSources(context)).then(map(output(context.logger))).inner);
 
 /**
  * Processes source files found in path(s).
@@ -140,8 +140,7 @@ export async function processSources({ opts, logger, getHelpMessage }: CommandCo
                 : failIfEmpty('no files for processing found, they may be already processed'),
         )
         .then(map(processCommand))
-        .then(opts['dry-run'] ? Ok : map(writeCommand))
-        .then(map(output(logger))).inner;
+        .then(opts['dry-run'] ? Ok : map(writeCommand)).inner;
 }
 
 function isAssetProcessed(sourceProcessor: SourceProcessor) {

--- a/tools/cli/src/sourcemaps/process.ts
+++ b/tools/cli/src/sourcemaps/process.ts
@@ -17,10 +17,11 @@ import {
 } from '@backtrace-labs/sourcemap-tools';
 import { GlobalOptions } from '..';
 import { Command, CommandContext } from '../commands/Command';
+import { toAsset } from '../helpers/common';
 import { find } from '../helpers/find';
 import { logAsset } from '../helpers/logs';
 import { normalizePaths } from '../helpers/normalizePaths';
-import { CliLogger, createLogger } from '../logger';
+import { CliLogger } from '../logger';
 import { loadAndJoinOptions } from '../options/loadOptions';
 
 export interface ProcessOptions extends GlobalOptions {
@@ -36,7 +37,7 @@ export const processCmd = new Command<ProcessOptions>({
 })
     .option({
         name: 'path',
-        description: 'Path to sourcemap files or directories containing sourcemaps to upload.',
+        description: 'Path to source files or directories containing sourcemaps to process.',
         defaultOption: true,
         multiple: true,
         alias: 'p',
@@ -63,8 +64,7 @@ export const processCmd = new Command<ProcessOptions>({
 /**
  * Processes source files found in path(s).
  */
-export async function processSources({ opts, getHelpMessage }: CommandContext<ProcessOptions>) {
-    const logger = createLogger(opts);
+export async function processSources({ opts, logger, getHelpMessage }: CommandContext<ProcessOptions>) {
     const sourceProcessor = new SourceProcessor(new DebugIdGenerator());
 
     const optsResult = await loadAndJoinOptions(opts.config)('process', opts, {
@@ -141,12 +141,7 @@ export async function processSources({ opts, getHelpMessage }: CommandContext<Pr
         )
         .then(map(processCommand))
         .then(opts['dry-run'] ? Ok : map(writeCommand))
-        .then(map(output(logger)))
-        .then(() => 0).inner;
-}
-
-function toAsset(file: string): Asset {
-    return { name: file, path: file };
+        .then(map(output(logger))).inner;
 }
 
 function isAssetProcessed(sourceProcessor: SourceProcessor) {

--- a/tools/cli/src/sourcemaps/process.ts
+++ b/tools/cli/src/sourcemaps/process.ts
@@ -58,7 +58,7 @@ export const processCmd = new Command<ProcessOptions>({
         type: Boolean,
         description: 'Exits with zero exit code if no files for processing are found.',
     })
-    .execute(async function (opts, command, stack) {
+    .execute(async function ({ opts, getHelpMessage }) {
         const logger = createLogger(opts);
         const sourceProcessor = new SourceProcessor(new DebugIdGenerator());
 
@@ -76,7 +76,7 @@ export const processCmd = new Command<ProcessOptions>({
 
         const searchPaths = normalizePaths(opts.path, process.cwd());
         if (!searchPaths) {
-            logger.info(Command.getHelpMessage(command, stack));
+            logger.info(getHelpMessage());
             return Err('path must be specified');
         }
 

--- a/tools/cli/src/sourcemaps/run.ts
+++ b/tools/cli/src/sourcemaps/run.ts
@@ -42,14 +42,14 @@ export const runCmd = new Command<RunOptions>({
     description: 'Runs all of the source commands in one go.',
 })
     .option({
-        name: 'add-sources',
-        type: Boolean,
-        description: 'Adds sources to found sourcemaps.',
-    })
-    .option({
         name: 'process',
         type: Boolean,
         description: 'Processes found sources.',
+    })
+    .option({
+        name: 'add-sources',
+        type: Boolean,
+        description: 'Adds sources to found sourcemaps.',
     })
     .option({
         name: 'upload',

--- a/tools/cli/src/sourcemaps/run.ts
+++ b/tools/cli/src/sourcemaps/run.ts
@@ -28,7 +28,7 @@ export interface RunOptions extends GlobalOptions {
     readonly 'add-sources': boolean;
     readonly upload: boolean;
     readonly process: boolean;
-    readonly path: string[];
+    readonly path: string | string[];
     readonly force: boolean;
     readonly 'pass-with-no-files': boolean;
 }
@@ -86,6 +86,11 @@ export const runCmd = new Command<RunOptions>({
             logger.info(getHelpMessage());
             return Err('cannot read config file');
         }
+
+        opts = {
+            path: config.path ?? process.cwd(),
+            ...opts,
+        };
 
         const runProcess = shouldRunCommand(opts, config, 'process');
         const runAddSources = shouldRunCommand(opts, config, 'add-sources');

--- a/tools/cli/src/sourcemaps/run.ts
+++ b/tools/cli/src/sourcemaps/run.ts
@@ -1,0 +1,185 @@
+import {
+    Asset,
+    AsyncResult,
+    DebugIdGenerator,
+    Err,
+    Ok,
+    SourceProcessor,
+    failIfEmpty,
+    filter,
+    log,
+    map,
+    matchSourceExtension,
+} from '@backtrace-labs/sourcemap-tools';
+import { GlobalOptions } from '..';
+import { Command } from '../commands/Command';
+import { toAsset } from '../helpers/common';
+import { find } from '../helpers/find';
+import { logAsset } from '../helpers/logs';
+import { normalizePaths } from '../helpers/normalizePaths';
+import { loadOptions } from '../options/loadOptions';
+import { CliOptions, CommandCliOptions } from '../options/models/CliOptions';
+import { addSourcesToSourcemaps } from './add-sources';
+import { processSources } from './process';
+import { uploadSourcemaps } from './upload';
+
+export interface RunOptions extends GlobalOptions {
+    readonly 'add-sources': boolean;
+    readonly upload: boolean;
+    readonly process: boolean;
+    readonly path: string[];
+    readonly force: boolean;
+    readonly 'pass-with-no-files': boolean;
+}
+
+interface AssetWithSourceMapPath extends Asset {
+    readonly sourceMapPath: string;
+}
+
+export const runCmd = new Command<RunOptions>({
+    name: 'run',
+    description: 'Runs all of the source commands in one go.',
+})
+    .option({
+        name: 'add-sources',
+        type: Boolean,
+        description: 'Adds sources to found sourcemaps.',
+    })
+    .option({
+        name: 'process',
+        type: Boolean,
+        description: 'Processes found sources.',
+    })
+    .option({
+        name: 'upload',
+        type: Boolean,
+        description: 'Uploads found sourcemaps to Backtrace.',
+    })
+    .option({
+        name: 'path',
+        type: String,
+        description: 'Path to sources.',
+        multiple: true,
+        alias: 'p',
+    })
+    .option({
+        name: 'force',
+        alias: 'f',
+        type: Boolean,
+        description: 'Forces execution of commands.',
+    })
+    .option({
+        name: 'pass-with-no-files',
+        type: Boolean,
+        description: 'Exits with zero exit code if no sourcemaps are found.',
+    })
+    .execute(async function ({ opts, logger, getHelpMessage }) {
+        const optsResult = await loadOptions(opts.config);
+        if (optsResult.isErr()) {
+            return optsResult;
+        }
+
+        const config = optsResult.data;
+        if (!config) {
+            logger.info(getHelpMessage());
+            return Err('cannot read config file');
+        }
+
+        const runAddSources = shouldRunCommand(opts, config, 'add-sources');
+        const runUpload = shouldRunCommand(opts, config, 'upload');
+        const runProcess = shouldRunCommand(opts, config, 'process');
+        if (!runAddSources && !runUpload && !runProcess) {
+            logger.info(getHelpMessage());
+
+            return Err('--add-sources, --upload and/or --process must be specified');
+        }
+
+        const searchPaths = normalizePaths(opts.path, process.cwd());
+        if (!searchPaths.length) {
+            logger.info(getHelpMessage());
+            return Err('path must be specified');
+        }
+
+        const logInfo = log(logger, 'info');
+        const logDebug = log(logger, 'debug');
+        const logTrace = log(logger, 'trace');
+        const logDebugAsset = logAsset(logger, 'debug');
+        const logTraceAsset = logAsset(logger, 'trace');
+        const sourceProcessor = new SourceProcessor(new DebugIdGenerator());
+
+        const getSourceMapPathCommand = (asset: Asset) =>
+            AsyncResult.fromValue<Asset, string>(asset)
+                .then(logTraceAsset('reading sourcemap path'))
+                .then(getSourceMapPath(sourceProcessor))
+                .then<AssetWithSourceMapPath>((sourceMapPath) => ({ ...asset, sourceMapPath }))
+                .then(logDebugAsset('read sourcemap path')).inner;
+
+        const addSourcesCommand = (assets: AssetWithSourceMapPath[]) =>
+            AsyncResult.equip(
+                addSourcesToSourcemaps({
+                    opts: { ...opts, 'pass-with-no-files': true, path: assets.map((a) => a.sourceMapPath) },
+                    getHelpMessage,
+                    logger: logger.clone({ prefix: 'add-sources:' }),
+                }),
+            )
+                .then(logInfo((results) => `added sources to ${results.length} files`))
+                .then(() => assets).inner;
+
+        const processCommand = (assets: AssetWithSourceMapPath[]) =>
+            AsyncResult.equip(
+                processSources({
+                    opts: { ...opts, 'pass-with-no-files': true, path: assets.map((a) => a.path) },
+                    getHelpMessage,
+                    logger: logger.clone({ prefix: 'process:' }),
+                }),
+            )
+                .then(logInfo((results) => `processed ${results.length} files`))
+                .then(() => assets).inner;
+
+        const uploadCommand = (assets: AssetWithSourceMapPath[]) =>
+            AsyncResult.equip(
+                uploadSourcemaps({
+                    opts: { ...opts, 'pass-with-no-files': true, path: assets.map((a) => a.sourceMapPath) },
+                    getHelpMessage,
+                    logger: logger.clone({ prefix: 'upload:' }),
+                }),
+            )
+                .then(logInfo((result) => `upload result: ${result?.rxid ?? '<dry-run>'}`))
+                .then(() => assets).inner;
+
+        return AsyncResult.equip(find(...searchPaths))
+            .then(logDebug((r) => `found ${r.length} files`))
+            .then(map(logTrace((result) => `found file: ${result.path}`)))
+            .then(filter((t) => t.direct || matchSourceExtension(t.path)))
+            .then(map((t) => t.path))
+            .then(logDebug((r) => `found ${r.length} source files`))
+            .then(map(logTrace((path) => `found source file: ${path}`)))
+            .then(opts['pass-with-no-files'] ? Ok : failIfEmpty('no sourcemaps found'))
+            .then(map(toAsset))
+            .then(map(getSourceMapPathCommand))
+            .then(runAddSources ? addSourcesCommand : Ok)
+            .then(runProcess ? processCommand : Ok)
+            .then(runUpload ? uploadCommand : Ok).inner;
+    });
+
+function getSourceMapPath(sourceProcessor: SourceProcessor) {
+    return function getSourceMapPath(asset: Asset) {
+        return sourceProcessor.getSourceMapPathFromSourceFile(asset.path);
+    };
+}
+
+function shouldRunCommand(opts: Partial<RunOptions>, config: CliOptions, key: keyof CommandCliOptions) {
+    if (opts[key]) {
+        return true;
+    }
+
+    if (!config?.run) {
+        return false;
+    }
+
+    if (Array.isArray(config.run)) {
+        return config.run.includes(key);
+    }
+
+    return !!config.run[key];
+}

--- a/tools/cli/src/sourcemaps/upload.ts
+++ b/tools/cli/src/sourcemaps/upload.ts
@@ -26,7 +26,7 @@ import {
     UploadResult,
 } from '@backtrace-labs/sourcemap-tools';
 import { GlobalOptions } from '..';
-import { Command } from '../commands/Command';
+import { Command, CommandContext } from '../commands/Command';
 import { find } from '../helpers/find';
 import { logAsset } from '../helpers/logs';
 import { normalizePaths } from '../helpers/normalizePaths';
@@ -110,142 +110,149 @@ export const uploadCmd = new Command<UploadOptions>({
         description: 'If set, archive with sourcemaps will be outputted to this path instead of being uploaded.',
         type: String,
     })
-    .execute(async function ({ opts, getHelpMessage }) {
-        const logger = createLogger(opts);
-        const sourceProcessor = new SourceProcessor(new DebugIdGenerator());
+    .execute(uploadSourcemaps);
 
-        const optsResult = await loadAndJoinOptions(opts.config)('upload', opts, {
-            url: process.env.BACKTRACE_JS_UPLOAD_URL,
-        });
+/**
+ * Uploads sourcemaps found in path(s).
+ */
+export async function uploadSourcemaps({ opts, getHelpMessage }: CommandContext<UploadOptions>) {
+    const logger = createLogger(opts);
+    const sourceProcessor = new SourceProcessor(new DebugIdGenerator());
 
-        if (optsResult.isErr()) {
-            return optsResult;
-        }
-
-        opts = optsResult.data;
-
-        logger.trace(`resolved options: \n${JSON.stringify(opts, null, '  ')}`);
-
-        const searchPaths = normalizePaths(opts.path, process.cwd());
-        if (!searchPaths) {
-            logger.info(getHelpMessage());
-            return Err('path must be specified');
-        }
-
-        const uploadUrlResult = getUploadUrl(opts);
-        if (uploadUrlResult.isErr()) {
-            logger.info(getHelpMessage());
-            return uploadUrlResult;
-        }
-
-        const outputPath = opts.output;
-        const uploadUrl = uploadUrlResult.data;
-        if (!outputPath && !uploadUrl) {
-            logger.info(getHelpMessage());
-            return Err('upload URL is required.');
-        }
-
-        if (outputPath && uploadUrl) {
-            logger.info(getHelpMessage());
-            return Err('outputting archive and uploading are exclusive');
-        }
-
-        const logDebug = log(logger, 'debug');
-        const logTrace = log(logger, 'trace');
-        const logDebugAsset = logAsset(logger, 'debug');
-        const logTraceAsset = logAsset(logger, 'trace');
-
-        const isAssetProcessedCommand = (asset: Asset) =>
-            AsyncResult.fromValue<Asset, string>(asset)
-                .then(logTraceAsset('checking if asset is processed'))
-                .then(isAssetProcessed(sourceProcessor))
-                .then(
-                    logDebug(
-                        ({ asset, result }) =>
-                            `${asset.name}: ` + (result ? 'asset is processed' : 'asset is not processed'),
-                    ),
-                )
-                .thenErr((error) => `${asset.name}: ${error}`).inner;
-
-        const filterProcessedAssetsCommand = (assets: Asset[]) =>
-            AsyncResult.fromValue<Asset[], string>(assets)
-                .then(map(isAssetProcessedCommand))
-                .then(filter((f) => f.result))
-                .then(map((f) => f.asset)).inner;
-
-        const loadSourceMapCommand = (asset: Asset) =>
-            AsyncResult.fromValue<Asset, string>(asset)
-                .then(logTraceAsset('loading sourcemap'))
-                .then(loadSourceMap)
-                .then(logDebugAsset('loaded sourcemap'))
-                .then(opts['include-sources'] ? pass : stripSourcesContent).inner;
-
-        const createArchiveCommand = (assets: AssetWithContent<RawSourceMap>[]) =>
-            AsyncResult.fromValue<AssetWithContent<RawSourceMap>[], string>(assets)
-                .then(logTrace('creating archive'))
-                .then(createArchive(sourceProcessor))
-                .then(logDebug('archive created')).inner;
-
-        const saveArchiveCommand = outputPath
-            ? (archive: ArchiveWithSourceMapsAndDebugIds) =>
-                  AsyncResult.fromValue<ArchiveWithSourceMapsAndDebugIds, string>(archive)
-                      .then(logTrace(`saving archive to ${outputPath}`))
-                      .then(({ assets, archive }) => {
-                          return AsyncResult.equip(createWriteStream(outputPath))
-                              .then(pipeStream(archive))
-                              .then(() => finalizeArchive({ assets, archive })).inner;
-                      })
-                      .then<UploadResult>(() => ({ rxid: outputPath }))
-                      .then(logDebug(`saved archive to ${outputPath}`)).inner
-            : uploadUrl
-            ? (archive: ArchiveWithSourceMapsAndDebugIds) =>
-                  AsyncResult.fromValue<ArchiveWithSourceMapsAndDebugIds, string>(archive)
-                      .then(logTrace(`uploading archive to ${uploadUrl}`))
-                      .then(async ({ assets, archive }) => {
-                          const uploader = uploadArchive(
-                              new SymbolUploader(uploadUrl, { ignoreSsl: opts.insecure ?? false }),
-                          );
-
-                          // We first create the upload request, which pipes the archive to itself
-                          const promise = uploader(archive);
-
-                          // Next we finalize the archive, which causes the assets to be written to the archive,
-                          // and consequently to the request
-                          await finalizeArchive({ assets, archive });
-
-                          // Finally, we return the upload request promise
-                          return promise;
-                      })
-                      .then(logDebug(`archive uploaded to ${uploadUrl}`)).inner
-            : undefined;
-
-        if (!saveArchiveCommand) {
-            throw new Error('processArchive function should be defined');
-        }
-
-        return AsyncResult.equip(find(...searchPaths))
-            .then(logDebug((r) => `found ${r.length} files`))
-            .then(map(logTrace((result) => `found file: ${result.path}`)))
-            .then(filter((t) => t.direct || matchSourceMapExtension(t.path)))
-            .then(map((t) => t.path))
-            .then(logDebug((r) => `found ${r.length} files for upload`))
-            .then(map(logTrace((path) => `file for upload: ${path}`)))
-            .then(opts['pass-with-no-files'] ? Ok : failIfEmpty('no sourcemaps found'))
-            .then(map(toAsset))
-            .then(opts.force ? Ok : filterProcessedAssetsCommand)
-            .then(map(loadSourceMapCommand))
-            .then(logDebug((r) => `uploading ${r.length} files`))
-            .then(map(logTrace(({ path }) => `file to upload: ${path}`)))
-            .then(
-                opts['pass-with-no-files']
-                    ? Ok
-                    : failIfEmpty('no processed sourcemaps found, make sure to run process first'),
-            )
-            .then(createArchiveCommand)
-            .then((archive) => (opts['dry-run'] ? Ok(null) : saveArchiveCommand(archive)))
-            .then(output(logger))
-            .then(() => 0).inner;
+    const optsResult = await loadAndJoinOptions(opts.config)('upload', opts, {
+        url: process.env.BACKTRACE_JS_UPLOAD_URL,
     });
+
+    if (optsResult.isErr()) {
+        return optsResult;
+    }
+
+    opts = optsResult.data;
+
+    logger.trace(`resolved options: \n${JSON.stringify(opts, null, '  ')}`);
+
+    const searchPaths = normalizePaths(opts.path, process.cwd());
+    if (!searchPaths) {
+        logger.info(getHelpMessage());
+        return Err('path must be specified');
+    }
+
+    const uploadUrlResult = getUploadUrl(opts);
+    if (uploadUrlResult.isErr()) {
+        logger.info(getHelpMessage());
+        return uploadUrlResult;
+    }
+
+    const outputPath = opts.output;
+    const uploadUrl = uploadUrlResult.data;
+    if (!outputPath && !uploadUrl) {
+        logger.info(getHelpMessage());
+        return Err('upload URL is required.');
+    }
+
+    if (outputPath && uploadUrl) {
+        logger.info(getHelpMessage());
+        return Err('outputting archive and uploading are exclusive');
+    }
+
+    const logDebug = log(logger, 'debug');
+    const logTrace = log(logger, 'trace');
+    const logDebugAsset = logAsset(logger, 'debug');
+    const logTraceAsset = logAsset(logger, 'trace');
+
+    const isAssetProcessedCommand = (asset: Asset) =>
+        AsyncResult.fromValue<Asset, string>(asset)
+            .then(logTraceAsset('checking if asset is processed'))
+            .then(isAssetProcessed(sourceProcessor))
+            .then(
+                logDebug(
+                    ({ asset, result }) =>
+                        `${asset.name}: ` + (result ? 'asset is processed' : 'asset is not processed'),
+                ),
+            )
+            .thenErr((error) => `${asset.name}: ${error}`).inner;
+
+    const filterProcessedAssetsCommand = (assets: Asset[]) =>
+        AsyncResult.fromValue<Asset[], string>(assets)
+            .then(map(isAssetProcessedCommand))
+            .then(filter((f) => f.result))
+            .then(map((f) => f.asset)).inner;
+
+    const loadSourceMapCommand = (asset: Asset) =>
+        AsyncResult.fromValue<Asset, string>(asset)
+            .then(logTraceAsset('loading sourcemap'))
+            .then(loadSourceMap)
+            .then(logDebugAsset('loaded sourcemap'))
+            .then(opts['include-sources'] ? pass : stripSourcesContent).inner;
+
+    const createArchiveCommand = (assets: AssetWithContent<RawSourceMap>[]) =>
+        AsyncResult.fromValue<AssetWithContent<RawSourceMap>[], string>(assets)
+            .then(logTrace('creating archive'))
+            .then(createArchive(sourceProcessor))
+            .then(logDebug('archive created')).inner;
+
+    const writeArchiveCommand = (outputPath: string) => (archive: ArchiveWithSourceMapsAndDebugIds) =>
+        AsyncResult.fromValue<ArchiveWithSourceMapsAndDebugIds, string>(archive)
+            .then(logTrace(`saving archive to ${outputPath}`))
+            .then(({ assets, archive }) => {
+                return AsyncResult.equip(createWriteStream(outputPath))
+                    .then(pipeStream(archive))
+                    .then(() => finalizeArchive({ assets, archive })).inner;
+            })
+            .then<UploadResult>(() => ({ rxid: outputPath }))
+            .then(logDebug(`saved archive to ${outputPath}`)).inner;
+
+    const uploadArchiveCommand = (uploadUrl: string) => (archive: ArchiveWithSourceMapsAndDebugIds) =>
+        AsyncResult.fromValue<ArchiveWithSourceMapsAndDebugIds, string>(archive)
+            .then(logTrace(`uploading archive to ${uploadUrl}`))
+            .then(async ({ assets, archive }) => {
+                const uploader = uploadArchive(new SymbolUploader(uploadUrl, { ignoreSsl: opts.insecure ?? false }));
+
+                // We first create the upload request, which pipes the archive to itself
+                const promise = uploader(archive);
+
+                // Next we finalize the archive, which causes the assets to be written to the archive,
+                // and consequently to the request
+                await finalizeArchive({ assets, archive });
+
+                // Finally, we return the upload request promise
+                return promise;
+            })
+            .then(logDebug(`archive uploaded to ${uploadUrl}`)).inner;
+
+    const saveArchiveCommand = outputPath
+        ? writeArchiveCommand(outputPath)
+        : uploadUrl
+        ? uploadArchiveCommand(uploadUrl)
+        : undefined;
+
+    if (!saveArchiveCommand) {
+        throw new Error('processArchive function should be defined');
+    }
+
+    return AsyncResult.equip(find(...searchPaths))
+        .then(logDebug((r) => `found ${r.length} files`))
+        .then(map(logTrace((result) => `found file: ${result.path}`)))
+        .then(filter((t) => t.direct || matchSourceMapExtension(t.path)))
+        .then(map((t) => t.path))
+        .then(logDebug((r) => `found ${r.length} files for upload`))
+        .then(map(logTrace((path) => `file for upload: ${path}`)))
+        .then(opts['pass-with-no-files'] ? Ok : failIfEmpty('no sourcemaps found'))
+        .then(map(toAsset))
+        .then(opts.force ? Ok : filterProcessedAssetsCommand)
+        .then(map(loadSourceMapCommand))
+        .then(logDebug((r) => `uploading ${r.length} files`))
+        .then(map(logTrace(({ path }) => `file to upload: ${path}`)))
+        .then(
+            opts['pass-with-no-files']
+                ? Ok
+                : failIfEmpty('no processed sourcemaps found, make sure to run process first'),
+        )
+        .then(createArchiveCommand)
+        .then((archive) => (opts['dry-run'] ? Ok(null) : saveArchiveCommand(archive)))
+        .then(output(logger))
+        .then(() => 0).inner;
+}
 
 function validateUrl(url: string) {
     try {

--- a/tools/cli/src/sourcemaps/upload.ts
+++ b/tools/cli/src/sourcemaps/upload.ts
@@ -110,7 +110,7 @@ export const uploadCmd = new Command<UploadOptions>({
         description: 'If set, archive with sourcemaps will be outputted to this path instead of being uploaded.',
         type: String,
     })
-    .execute(async function (opts, command, stack) {
+    .execute(async function ({ opts, getHelpMessage }) {
         const logger = createLogger(opts);
         const sourceProcessor = new SourceProcessor(new DebugIdGenerator());
 
@@ -128,25 +128,25 @@ export const uploadCmd = new Command<UploadOptions>({
 
         const searchPaths = normalizePaths(opts.path, process.cwd());
         if (!searchPaths) {
-            logger.info(Command.getHelpMessage(command, stack));
+            logger.info(getHelpMessage());
             return Err('path must be specified');
         }
 
         const uploadUrlResult = getUploadUrl(opts);
         if (uploadUrlResult.isErr()) {
-            logger.info(Command.getHelpMessage(command, stack));
+            logger.info(getHelpMessage());
             return uploadUrlResult;
         }
 
         const outputPath = opts.output;
         const uploadUrl = uploadUrlResult.data;
         if (!outputPath && !uploadUrl) {
-            logger.info(Command.getHelpMessage(command, stack));
+            logger.info(getHelpMessage());
             return Err('upload URL is required.');
         }
 
         if (outputPath && uploadUrl) {
-            logger.info(Command.getHelpMessage(command, stack));
+            logger.info(getHelpMessage());
             return Err('outputting archive and uploading are exclusive');
         }
 

--- a/tools/cli/src/sourcemaps/upload.ts
+++ b/tools/cli/src/sourcemaps/upload.ts
@@ -111,7 +111,7 @@ export const uploadCmd = new Command<UploadOptions>({
         description: 'If set, archive with sourcemaps will be outputted to this path instead of being uploaded.',
         type: String,
     })
-    .execute(uploadSourcemaps);
+    .execute((context) => AsyncResult.equip(uploadSourcemaps(context)).then(output(context.logger)).inner);
 
 /**
  * Uploads sourcemaps found in path(s).
@@ -249,8 +249,7 @@ export async function uploadSourcemaps({ opts, logger, getHelpMessage }: Command
                 : failIfEmpty('no processed sourcemaps found, make sure to run process first'),
         )
         .then(createArchiveCommand)
-        .then((archive) => (opts['dry-run'] ? Ok(null) : saveArchiveCommand(archive)))
-        .then(output(logger)).inner;
+        .then((archive) => (opts['dry-run'] ? Ok(null) : saveArchiveCommand(archive))).inner;
 }
 
 function validateUrl(url: string) {

--- a/tools/cli/src/sourcemaps/upload.ts
+++ b/tools/cli/src/sourcemaps/upload.ts
@@ -110,7 +110,7 @@ export const uploadCmd = new Command<UploadOptions>({
         description: 'If set, archive with sourcemaps will be outputted to this path instead of being uploaded.',
         type: String,
     })
-    .execute(async function (opts, stack) {
+    .execute(async function (opts, command, stack) {
         const logger = createLogger(opts);
         const sourceProcessor = new SourceProcessor(new DebugIdGenerator());
 
@@ -128,25 +128,25 @@ export const uploadCmd = new Command<UploadOptions>({
 
         const searchPaths = normalizePaths(opts.path, process.cwd());
         if (!searchPaths) {
-            logger.info(this.getHelpMessage(stack));
+            logger.info(Command.getHelpMessage(command, stack));
             return Err('path must be specified');
         }
 
         const uploadUrlResult = getUploadUrl(opts);
         if (uploadUrlResult.isErr()) {
-            logger.info(this.getHelpMessage(stack));
+            logger.info(Command.getHelpMessage(command, stack));
             return uploadUrlResult;
         }
 
         const outputPath = opts.output;
         const uploadUrl = uploadUrlResult.data;
         if (!outputPath && !uploadUrl) {
-            logger.info(this.getHelpMessage(stack));
+            logger.info(Command.getHelpMessage(command, stack));
             return Err('upload URL is required.');
         }
 
         if (outputPath && uploadUrl) {
-            logger.info(this.getHelpMessage(stack));
+            logger.info(Command.getHelpMessage(command, stack));
             return Err('outputting archive and uploading are exclusive');
         }
 

--- a/tools/cli/src/sourcemaps/upload.ts
+++ b/tools/cli/src/sourcemaps/upload.ts
@@ -27,10 +27,11 @@ import {
 } from '@backtrace-labs/sourcemap-tools';
 import { GlobalOptions } from '..';
 import { Command, CommandContext } from '../commands/Command';
+import { toAsset } from '../helpers/common';
 import { find } from '../helpers/find';
 import { logAsset } from '../helpers/logs';
 import { normalizePaths } from '../helpers/normalizePaths';
-import { CliLogger, createLogger } from '../logger';
+import { CliLogger } from '../logger';
 import { loadAndJoinOptions } from '../options/loadOptions';
 
 export interface UploadOptions extends GlobalOptions {
@@ -115,8 +116,7 @@ export const uploadCmd = new Command<UploadOptions>({
 /**
  * Uploads sourcemaps found in path(s).
  */
-export async function uploadSourcemaps({ opts, getHelpMessage }: CommandContext<UploadOptions>) {
-    const logger = createLogger(opts);
+export async function uploadSourcemaps({ opts, logger, getHelpMessage }: CommandContext<UploadOptions>) {
     const sourceProcessor = new SourceProcessor(new DebugIdGenerator());
 
     const optsResult = await loadAndJoinOptions(opts.config)('upload', opts, {
@@ -250,8 +250,7 @@ export async function uploadSourcemaps({ opts, getHelpMessage }: CommandContext<
         )
         .then(createArchiveCommand)
         .then((archive) => (opts['dry-run'] ? Ok(null) : saveArchiveCommand(archive)))
-        .then(output(logger))
-        .then(() => 0).inner;
+        .then(output(logger)).inner;
 }
 
 function validateUrl(url: string) {
@@ -281,10 +280,6 @@ function getUploadUrl(opts: Partial<UploadOptions>): Result<string | undefined, 
     }
 
     return Ok(undefined);
-}
-
-function toAsset(file: string): Asset {
-    return { name: file, path: file };
 }
 
 function isAssetProcessed(sourceProcessor: SourceProcessor) {

--- a/tools/sourcemap-tools/src/SourceProcessor.ts
+++ b/tools/sourcemap-tools/src/SourceProcessor.ts
@@ -116,12 +116,12 @@ export class SourceProcessor {
 
         const source = sourceReadResult.data;
         if (!sourceMapPath) {
-            const match = source.match(/^\/\/# sourceMappingURL=(.+)$/m);
-            if (!match || !match[1]) {
-                return Err('Could not find source map for source.');
+            const sourceMapPathResult = this.getSourceMapPathFromSource(source, sourcePath);
+            if (sourceMapPathResult.isErr()) {
+                return sourceMapPathResult;
             }
 
-            sourceMapPath = path.resolve(path.dirname(sourcePath), match[1]);
+            sourceMapPath = sourceMapPathResult.data;
         }
 
         const sourceMapReadResult = await readFile(sourceMapPath);
@@ -141,6 +141,24 @@ export class SourceProcessor {
             sourcePath,
             sourceMapPath,
         } as ProcessResultWithPaths);
+    }
+
+    public async getSourceMapPathFromSourceFile(sourcePath: string) {
+        const sourceReadResult = await readFile(sourcePath);
+        if (sourceReadResult.isErr()) {
+            return sourceReadResult;
+        }
+
+        return this.getSourceMapPathFromSource(sourceReadResult.data, sourcePath);
+    }
+
+    public getSourceMapPathFromSource(source: string, sourcePath: string) {
+        const match = source.match(/^\/\/# sourceMappingURL=(.+)$/m);
+        if (!match || !match[1]) {
+            return Err('Could not find source map for source.');
+        }
+
+        return Ok(path.resolve(path.dirname(sourcePath), match[1]));
     }
 
     public async addSourcesToSourceMap(


### PR DESCRIPTION
This PR adds `backtrace-js run` which works with `.backtracejsrc` to execute each command. It accepts some of the common parameters like `path`. The path has to always point to the source files - sourcemap files will be resolved from `sourceMappingURL`.