### PR TITLE
Combining the error and string overloads in BacktraceCoreClient.send()

### DIFF
--- a/packages/sdk-core/src/BacktraceCoreClient.ts
+++ b/packages/sdk-core/src/BacktraceCoreClient.ts
@@ -177,19 +177,12 @@ export abstract class BacktraceCoreClient {
 
     /**
      * Asynchronously sends error data to Backtrace.
-     * @param error Backtrace Report or error or message
-     * @param attributes Report attributes
-     * @param attachments Report attachments
-     */
-    public send(error: Error, attributes?: Record<string, unknown>, attachments?: BacktraceAttachment[]): Promise<void>;
-    /**
-     * Asynchronously sends a message report to Backtrace
-     * @param message Report message
+     * @param error Error or message
      * @param attributes Report attributes
      * @param attachments Report attachments
      */
     public send(
-        message: string,
+        error: Error | string,
         attributes?: Record<string, unknown>,
         attachments?: BacktraceAttachment[],
     ): Promise<void>;


### PR DESCRIPTION
### Why
As people switch to the new Backtrace sdk, they may not make calls directly to `client.send()`. Instead, as I've experienced in a current migration, they may just need to wrap `client.send()` in an existing `reportError()` (or similar) function. In this case, the user would need to overload their function as well. I think it is a better user experience if we just have the two overloads as in most cases, a user will only send an Error or string (not a BacktraceReport) and won't have to overload their function at all.