### PR TITLE
cli: add possibility of specifying source files for upload and add-sources

### DIFF
--- a/tools/cli/src/helpers/common.ts
+++ b/tools/cli/src/helpers/common.ts
@@ -1,5 +1,42 @@
-import { Asset } from '@backtrace-labs/sourcemap-tools';
+import {
+    Asset,
+    AssetWithContent,
+    AsyncResult,
+    ResultPromise,
+    SourceProcessor,
+    loadSourceMap,
+    readFile,
+} from '@backtrace-labs/sourcemap-tools';
 
 export function toAsset(file: string): Asset {
     return { name: file, path: file };
+}
+
+export function readAsset(asset: Asset): ResultPromise<AssetWithContent<string>, string> {
+    return AsyncResult.equip(readFile(asset.path)).then((content) => ({ ...asset, content })).inner;
+}
+
+export function loadSourceMapFromPathOrFromSource(sourceProcessor: SourceProcessor) {
+    return function loadSourceMapFromPathOrFromSource(asset: Asset) {
+        return AsyncResult.fromValue<Asset, string>(asset)
+            .then(loadSourceMap)
+            .thenErr(
+                () =>
+                    AsyncResult.fromValue<Asset, string>(asset)
+                        .then(resolveSourceMapPathFromSource(sourceProcessor))
+                        .then(loadSourceMap).inner,
+            ).inner;
+    };
+}
+
+function resolveSourceMapPathFromSource(sourceProcessor: SourceProcessor) {
+    return function resolveSourceMapFromSource(asset: Asset) {
+        return AsyncResult.equip(sourceProcessor.getSourceMapPathFromSourceFile(asset.path))
+            .then<Asset>((path) => ({
+                ...asset,
+                name: path,
+                path,
+            }))
+            .thenErr((err) => `file is not a sourcemap, and sourcemap search failed: ${err}`).inner;
+    };
 }

--- a/tools/sourcemap-tools/src/SourceProcessor.ts
+++ b/tools/sourcemap-tools/src/SourceProcessor.ts
@@ -155,7 +155,7 @@ export class SourceProcessor {
     public getSourceMapPathFromSource(source: string, sourcePath: string) {
         const match = source.match(/^\/\/# sourceMappingURL=(.+)$/m);
         if (!match || !match[1]) {
-            return Err('Could not find source map for source.');
+            return Err('could not find source map for source.');
         }
 
         return Ok(path.resolve(path.dirname(sourcePath), match[1]));

--- a/tools/sourcemap-tools/src/models/AsyncResult.ts
+++ b/tools/sourcemap-tools/src/models/AsyncResult.ts
@@ -81,6 +81,7 @@ export class AsyncResult<T, E> {
     public thenErr<N>(transform: (data: E) => Promise<Result<T, N>>): AsyncResult<T, N>;
     public thenErr<N>(transform: (data: E) => Result<T, N>): AsyncResult<T, N>;
     public thenErr<N>(transform: (data: E) => Promise<N>): AsyncResult<T, N>;
+    public thenErr<NT, NE>(transform: (data: E) => Result<NT, NE>): AsyncResult<NT, NE>;
     public thenErr<N>(transform: (data: E) => N): AsyncResult<T, N>;
     public thenErr<N>(transform: (data: E) => Result<T, N> | N | Promise<N | Result<T, N>>): AsyncResult<T, N>;
     public thenErr<N>(transform: (data: E) => Result<never, N> | N | Promise<N | Result<never, N>>): AsyncResult<T, N> {


### PR DESCRIPTION
Currently `upload` and `add-sources` accept sourcemaps, which can be a bit misleading when using `process`, which accepts sources.

This PR allows for `upload` and `add-sources` to accept source files. CLI will try to resolve sourcemaps for given source files and continue as before:
```
> backtrace-js add-sources *.js
> backtrace-js process *.js
> backtrace-js upload *.js
> backtrace-js run *.js
```