### PR TITLE
sourcemap tools: fix sourcemap invalid sourcesContent and shebang offset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12263,7 +12263,6 @@
             "version": "0.0.3",
             "license": "MIT",
             "dependencies": {
-                "source-map": "^0.7.4",
                 "tar-stream": "^3.1.6"
             },
             "devDependencies": {
@@ -12273,6 +12272,7 @@
                 "decompress": "^4.2.1",
                 "jest": "^29.5.0",
                 "nock": "^13.3.1",
+                "source-map": "^0.7.4",
                 "ts-jest": "^29.1.0",
                 "typescript": "^5.0.4"
             },

--- a/tools/sourcemap-tools/package.json
+++ b/tools/sourcemap-tools/package.json
@@ -43,11 +43,11 @@
         "decompress": "^4.2.1",
         "jest": "^29.5.0",
         "nock": "^13.3.1",
+        "source-map": "^0.7.4",
         "ts-jest": "^29.1.0",
         "typescript": "^5.0.4"
     },
     "dependencies": {
-        "source-map": "^0.7.4",
         "tar-stream": "^3.1.6"
     }
 }

--- a/tools/sourcemap-tools/src/SourceProcessor.ts
+++ b/tools/sourcemap-tools/src/SourceProcessor.ts
@@ -1,10 +1,10 @@
 import path from 'path';
-import { RawSourceMap } from 'source-map';
 import { DebugIdGenerator } from './DebugIdGenerator';
 import { parseJSON, readFile } from './helpers/common';
 import { appendBeforeWhitespaces } from './helpers/stringHelpers';
 import { stringToUuid } from './helpers/stringToUuid';
 import { AsyncResult, ResultPromise } from './models/AsyncResult';
+import { RawSourceMap } from './models/RawSourceMap';
 import { Err, Ok, Result } from './models/Result';
 
 export interface ProcessResult {

--- a/tools/sourcemap-tools/src/SourceProcessor.ts
+++ b/tools/sourcemap-tools/src/SourceProcessor.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { BasicSourceMapConsumer, Position, RawSourceMap, SourceMapConsumer, SourceMapGenerator } from 'source-map';
+import { RawSourceMap } from 'source-map';
 import { DebugIdGenerator } from './DebugIdGenerator';
 import { parseJSON, readFile } from './helpers/common';
 import { appendBeforeWhitespaces } from './helpers/stringHelpers';
@@ -70,6 +70,14 @@ export class SourceProcessor {
             debugId = stringToUuid(source);
         }
 
+        if (typeof sourceMap === 'string') {
+            const parseResult = parseJSON<RawSourceMap>(sourceMap);
+            if (parseResult.isErr()) {
+                return parseResult;
+            }
+            sourceMap = parseResult.data;
+        }
+
         const sourceSnippet = this._debugIdGenerator.generateSourceSnippet(debugId);
 
         const shebang = source.match(/^(#!.+\n)/)?.[1];
@@ -86,13 +94,9 @@ export class SourceProcessor {
         // So if we add any code to generated code, mappings after that code will become invalid
         // We need to offset the mapping lines by sourceSnippetNewlineCount:
         // original code X:Y => generated code (A + sourceSnippetNewlineCount):B
-        const sourceSnippetNewlineCount = (sourceSnippet.match(/\n/g)?.length ?? 0) + (shebang ? 1 : 0);
-        const offsetSourceMapResult = await this.offsetSourceMap(sourceMap, 0, sourceSnippetNewlineCount + 1);
-        if (offsetSourceMapResult.isErr()) {
-            return offsetSourceMapResult;
-        }
-
-        const newSourceMap = this._debugIdGenerator.addSourceMapDebugId(offsetSourceMapResult.data, debugId);
+        const sourceSnippetNewlineCount = sourceSnippet.match(/\n/g)?.length ?? 0;
+        const offsetSourceMap = await this.offsetSourceMap(sourceMap, sourceSnippetNewlineCount + 1);
+        const newSourceMap = this._debugIdGenerator.addSourceMapDebugId(offsetSourceMap, debugId);
         return Ok({ debugId, source: newSource, sourceMap: newSourceMap });
     }
 
@@ -197,46 +201,11 @@ export class SourceProcessor {
         return sourceMap.sources?.length === sourceMap.sourcesContent?.length;
     }
 
-    private async offsetSourceMap(
-        sourceMap: string | RawSourceMap,
-        fromLine: number,
-        count: number,
-    ): ResultPromise<RawSourceMap, string> {
-        if (typeof sourceMap === 'string') {
-            const parseResult = parseJSON<RawSourceMap>(sourceMap);
-            if (parseResult.isErr()) {
-                return parseResult;
-            }
-            sourceMap = parseResult.data;
-        }
-
-        const consumer = (await new SourceMapConsumer(sourceMap)) as BasicSourceMapConsumer;
-        const newSourceMap = new SourceMapGenerator({
-            file: consumer.file,
-            sourceRoot: consumer.sourceRoot,
-        });
-
-        consumer.eachMapping((m) => {
-            if (m.generatedLine < fromLine) {
-                return;
-            }
-
-            // Despite how the mappings are written, addMapping expects here a null value if the column/line is not set
-            newSourceMap.addMapping({
-                source: m.source,
-                name: m.name,
-                generated:
-                    m?.generatedColumn != null && m?.generatedLine != null
-                        ? { column: m.generatedColumn, line: m.generatedLine + count }
-                        : (null as unknown as Position),
-                original:
-                    m?.originalColumn != null && m?.originalLine != null
-                        ? { column: m.originalColumn, line: m.originalLine }
-                        : (null as unknown as Position),
-            });
-        });
-
-        const newSourceMapJson = newSourceMap.toJSON();
-        return Ok({ ...sourceMap, ...newSourceMapJson });
+    public async offsetSourceMap(sourceMap: RawSourceMap, count: number): Promise<RawSourceMap> {
+        // Each line in sourcemap is separated by a semicolon.
+        // Offsetting source map lines is just done by prepending semicolons
+        const offset = ';'.repeat(count);
+        const mappings = offset + sourceMap.mappings;
+        return { ...sourceMap, mappings };
     }
 }

--- a/tools/sourcemap-tools/src/index.ts
+++ b/tools/sourcemap-tools/src/index.ts
@@ -1,4 +1,3 @@
-export { RawSourceMap } from 'source-map';
 export * from './DebugIdGenerator';
 export * from './FileFinder';
 export * from './Logger';
@@ -11,4 +10,5 @@ export * from './helpers/match';
 export * from './models/Asset';
 export * from './models/AsyncResult';
 export * from './models/ProcessAssetResult';
+export * from './models/RawSourceMap';
 export * from './models/Result';

--- a/tools/sourcemap-tools/src/models/RawSourceMap.ts
+++ b/tools/sourcemap-tools/src/models/RawSourceMap.ts
@@ -1,0 +1,9 @@
+export interface RawSourceMap {
+    version: number;
+    sources: string[];
+    names: string[];
+    sourceRoot?: string;
+    sourcesContent?: string[];
+    mappings: string;
+    file: string;
+}

--- a/tools/sourcemap-tools/tests/SourceProcessor.spec.ts
+++ b/tools/sourcemap-tools/tests/SourceProcessor.spec.ts
@@ -304,5 +304,24 @@ function foo(){console.log("Hello World!")}foo();`;
 
             expect(actualPosition).toEqual(expectedPosition);
         });
+
+        it('should modify only mappings', async () => {
+            const debugIdGenerator = new DebugIdGenerator();
+            const sourceProcessor = new SourceProcessor(debugIdGenerator);
+            const count = 3;
+
+            const sourceMap = {
+                version: 3,
+                file: Math.random().toString(),
+                sources: [new Array(100)].map(() => Math.random().toString()),
+                names: [new Array(100)].map(() => Math.random().toString()),
+                mappings: 'AACA,SAASA,MACLC,QAAQC,IAAI,cAAc,CAC9B,CACAF,IAAI',
+                foo: 'bar',
+            };
+
+            const result = await sourceProcessor.offsetSourceMap(sourceMap, count);
+            expect(result).toEqual({ ...sourceMap, mappings: expect.any(String) });
+            expect(result.mappings).not.toEqual(sourceMap.mappings);
+        });
     });
 });


### PR DESCRIPTION
This PR fixes two issues:
* `sourcesContent` array was out of sync with `sources` in offset sourcemap
* shebang occurrence erroneously offset sourcemap with additional line

Additionally, I realized that offsetting the sourcemap by lines is just prepending semicolons. This allowed me to simplify offsetting and move `source-map` to dev dependencies (still used for unit tests).