### PR TITLE
cli: add finding sourcemap by {filename.js}.map

### DIFF
--- a/tools/cli/tests/_files/not-linked-sourcemaps/entry1.js
+++ b/tools/cli/tests/_files/not-linked-sourcemaps/entry1.js
@@ -1,0 +1,6 @@
+function doSomething() {
+    console.log('Done something');
+}
+
+console.log('Hello World Entry 1!');
+doSomething();

--- a/tools/cli/tests/_files/not-linked-sourcemaps/entry1.js.map
+++ b/tools/cli/tests/_files/not-linked-sourcemaps/entry1.js.map
@@ -1,0 +1,11 @@
+{
+    "version": 3,
+    "file": "entry1.js",
+    "mappings": "",
+    "sources": [
+        "../sources/dependency.ts",
+        "../sources/entry1.ts"
+    ],
+    "names": [],
+    "sourceRoot": ""
+}

--- a/tools/cli/tests/_files/not-linked-sourcemaps/entry2.js
+++ b/tools/cli/tests/_files/not-linked-sourcemaps/entry2.js
@@ -1,0 +1,6 @@
+function doSomething() {
+    console.log('Done something');
+}
+
+console.log('Hello World Entry 2!');
+doSomething();

--- a/tools/cli/tests/_files/not-linked-sourcemaps/entry2.js.map
+++ b/tools/cli/tests/_files/not-linked-sourcemaps/entry2.js.map
@@ -1,0 +1,11 @@
+{
+    "version": 3,
+    "file": "entry2.js",
+    "mappings": "",
+    "sources": [
+        "../sources/dependency.ts",
+        "../sources/entry2.ts"
+    ],
+    "names": [],
+    "sourceRoot": ""
+}

--- a/tools/cli/tests/_files/processed-not-linked-sourcemaps/entry1.js
+++ b/tools/cli/tests/_files/processed-not-linked-sourcemaps/entry1.js
@@ -1,0 +1,8 @@
+;!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e._btDebugIds=e._btDebugIds||{},e._btDebugIds[n]="4fe9a5c9-ab48-b240-9469-04aa2db251b6")}catch(e){}}();
+function doSomething() {
+    console.log('Done something');
+}
+
+console.log('Hello World Entry 1!');
+doSomething();
+//# debugId=4fe9a5c9-ab48-b240-9469-04aa2db251b6

--- a/tools/cli/tests/_files/processed-not-linked-sourcemaps/entry1.js.map
+++ b/tools/cli/tests/_files/processed-not-linked-sourcemaps/entry1.js.map
@@ -1,0 +1,16 @@
+{
+    "version": 3,
+    "file": "entry1.js",
+    "mappings": ";",
+    "sources": [
+        "../sources/dependency.ts",
+        "../sources/entry1.ts"
+    ],
+    "names": [],
+    "sourceRoot": "",
+    "debugId": "4fe9a5c9-ab48-b240-9469-04aa2db251b6",
+    "sourcesContent": [
+        "export function doSomething() {\n    console.log('Done something');\n}\n",
+        "import { doSomething } from './dependency';\n\nconsole.log('Hello World Entry 1!');\ndoSomething();\n"
+    ]
+}

--- a/tools/cli/tests/_files/processed-not-linked-sourcemaps/entry2.js
+++ b/tools/cli/tests/_files/processed-not-linked-sourcemaps/entry2.js
@@ -1,0 +1,8 @@
+;!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e._btDebugIds=e._btDebugIds||{},e._btDebugIds[n]="d538bdaa-8149-8111-25f0-b5c0f472366a")}catch(e){}}();
+function doSomething() {
+    console.log('Done something');
+}
+
+console.log('Hello World Entry 2!');
+doSomething();
+//# debugId=d538bdaa-8149-8111-25f0-b5c0f472366a

--- a/tools/cli/tests/_files/processed-not-linked-sourcemaps/entry2.js.map
+++ b/tools/cli/tests/_files/processed-not-linked-sourcemaps/entry2.js.map
@@ -1,0 +1,16 @@
+{
+    "version": 3,
+    "file": "entry2.js",
+    "mappings": ";",
+    "sources": [
+        "../sources/dependency.ts",
+        "../sources/entry2.ts"
+    ],
+    "names": [],
+    "sourceRoot": "",
+    "debugId": "d538bdaa-8149-8111-25f0-b5c0f472366a",
+    "sourcesContent": [
+        "export function doSomething() {\n    console.log('Done something');\n}\n",
+        "import { doSomething } from './dependency';\n\nconsole.log('Hello World Entry 2!');\ndoSomething();\n"
+    ]
+}

--- a/tools/cli/tests/_helpers/testFiles.ts
+++ b/tools/cli/tests/_helpers/testFiles.ts
@@ -6,6 +6,8 @@ import path from 'path';
 
 export type TestFiles =
     | 'no-sourcemaps'
+    | 'not-linked-sourcemaps'
+    | 'processed-not-linked-sourcemaps'
     | 'original'
     | 'processed'
     | 'processed-with-sources'

--- a/tools/cli/tests/sourcemaps/process.spec.ts
+++ b/tools/cli/tests/sourcemaps/process.spec.ts
@@ -339,4 +339,85 @@ describe('process', () => {
             }),
         );
     });
+
+    describe('not linked sourcemaps', () => {
+        it(
+            'should not fail',
+            withWorkingCopy('not-linked-sourcemaps', async (workingDir) => {
+                const result = await processSources({
+                    logger: new CliLogger({ level: 'output', silent: true }),
+                    getHelpMessage,
+                    opts: {
+                        path: workingDir,
+                    },
+                });
+
+                assert(result.isOk(), result.data as string);
+            }),
+        );
+
+        it(
+            'should call SourceProcessor with sources',
+            withWorkingCopy('not-linked-sourcemaps', async (workingDir) => {
+                const spy = jest.spyOn(SourceProcessor.prototype, 'processSourceAndSourceMap');
+
+                const files = await glob(`${workingDir}/*.js`);
+                const originalSources = await readEachFile(files);
+
+                const result = await processSources({
+                    logger: new CliLogger({ level: 'output', silent: true }),
+                    getHelpMessage,
+                    opts: {
+                        path: workingDir,
+                    },
+                });
+
+                assert(result.isOk(), result.data as string);
+
+                for (const source of Object.values(originalSources)) {
+                    expect(spy).toBeCalledWith(source, expect.anything());
+                }
+            }),
+        );
+
+        it(
+            'should modify sources in place',
+            withWorkingCopy('not-linked-sourcemaps', async (workingDir) => {
+                const preHashes = await hashEachFile(await glob(`${workingDir}/*.js`));
+
+                const result = await processSources({
+                    logger: new CliLogger({ level: 'output', silent: true }),
+                    getHelpMessage,
+                    opts: {
+                        path: workingDir,
+                    },
+                });
+
+                assert(result.isOk(), result.data as string);
+                const postHashes = await hashEachFile(await glob(`${workingDir}/*.js`));
+
+                expectHashesToChange(preHashes, postHashes);
+            }),
+        );
+
+        it(
+            'should modify sourcemaps in place',
+            withWorkingCopy('not-linked-sourcemaps', async (workingDir) => {
+                const preHashes = await hashEachFile(await glob(`${workingDir}/*.js.map`));
+
+                const result = await processSources({
+                    logger: new CliLogger({ level: 'output', silent: true }),
+                    getHelpMessage,
+                    opts: {
+                        path: workingDir,
+                    },
+                });
+
+                assert(result.isOk(), result.data as string);
+                const postHashes = await hashEachFile(await glob(`${workingDir}/*.js.map`));
+
+                expectHashesToChange(preHashes, postHashes);
+            }),
+        );
+    });
 });

--- a/tools/cli/tests/sourcemaps/run.spec.ts
+++ b/tools/cli/tests/sourcemaps/run.spec.ts
@@ -463,4 +463,38 @@ describe('run', () => {
             }),
         );
     });
+
+    describe('not linked sourcemaps', () => {
+        it(
+            'should return processed sources and sourcemap paths',
+            withWorkingCopy('not-linked-sourcemaps', async (workingDir) => {
+                const config = await mockOptions(workingDir, {
+                    run: {
+                        'add-sources': true,
+                        process: true,
+                        upload: true,
+                    },
+                    upload: {
+                        url: 'https://test',
+                    },
+                });
+
+                const result = await runSourcemapCommands({
+                    logger: new CliLogger({ level: 'output', silent: true }),
+                    getHelpMessage,
+                    opts: {
+                        path: workingDir,
+                        config,
+                    },
+                });
+
+                assert(result.isOk(), result.data as string);
+
+                const expected = [...(await glob(`${workingDir}/*.js`)), ...(await glob(`${workingDir}/*.js.map`))];
+                expect(result.data.flatMap((d) => [d.source.path, d.sourceMap.path])).toEqual(
+                    expect.arrayContaining(expected),
+                );
+            }),
+        );
+    });
 });

--- a/tools/sourcemap-tools/src/SourceProcessor.ts
+++ b/tools/sourcemap-tools/src/SourceProcessor.ts
@@ -117,12 +117,12 @@ export class SourceProcessor {
 
         const source = sourceReadResult.data;
         if (!sourceMapPath) {
-            const sourceMapPathResult = this.getSourceMapPathFromSource(source, sourcePath);
-            if (sourceMapPathResult.isErr()) {
-                return sourceMapPathResult;
+            const pathFromSource = this.getSourceMapPathFromSource(source, sourcePath);
+            if (!pathFromSource) {
+                return Err('could not find source map for source');
             }
 
-            sourceMapPath = sourceMapPathResult.data;
+            sourceMapPath = pathFromSource;
         }
 
         const sourceMapReadResult = await readFile(sourceMapPath);
@@ -152,16 +152,16 @@ export class SourceProcessor {
             return sourceReadResult;
         }
 
-        return this.getSourceMapPathFromSource(sourceReadResult.data, sourcePath);
+        return Ok(this.getSourceMapPathFromSource(sourceReadResult.data, sourcePath));
     }
 
     public getSourceMapPathFromSource(source: string, sourcePath: string) {
         const match = source.match(/^\/\/# sourceMappingURL=(.+)$/m);
         if (!match || !match[1]) {
-            return Err('could not find source map for source');
+            return undefined;
         }
 
-        return Ok(path.resolve(path.dirname(sourcePath), match[1]));
+        return path.resolve(path.dirname(sourcePath), match[1]);
     }
 
     public async addSourcesToSourceMap(


### PR DESCRIPTION
This PR adds the functionality of locating the sourcemap file when `//# sourceMappingURL` is missing.