### PR TITLE
cli: add asset error behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12263,7 +12263,6 @@
             "version": "0.0.3",
             "license": "MIT",
             "dependencies": {
-                "source-map": "^0.7.4",
                 "tar-stream": "^3.1.6"
             },
             "devDependencies": {
@@ -12273,6 +12272,7 @@
                 "decompress": "^4.2.1",
                 "jest": "^29.5.0",
                 "nock": "^13.3.1",
+                "source-map": "^0.7.4",
                 "ts-jest": "^29.1.0",
                 "typescript": "^5.0.4"
             },

--- a/tools/cli/src/helpers/errorBehavior.ts
+++ b/tools/cli/src/helpers/errorBehavior.ts
@@ -1,0 +1,50 @@
+import { Err, Ok, Result, ResultErr } from '@backtrace-labs/sourcemap-tools';
+
+export const ErrorBehaviors = {
+    exit: 'exit',
+    error: 'error',
+    warn: 'warn',
+    info: 'info',
+    debug: 'debug',
+    trace: 'trace',
+    skip: 'skip',
+} as const;
+
+export type ErrorBehavior = keyof typeof ErrorBehaviors;
+
+export function GetErrorBehavior(type: string): Result<ErrorBehavior, string> {
+    const valid = Object.keys(ErrorBehaviors);
+    if (valid.includes(type)) {
+        return Ok(type as ErrorBehavior);
+    }
+
+    return Err(`invalid error behavior "${type}", expected one of: ${valid.join(', ')}`);
+}
+
+export interface FailedElement<E> {
+    readonly reason: Result<never, E>;
+}
+
+export function handleError(behavior: ErrorBehavior = 'exit') {
+    return function _handleAssetErrors<T, E = string>(
+        fn?: (err: E, behavior: Exclude<ErrorBehavior, 'skip' | 'exit'>) => void,
+    ) {
+        return function _handleAssetErrors(error: E): Result<T | FailedElement<E>, E> {
+            switch (behavior) {
+                case 'exit':
+                    return Err(error);
+                case 'skip':
+                    return Ok<FailedElement<E>>({ reason: Err(error) });
+                default:
+                    fn && fn(error, behavior);
+                    return Ok<FailedElement<E>>({ reason: Err(error) });
+            }
+        };
+    };
+}
+
+export function filterFailedElements<T>(asset: Array<T | FailedElement<unknown>>): T[] {
+    return asset.filter(
+        (a) => !(typeof a === 'object' && !!a && 'reason' in a && a.reason instanceof ResultErr),
+    ) as T[];
+}

--- a/tools/cli/src/helpers/errorBehavior.ts
+++ b/tools/cli/src/helpers/errorBehavior.ts
@@ -12,7 +12,7 @@ export const ErrorBehaviors = {
 
 export type ErrorBehavior = keyof typeof ErrorBehaviors;
 
-export function GetErrorBehavior(type: string): Result<ErrorBehavior, string> {
+export function getErrorBehavior(type: string): Result<ErrorBehavior, string> {
     const valid = Object.keys(ErrorBehaviors);
     if (valid.includes(type)) {
         return Ok(type as ErrorBehavior);

--- a/tools/cli/src/index.ts
+++ b/tools/cli/src/index.ts
@@ -95,7 +95,7 @@ const mainCommand = new Command<GlobalOptions & MainOptions>({
     } else {
         const loggerOptions = commandLineArgs(mainCommand.options, { partial: true }) as Partial<CreateLoggerOptions>;
         const logger = createLogger(loggerOptions);
-        logger.error(result.data.error);
+        logger.fatal(result.data.error);
         process.exit(1);
     }
 })();

--- a/tools/cli/src/logger.ts
+++ b/tools/cli/src/logger.ts
@@ -13,7 +13,7 @@ export interface CliLoggerOptions {
     readonly prefix?: string;
 }
 
-export type CliLogLevel = LogLevel | 'output';
+export type CliLogLevel = LogLevel | 'output' | 'fatal';
 
 export class CliLogger implements Logger {
     private readonly _levelMap: Record<CliLogLevel, boolean>;
@@ -28,6 +28,10 @@ export class CliLogger implements Logger {
 
     public output(value: unknown | Error, ...args: unknown[]) {
         return this.log('output', value, ...args);
+    }
+
+    public fatal(value: unknown | Error, ...args: unknown[]) {
+        return this.log('fatal', value, ...args);
     }
 
     public error(value: unknown | Error, ...args: unknown[]) {
@@ -87,15 +91,17 @@ export class CliLogger implements Logger {
     private createLevelMap(level: CliLogLevel): Record<CliLogLevel, boolean> {
         const levelMap: Record<CliLogLevel, number> = {
             output: 0,
-            error: 1,
-            warn: 2,
-            info: 3,
-            debug: 4,
-            trace: 5,
+            fatal: 1,
+            error: 2,
+            warn: 3,
+            info: 4,
+            debug: 5,
+            trace: 6,
         };
 
         return {
             output: levelMap[level] >= levelMap['output'],
+            fatal: levelMap[level] >= levelMap['fatal'],
             error: levelMap[level] >= levelMap['error'],
             warn: levelMap[level] >= levelMap['warn'],
             info: levelMap[level] >= levelMap['info'],

--- a/tools/cli/src/options/loadOptions.ts
+++ b/tools/cli/src/options/loadOptions.ts
@@ -43,10 +43,10 @@ export function joinOptions<K extends keyof CommandCliOptions>(key: K, defaults?
         return {
             ...defaults,
             ...loadedOptions,
-            ...loadedOptions[key],
             'add-sources': undefined,
             upload: undefined,
             process: undefined,
+            ...loadedOptions[key],
         };
     };
 }

--- a/tools/cli/src/options/models/CliOptions.ts
+++ b/tools/cli/src/options/models/CliOptions.ts
@@ -1,6 +1,7 @@
 import { GlobalOptions } from '../..';
 import { AddSourcesOptions } from '../../sourcemaps/add-sources';
 import { ProcessOptions } from '../../sourcemaps/process';
+import { RunOptions } from '../../sourcemaps/run';
 import { UploadOptions } from '../../sourcemaps/upload';
 
 export type CommonCliOptions = Partial<
@@ -16,13 +17,10 @@ export type CommonCliOptions = Partial<
 >;
 
 export interface CommandCliOptions {
+    readonly run: Partial<RunOptions>;
     readonly upload: Partial<UploadOptions>;
     readonly 'add-sources': Partial<AddSourcesOptions>;
     readonly process: Partial<ProcessOptions>;
 }
 
-export interface RunCliOptions {
-    readonly run: (keyof CommandCliOptions)[] | Partial<Record<keyof CommandCliOptions, boolean>>;
-}
-
-export type CliOptions = Partial<CommonCliOptions & CommandCliOptions & RunCliOptions>;
+export type CliOptions = Partial<CommonCliOptions & CommandCliOptions>;

--- a/tools/cli/src/sourcemaps/add-sources.ts
+++ b/tools/cli/src/sourcemaps/add-sources.ts
@@ -19,7 +19,7 @@ import path from 'path';
 import { GlobalOptions } from '..';
 import { Command, CommandContext } from '../commands/Command';
 import { loadSourceMapFromPathOrFromSource, toAsset } from '../helpers/common';
-import { ErrorBehaviors, filterFailedElements, getErrorBehavior, handleError } from '../helpers/errorBehavior';
+import { ErrorBehaviors, filterBehaviorSkippedElements, getErrorBehavior, handleError } from '../helpers/errorBehavior';
 import { find } from '../helpers/find';
 import { logAsset } from '../helpers/logs';
 import { normalizePaths, relativePaths } from '../helpers/normalizePaths';
@@ -168,7 +168,7 @@ export async function addSourcesToSourcemaps({ opts, logger, getHelpMessage }: C
         .then(opts['pass-with-no-files'] ? Ok : failIfEmpty('no sourcemaps found'))
         .then(map(toAsset))
         .then(map(loadSourceMapCommand))
-        .then(filterFailedElements)
+        .then(filterBehaviorSkippedElements)
         .then(opts.force ? Ok : filterAssetsCommand)
         .then(logDebug((r) => `adding sources to ${r.length} files`))
         .then(map(logTrace(({ path }) => `file to add sources to: ${path}`)))
@@ -178,9 +178,9 @@ export async function addSourcesToSourcemaps({ opts, logger, getHelpMessage }: C
                 : failIfEmpty('no sourcemaps without sources found, use --force to overwrite sources'),
         )
         .then(map(addSourceCommand))
-        .then(filterFailedElements)
+        .then(filterBehaviorSkippedElements)
         .then(opts['dry-run'] ? Ok : map(writeSourceMapCommand))
-        .then(filterFailedElements).inner;
+        .then(filterBehaviorSkippedElements).inner;
 }
 
 function doesSourceMapHaveSources(sourceProcessor: SourceProcessor) {

--- a/tools/cli/src/sourcemaps/add-sources.ts
+++ b/tools/cli/src/sourcemaps/add-sources.ts
@@ -12,7 +12,6 @@ import {
     matchSourceMapExtension,
     Ok,
     RawSourceMap,
-    Result,
     SourceProcessor,
     writeFile,
 } from '@backtrace-labs/sourcemap-tools';
@@ -20,13 +19,7 @@ import path from 'path';
 import { GlobalOptions } from '..';
 import { Command, CommandContext } from '../commands/Command';
 import { loadSourceMapFromPathOrFromSource, toAsset } from '../helpers/common';
-import {
-    ErrorBehavior,
-    ErrorBehaviors,
-    filterFailedElements,
-    GetErrorBehavior,
-    handleError,
-} from '../helpers/errorBehavior';
+import { ErrorBehaviors, filterFailedElements, getErrorBehavior, handleError } from '../helpers/errorBehavior';
 import { find } from '../helpers/find';
 import { logAsset } from '../helpers/logs';
 import { normalizePaths, relativePaths } from '../helpers/normalizePaths';
@@ -39,7 +32,7 @@ export interface AddSourcesOptions extends GlobalOptions {
     readonly force: boolean;
     readonly skipFailing: boolean;
     readonly 'pass-with-no-files': boolean;
-    readonly 'asset-error-behavior': Result<ErrorBehavior, string>;
+    readonly 'asset-error-behavior': string;
 }
 
 export const addSourcesCmd = new Command<AddSourcesOptions>({
@@ -68,7 +61,7 @@ export const addSourcesCmd = new Command<AddSourcesOptions>({
     .option({
         name: 'asset-error-behavior',
         alias: 'e',
-        type: GetErrorBehavior,
+        type: getErrorBehavior,
         typeLabel: 'string',
         description: `What to do when an asset fails. Can be one of: ${Object.keys(ErrorBehaviors).join(', ')}.`,
     })
@@ -112,12 +105,14 @@ export async function addSourcesToSourcemaps({ opts, logger, getHelpMessage }: C
     const logDebugAsset = logAsset(logger, 'debug');
     const logTraceAsset = logAsset(logger, 'trace');
 
-    if (opts['asset-error-behavior']?.isErr()) {
+    const assetErrorBehaviorResult = getErrorBehavior(opts['asset-error-behavior'] ?? 'exit');
+    if (assetErrorBehaviorResult.isErr()) {
         logger.info(getHelpMessage());
-        return opts['asset-error-behavior'];
+        return assetErrorBehaviorResult;
     }
 
-    const assetErrorBehavior = (opts['asset-error-behavior']?.data as ErrorBehavior) ?? 'exit';
+    const assetErrorBehavior = assetErrorBehaviorResult.data;
+
     const handleFailedAsset = handleError(assetErrorBehavior);
 
     const logAssetBehaviorError = (asset: Asset) => (err: string, level: LogLevel) =>

--- a/tools/cli/src/sourcemaps/add-sources.ts
+++ b/tools/cli/src/sourcemaps/add-sources.ts
@@ -61,8 +61,7 @@ export const addSourcesCmd = new Command<AddSourcesOptions>({
     .option({
         name: 'asset-error-behavior',
         alias: 'e',
-        type: getErrorBehavior,
-        typeLabel: 'string',
+        type: String,
         description: `What to do when an asset fails. Can be one of: ${Object.keys(ErrorBehaviors).join(', ')}.`,
     })
     .option({

--- a/tools/cli/src/sourcemaps/add-sources.ts
+++ b/tools/cli/src/sourcemaps/add-sources.ts
@@ -7,10 +7,12 @@ import {
     failIfEmpty,
     filter,
     log,
+    LogLevel,
     map,
     matchSourceMapExtension,
     Ok,
     RawSourceMap,
+    Result,
     SourceProcessor,
     writeFile,
 } from '@backtrace-labs/sourcemap-tools';
@@ -18,6 +20,13 @@ import path from 'path';
 import { GlobalOptions } from '..';
 import { Command, CommandContext } from '../commands/Command';
 import { loadSourceMapFromPathOrFromSource, toAsset } from '../helpers/common';
+import {
+    ErrorBehavior,
+    ErrorBehaviors,
+    filterFailedElements,
+    GetErrorBehavior,
+    handleError,
+} from '../helpers/errorBehavior';
 import { find } from '../helpers/find';
 import { logAsset } from '../helpers/logs';
 import { normalizePaths, relativePaths } from '../helpers/normalizePaths';
@@ -30,6 +39,7 @@ export interface AddSourcesOptions extends GlobalOptions {
     readonly force: boolean;
     readonly skipFailing: boolean;
     readonly 'pass-with-no-files': boolean;
+    readonly 'asset-error-behavior': Result<ErrorBehavior, string>;
 }
 
 export const addSourcesCmd = new Command<AddSourcesOptions>({
@@ -54,6 +64,13 @@ export const addSourcesCmd = new Command<AddSourcesOptions>({
         alias: 'f',
         type: Boolean,
         description: 'Processes files even if sourcesContent is not empty. Will overwrite existing sources.',
+    })
+    .option({
+        name: 'asset-error-behavior',
+        alias: 'e',
+        type: GetErrorBehavior,
+        typeLabel: 'string',
+        description: `What to do when an asset fails. Can be one of: ${Object.keys(ErrorBehaviors).join(', ')}.`,
     })
     .option({
         name: 'pass-with-no-files',
@@ -95,14 +112,26 @@ export async function addSourcesToSourcemaps({ opts, logger, getHelpMessage }: C
     const logDebugAsset = logAsset(logger, 'debug');
     const logTraceAsset = logAsset(logger, 'trace');
 
+    if (opts['asset-error-behavior']?.isErr()) {
+        logger.info(getHelpMessage());
+        return opts['asset-error-behavior'];
+    }
+
+    const assetErrorBehavior = (opts['asset-error-behavior']?.data as ErrorBehavior) ?? 'exit';
+    const handleFailedAsset = handleError(assetErrorBehavior);
+
+    const logAssetBehaviorError = (asset: Asset) => (err: string, level: LogLevel) =>
+        logAsset(logger, level)(err)(asset);
+
     const loadSourceMapCommand = (asset: Asset) =>
         AsyncResult.fromValue<Asset, string>(asset)
             .then(logTraceAsset('loading sourcemap'))
             .then(loadSourceMapFromPathOrFromSource(sourceProcessor))
-            .then(logDebugAsset('loaded sourcemap')).inner;
+            .then(logDebugAsset('loaded sourcemap'))
+            .thenErr(handleFailedAsset<AssetWithContent<RawSourceMap>>(logAssetBehaviorError(asset))).inner;
 
     const doesSourceMapHaveSourcesCommand = (asset: AssetWithContent<RawSourceMap>) =>
-        AsyncResult.fromValue<AssetWithContent<RawSourceMap>, string>(asset)
+        AsyncResult.fromValue<AssetWithContent<RawSourceMap>, never>(asset)
             .then(logTraceAsset('checking if sourcemap has sources'))
             .then(doesSourceMapHaveSources(sourceProcessor))
             .then(
@@ -110,11 +139,10 @@ export async function addSourcesToSourcemaps({ opts, logger, getHelpMessage }: C
                     ({ asset, result }) =>
                         `${asset.name}: ` + (result ? 'sourcemap has sources' : 'sourcemap does not have sources'),
                 ),
-            )
-            .thenErr((error) => `${asset.name}: ${error}`).inner;
+            ).inner;
 
     const filterAssetsCommand = (assets: AssetWithContent<RawSourceMap>[]) =>
-        AsyncResult.fromValue<AssetWithContent<RawSourceMap>[], string>(assets)
+        AsyncResult.fromValue<AssetWithContent<RawSourceMap>[], never>(assets)
             .then(map(doesSourceMapHaveSourcesCommand))
             .then(filter((f) => !f.result))
             .then(map((f) => f.asset)).inner;
@@ -124,6 +152,7 @@ export async function addSourcesToSourcemaps({ opts, logger, getHelpMessage }: C
             .then(logTraceAsset('adding source'))
             .then(addSource(sourceProcessor))
             .then(logDebugAsset('source added'))
+            .thenErr(handleFailedAsset<AssetWithContent<RawSourceMap>>(logAssetBehaviorError(asset)))
             .thenErr((error) => `${asset.name}: ${error}`).inner;
 
     const writeSourceMapCommand = (asset: AssetWithContent<RawSourceMap>) =>
@@ -131,6 +160,7 @@ export async function addSourcesToSourcemaps({ opts, logger, getHelpMessage }: C
             .then(logTraceAsset('writing sourcemap'))
             .then(writeSourceMap)
             .then(logDebugAsset('sourcemap written'))
+            .thenErr(handleFailedAsset<AssetWithContent<RawSourceMap>>(logAssetBehaviorError(asset)))
             .thenErr((error) => `${asset.name}: ${error}`).inner;
 
     return AsyncResult.equip(find(...searchPaths))
@@ -143,6 +173,7 @@ export async function addSourcesToSourcemaps({ opts, logger, getHelpMessage }: C
         .then(opts['pass-with-no-files'] ? Ok : failIfEmpty('no sourcemaps found'))
         .then(map(toAsset))
         .then(map(loadSourceMapCommand))
+        .then(filterFailedElements)
         .then(opts.force ? Ok : filterAssetsCommand)
         .then(logDebug((r) => `adding sources to ${r.length} files`))
         .then(map(logTrace(({ path }) => `file to add sources to: ${path}`)))
@@ -152,7 +183,9 @@ export async function addSourcesToSourcemaps({ opts, logger, getHelpMessage }: C
                 : failIfEmpty('no sourcemaps without sources found, use --force to overwrite sources'),
         )
         .then(map(addSourceCommand))
-        .then(opts['dry-run'] ? Ok : map(writeSourceMapCommand)).inner;
+        .then(filterFailedElements)
+        .then(opts['dry-run'] ? Ok : map(writeSourceMapCommand))
+        .then(filterFailedElements).inner;
 }
 
 function doesSourceMapHaveSources(sourceProcessor: SourceProcessor) {

--- a/tools/cli/src/sourcemaps/process.ts
+++ b/tools/cli/src/sourcemaps/process.ts
@@ -62,7 +62,6 @@ export const processCmd = new Command<ProcessOptions>({
         name: 'asset-error-behavior',
         alias: 'e',
         type: String,
-        typeLabel: 'string',
         description: `What to do when an asset fails. Can be one of: ${Object.keys(ErrorBehaviors).join(', ')}.`,
     })
     .option({

--- a/tools/cli/src/sourcemaps/process.ts
+++ b/tools/cli/src/sourcemaps/process.ts
@@ -20,7 +20,7 @@ import path from 'path';
 import { GlobalOptions } from '..';
 import { Command, CommandContext } from '../commands/Command';
 import { toAsset } from '../helpers/common';
-import { ErrorBehaviors, filterFailedElements, getErrorBehavior, handleError } from '../helpers/errorBehavior';
+import { ErrorBehaviors, filterBehaviorSkippedElements, getErrorBehavior, handleError } from '../helpers/errorBehavior';
 import { find } from '../helpers/find';
 import { logAsset } from '../helpers/logs';
 import { normalizePaths, relativePaths } from '../helpers/normalizePaths';
@@ -136,7 +136,7 @@ export async function processSources({ opts, logger, getHelpMessage }: CommandCo
     const filterUnprocessedAssetsCommand = (assets: Asset[]) =>
         AsyncResult.fromValue<Asset[], string>(assets)
             .then(map(isAssetProcessedCommand))
-            .then(filterFailedElements)
+            .then(filterBehaviorSkippedElements)
             .then(filter((f) => !f.result))
             .then(map((f) => f.asset)).inner;
 
@@ -174,9 +174,9 @@ export async function processSources({ opts, logger, getHelpMessage }: CommandCo
                 : failIfEmpty('no files for processing found, they may be already processed'),
         )
         .then(map(processCommand))
-        .then(filterFailedElements)
+        .then(filterBehaviorSkippedElements)
         .then(opts['dry-run'] ? Ok : map(writeCommand))
-        .then(filterFailedElements).inner;
+        .then(filterBehaviorSkippedElements).inner;
 }
 
 function isAssetProcessed(sourceProcessor: SourceProcessor) {

--- a/tools/cli/src/sourcemaps/run.ts
+++ b/tools/cli/src/sourcemaps/run.ts
@@ -16,7 +16,7 @@ import path from 'path';
 import { GlobalOptions } from '..';
 import { Command } from '../commands/Command';
 import { toAsset } from '../helpers/common';
-import { filterBehaviorSkippedElements, getErrorBehavior, handleError } from '../helpers/errorBehavior';
+import { ErrorBehaviors, filterBehaviorSkippedElements, getErrorBehavior, handleError } from '../helpers/errorBehavior';
 import { find } from '../helpers/find';
 import { logAsset } from '../helpers/logs';
 import { normalizePaths, relativePaths } from '../helpers/normalizePaths';
@@ -76,7 +76,8 @@ export const runCmd = new Command<RunOptions>({
     .option({
         name: 'asset-error-behavior',
         alias: 'e',
-        type: getErrorBehavior,
+        type: String,
+        description: `What to do when an asset fails. Can be one of: ${Object.keys(ErrorBehaviors).join(', ')}.`,
     })
     .option({
         name: 'pass-with-no-files',

--- a/tools/cli/src/sourcemaps/run.ts
+++ b/tools/cli/src/sourcemaps/run.ts
@@ -16,7 +16,7 @@ import path from 'path';
 import { GlobalOptions } from '..';
 import { Command } from '../commands/Command';
 import { toAsset } from '../helpers/common';
-import { filterFailedElements, getErrorBehavior, handleError } from '../helpers/errorBehavior';
+import { filterBehaviorSkippedElements, getErrorBehavior, handleError } from '../helpers/errorBehavior';
 import { find } from '../helpers/find';
 import { logAsset } from '../helpers/logs';
 import { normalizePaths, relativePaths } from '../helpers/normalizePaths';
@@ -210,7 +210,7 @@ export const runCmd = new Command<RunOptions>({
             .then(opts['pass-with-no-files'] ? Ok : failIfEmpty('no source files found'))
             .then(map(toAsset))
             .then(map(getSourceMapPathCommand))
-            .then(filterFailedElements)
+            .then(filterBehaviorSkippedElements)
             .then(map(printAssetInfo(logger)))
             .then(runProcess ? processCommand : Ok)
             .then(runAddSources ? addSourcesCommand : Ok)

--- a/tools/cli/src/sourcemaps/upload.ts
+++ b/tools/cli/src/sourcemaps/upload.ts
@@ -29,7 +29,7 @@ import path from 'path';
 import { GlobalOptions } from '..';
 import { Command, CommandContext } from '../commands/Command';
 import { loadSourceMapFromPathOrFromSource, toAsset } from '../helpers/common';
-import { ErrorBehaviors, filterFailedElements, getErrorBehavior, handleError } from '../helpers/errorBehavior';
+import { ErrorBehaviors, filterBehaviorSkippedElements, getErrorBehavior, handleError } from '../helpers/errorBehavior';
 import { find } from '../helpers/find';
 import { logAsset } from '../helpers/logs';
 import { normalizePaths, relativePaths } from '../helpers/normalizePaths';
@@ -274,7 +274,7 @@ export async function uploadSourcemaps({ opts, logger, getHelpMessage }: Command
         .then(opts['pass-with-no-files'] ? Ok : failIfEmpty('no sourcemaps found'))
         .then(map(toAsset))
         .then(map(loadSourceMapCommand))
-        .then(filterFailedElements)
+        .then(filterBehaviorSkippedElements)
         .then(opts.force ? Ok : filterProcessedAssetsCommand)
         .then(logDebug((r) => `uploading ${r.length} files`))
         .then(map(logTrace(({ path }) => `file to upload: ${path}`)))

--- a/tools/cli/src/sourcemaps/upload.ts
+++ b/tools/cli/src/sourcemaps/upload.ts
@@ -115,8 +115,7 @@ export const uploadCmd = new Command<UploadOptions>({
     .option({
         name: 'asset-error-behavior',
         alias: 'e',
-        type: getErrorBehavior,
-        typeLabel: 'string',
+        type: String,
         description: `What to do when an asset fails. Can be one of: ${Object.keys(ErrorBehaviors).join(', ')}.`,
     })
     .option({

--- a/tools/sourcemap-tools/package.json
+++ b/tools/sourcemap-tools/package.json
@@ -43,11 +43,11 @@
         "decompress": "^4.2.1",
         "jest": "^29.5.0",
         "nock": "^13.3.1",
+        "source-map": "^0.7.4",
         "ts-jest": "^29.1.0",
         "typescript": "^5.0.4"
     },
     "dependencies": {
-        "source-map": "^0.7.4",
         "tar-stream": "^3.1.6"
     }
 }

--- a/tools/sourcemap-tools/src/SourceProcessor.ts
+++ b/tools/sourcemap-tools/src/SourceProcessor.ts
@@ -159,7 +159,7 @@ export class SourceProcessor {
     public getSourceMapPathFromSource(source: string, sourcePath: string) {
         const match = source.match(/^\/\/# sourceMappingURL=(.+)$/m);
         if (!match || !match[1]) {
-            return Err('could not find source map for source.');
+            return Err('could not find source map for source');
         }
 
         return Ok(path.resolve(path.dirname(sourcePath), match[1]));

--- a/tools/sourcemap-tools/src/SourceProcessor.ts
+++ b/tools/sourcemap-tools/src/SourceProcessor.ts
@@ -1,10 +1,10 @@
 import path from 'path';
-import { RawSourceMap } from 'source-map';
 import { DebugIdGenerator } from './DebugIdGenerator';
 import { parseJSON, readFile } from './helpers/common';
 import { appendBeforeWhitespaces } from './helpers/stringHelpers';
 import { stringToUuid } from './helpers/stringToUuid';
 import { AsyncResult, ResultPromise } from './models/AsyncResult';
+import { RawSourceMap } from './models/RawSourceMap';
 import { Err, Ok, Result } from './models/Result';
 
 export interface ProcessResult {

--- a/tools/sourcemap-tools/src/SourceProcessor.ts
+++ b/tools/sourcemap-tools/src/SourceProcessor.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { BasicSourceMapConsumer, Position, RawSourceMap, SourceMapConsumer, SourceMapGenerator } from 'source-map';
+import { RawSourceMap } from 'source-map';
 import { DebugIdGenerator } from './DebugIdGenerator';
 import { parseJSON, readFile } from './helpers/common';
 import { appendBeforeWhitespaces } from './helpers/stringHelpers';
@@ -70,6 +70,14 @@ export class SourceProcessor {
             debugId = stringToUuid(source);
         }
 
+        if (typeof sourceMap === 'string') {
+            const parseResult = parseJSON<RawSourceMap>(sourceMap);
+            if (parseResult.isErr()) {
+                return parseResult;
+            }
+            sourceMap = parseResult.data;
+        }
+
         const sourceSnippet = this._debugIdGenerator.generateSourceSnippet(debugId);
 
         const shebang = source.match(/^(#!.+\n)/)?.[1];
@@ -86,13 +94,9 @@ export class SourceProcessor {
         // So if we add any code to generated code, mappings after that code will become invalid
         // We need to offset the mapping lines by sourceSnippetNewlineCount:
         // original code X:Y => generated code (A + sourceSnippetNewlineCount):B
-        const sourceSnippetNewlineCount = (sourceSnippet.match(/\n/g)?.length ?? 0) + (shebang ? 1 : 0);
-        const offsetSourceMapResult = await this.offsetSourceMap(sourceMap, 0, sourceSnippetNewlineCount + 1);
-        if (offsetSourceMapResult.isErr()) {
-            return offsetSourceMapResult;
-        }
-
-        const newSourceMap = this._debugIdGenerator.addSourceMapDebugId(offsetSourceMapResult.data, debugId);
+        const sourceSnippetNewlineCount = sourceSnippet.match(/\n/g)?.length ?? 0;
+        const offsetSourceMap = await this.offsetSourceMap(sourceMap, sourceSnippetNewlineCount + 1);
+        const newSourceMap = this._debugIdGenerator.addSourceMapDebugId(offsetSourceMap, debugId);
         return Ok({ debugId, source: newSource, sourceMap: newSourceMap });
     }
 
@@ -197,46 +201,11 @@ export class SourceProcessor {
         return sourceMap.sources?.length === sourceMap.sourcesContent?.length;
     }
 
-    private async offsetSourceMap(
-        sourceMap: string | RawSourceMap,
-        fromLine: number,
-        count: number,
-    ): ResultPromise<RawSourceMap, string> {
-        if (typeof sourceMap === 'string') {
-            const parseResult = parseJSON<RawSourceMap>(sourceMap);
-            if (parseResult.isErr()) {
-                return parseResult;
-            }
-            sourceMap = parseResult.data;
-        }
-
-        const consumer = (await new SourceMapConsumer(sourceMap)) as BasicSourceMapConsumer;
-        const newSourceMap = new SourceMapGenerator({
-            file: consumer.file,
-            sourceRoot: consumer.sourceRoot,
-        });
-
-        consumer.eachMapping((m) => {
-            if (m.generatedLine < fromLine) {
-                return;
-            }
-
-            // Despite how the mappings are written, addMapping expects here a null value if the column/line is not set
-            newSourceMap.addMapping({
-                source: m.source,
-                name: m.name,
-                generated:
-                    m?.generatedColumn != null && m?.generatedLine != null
-                        ? { column: m.generatedColumn, line: m.generatedLine + count }
-                        : (null as unknown as Position),
-                original:
-                    m?.originalColumn != null && m?.originalLine != null
-                        ? { column: m.originalColumn, line: m.originalLine }
-                        : (null as unknown as Position),
-            });
-        });
-
-        const newSourceMapJson = newSourceMap.toJSON();
-        return Ok({ ...sourceMap, ...newSourceMapJson });
+    public async offsetSourceMap(sourceMap: RawSourceMap, count: number): Promise<RawSourceMap> {
+        // Each line in sourcemap is separated by a semicolon.
+        // Offsetting source map lines is just done by prepending semicolons
+        const offset = ';'.repeat(count);
+        const mappings = offset + sourceMap.mappings;
+        return { ...sourceMap, mappings };
     }
 }

--- a/tools/sourcemap-tools/src/index.ts
+++ b/tools/sourcemap-tools/src/index.ts
@@ -1,4 +1,3 @@
-export { RawSourceMap } from 'source-map';
 export * from './DebugIdGenerator';
 export * from './FileFinder';
 export * from './Logger';
@@ -11,4 +10,5 @@ export * from './helpers/match';
 export * from './models/Asset';
 export * from './models/AsyncResult';
 export * from './models/ProcessAssetResult';
+export * from './models/RawSourceMap';
 export * from './models/Result';

--- a/tools/sourcemap-tools/src/models/RawSourceMap.ts
+++ b/tools/sourcemap-tools/src/models/RawSourceMap.ts
@@ -1,0 +1,9 @@
+export interface RawSourceMap {
+    version: number;
+    sources: string[];
+    names: string[];
+    sourceRoot?: string;
+    sourcesContent?: string[];
+    mappings: string;
+    file: string;
+}

--- a/tools/sourcemap-tools/tests/SourceProcessor.spec.ts
+++ b/tools/sourcemap-tools/tests/SourceProcessor.spec.ts
@@ -304,5 +304,24 @@ function foo(){console.log("Hello World!")}foo();`;
 
             expect(actualPosition).toEqual(expectedPosition);
         });
+
+        it('should modify only mappings', async () => {
+            const debugIdGenerator = new DebugIdGenerator();
+            const sourceProcessor = new SourceProcessor(debugIdGenerator);
+            const count = 3;
+
+            const sourceMap = {
+                version: 3,
+                file: Math.random().toString(),
+                sources: [new Array(100)].map(() => Math.random().toString()),
+                names: [new Array(100)].map(() => Math.random().toString()),
+                mappings: 'AACA,SAASA,MACLC,QAAQC,IAAI,cAAc,CAC9B,CACAF,IAAI',
+                foo: 'bar',
+            };
+
+            const result = await sourceProcessor.offsetSourceMap(sourceMap, count);
+            expect(result).toEqual({ ...sourceMap, mappings: expect.any(String) });
+            expect(result.mappings).not.toEqual(sourceMap.mappings);
+        });
     });
 });


### PR DESCRIPTION
This diff adds `--asset-error-behavior` which can control what happens when an asset fails:
* `exit` - process exits with code 1 as soon as an asset fails. This is the default behavior,
* `skip` - the asset is skipped silently,
* `error`, `warn`, `info`, `debug`, `trace` - the asset error is logged under this log level.

Note that if assets fail, the process can still exit with error code 1 - for example, if none assets succeed in upload, the upload will fail because no files were supplied.