### PR TITLE
Single client instance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12207,7 +12207,7 @@
             "version": "0.0.3",
             "license": "MIT",
             "dependencies": {
-                "@backtrace-labs/sdk-core": "^0.0.2",
+                "@backtrace-labs/sdk-core": "^0.0.3",
                 "form-data": "^4.0.0",
                 "native-reg": "^1.1.1"
             },
@@ -12225,17 +12225,13 @@
                 "node": ">=14"
             }
         },
-        "packages/node/node_modules/@backtrace-labs/sdk-core": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/@backtrace-labs/sdk-core/-/sdk-core-0.0.2.tgz",
-            "integrity": "sha512-o7sWq8FzOr9FQE+8P2slJJNldQFcR6y3lwaNQDkOp/vgwD5wuSxs6GRzQecTpsxMOwCWT1wFQSO4dulZIRMfIQ=="
-        },
         "packages/react": {
             "name": "@backtrace-labs/react",
             "version": "0.0.3",
             "license": "MIT",
             "dependencies": {
-                "@backtrace-labs/browser": "^0.0.3"
+                "@backtrace-labs/browser": "^0.0.3",
+                "@backtrace-labs/sdk-core": "^0.0.3"
             },
             "devDependencies": {
                 "@testing-library/react": "^14.0.0",
@@ -12882,7 +12878,7 @@
                 "@backtrace-labs/sourcemap-tools": "^0.0.4",
                 "@types/command-line-args": "^5.2.0",
                 "@types/command-line-usage": "^5.0.2",
-                "@types/fs-extra": "*",
+                "@types/fs-extra": "^11.0.1",
                 "command-line-args": "^5.2.1",
                 "command-line-usage": "^7.0.1",
                 "fs-extra": "^11.1.1",
@@ -12896,7 +12892,7 @@
         "@backtrace-labs/node": {
             "version": "file:packages/node",
             "requires": {
-                "@backtrace-labs/sdk-core": "^0.0.2",
+                "@backtrace-labs/sdk-core": "0.0.3",
                 "@types/jest": "^29.5.1",
                 "form-data": "^4.0.0",
                 "jest": "^29.5.0",
@@ -12907,19 +12903,13 @@
                 "webpack": "^5.87.0",
                 "webpack-cli": "^5.1.4",
                 "webpack-node-externals": "^3.0.0"
-            },
-            "dependencies": {
-                "@backtrace-labs/sdk-core": {
-                    "version": "0.0.2",
-                    "resolved": "https://registry.npmjs.org/@backtrace-labs/sdk-core/-/sdk-core-0.0.2.tgz",
-                    "integrity": "sha512-o7sWq8FzOr9FQE+8P2slJJNldQFcR6y3lwaNQDkOp/vgwD5wuSxs6GRzQecTpsxMOwCWT1wFQSO4dulZIRMfIQ=="
-                }
             }
         },
         "@backtrace-labs/react": {
             "version": "file:packages/react",
             "requires": {
                 "@backtrace-labs/browser": "^0.0.3",
+                "@backtrace-labs/sdk-core": "^0.0.3",
                 "@testing-library/react": "^14.0.0",
                 "@types/react": "^18.2.14",
                 "jest": "^29.5.0",

--- a/packages/browser/src/BacktraceClient.ts
+++ b/packages/browser/src/BacktraceClient.ts
@@ -18,7 +18,6 @@ import { BacktraceClientBuilder } from './builder/BacktraceClientBuilder';
 export class BacktraceClient extends BacktraceCoreClient {
     private readonly _disposeController: AbortController = new AbortController();
 
-    protected static _instance?: BacktraceClient;
     constructor(
         options: BacktraceConfiguration,
         requestHandler: BacktraceRequestHandler,
@@ -59,13 +58,13 @@ export class BacktraceClient extends BacktraceCoreClient {
         options: BacktraceConfiguration,
         build?: (builder: BacktraceClientBuilder) => void,
     ): BacktraceClient {
-        if (this._instance) {
-            return this._instance;
+        if (this.instance) {
+            return this.instance;
         }
         const builder = this.builder(options);
         build && build(builder);
         this._instance = builder.build();
-        return this._instance;
+        return this._instance as BacktraceClient;
     }
 
     /**
@@ -73,7 +72,7 @@ export class BacktraceClient extends BacktraceCoreClient {
      * Otherwise undefined.
      */
     public static get instance(): BacktraceClient | undefined {
-        return this._instance;
+        return this._instance as BacktraceClient;
     }
 
     /**

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -49,7 +49,7 @@
         "webpack-node-externals": "^3.0.0"
     },
     "dependencies": {
-        "@backtrace-labs/sdk-core": "^0.0.2",
+        "@backtrace-labs/sdk-core": "^0.0.3",
         "form-data": "^4.0.0",
         "native-reg": "^1.1.1"
     }

--- a/packages/node/src/BacktraceClient.ts
+++ b/packages/node/src/BacktraceClient.ts
@@ -21,7 +21,6 @@ import { BacktraceDatabaseFileStorageProvider } from './database/BacktraceDataba
 export class BacktraceClient extends BacktraceCoreClient {
     private _listeners: Record<string, NodeJS.UnhandledRejectionListener | NodeJS.UncaughtExceptionListener> = {};
 
-    private static _instance?: BacktraceClient;
     constructor(
         options: CoreConfiguration,
         requestHandler: BacktraceRequestHandler,
@@ -61,14 +60,17 @@ export class BacktraceClient extends BacktraceCoreClient {
      * @param build builder
      * @returns backtrace client
      */
-    public static initialize(options: BacktraceConfiguration, build?: (builder: BacktraceClientBuilder) => void) {
-        if (this._instance) {
-            return this._instance;
+    public static initialize(
+        options: BacktraceConfiguration,
+        build?: (builder: BacktraceClientBuilder) => void,
+    ): BacktraceClient {
+        if (this.instance) {
+            return this.instance;
         }
         const builder = this.builder(options);
         build && build(builder);
         this._instance = builder.build();
-        return this._instance;
+        return this._instance as BacktraceClient;
     }
 
     /**
@@ -76,7 +78,7 @@ export class BacktraceClient extends BacktraceCoreClient {
      * Otherwise undefined.
      */
     public static get instance(): BacktraceClient | undefined {
-        return this._instance;
+        return this._instance as BacktraceClient;
     }
 
     /**

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -47,7 +47,8 @@
         "webpack-cli": "^5.1.4"
     },
     "dependencies": {
-        "@backtrace-labs/browser": "^0.0.3"
+        "@backtrace-labs/browser": "^0.0.3",
+        "@backtrace-labs/sdk-core": "^0.0.3"
     },
     "peerDependencies": {
         "react": ">=16.8.0"

--- a/packages/react/src/BacktraceClient.ts
+++ b/packages/react/src/BacktraceClient.ts
@@ -11,8 +11,6 @@ import { AGENT } from './agentDefinition';
 import { BacktraceReactClientBuilder } from './builder/BacktraceReactClientBuilder';
 
 export class BacktraceClient extends BrowserClient {
-    protected static _instance?: BacktraceClient;
-
     constructor(
         options: BacktraceConfiguration,
         requestHandler: BacktraceRequestHandler,
@@ -43,14 +41,17 @@ export class BacktraceClient extends BrowserClient {
      * @param build builder
      * @returns backtrace client
      */
-    public static initialize(options: BacktraceConfiguration, build?: (builder: BacktraceReactClientBuilder) => void) {
-        if (this._instance) {
-            return this._instance;
+    public static initialize(
+        options: BacktraceConfiguration,
+        build?: (builder: BacktraceReactClientBuilder) => void,
+    ): BacktraceClient {
+        if (this.instance) {
+            return this.instance;
         }
         const builder = this.builder(options);
         build && build(builder);
         this._instance = builder.build();
-        return this._instance;
+        return this._instance as BacktraceClient;
     }
 
     /**
@@ -58,6 +59,6 @@ export class BacktraceClient extends BrowserClient {
      * Otherwise undefined.
      */
     public static get instance(): BacktraceClient | undefined {
-        return this._instance;
+        return this._instance as BacktraceClient;
     }
 }

--- a/packages/sdk-core/src/BacktraceCoreClient.ts
+++ b/packages/sdk-core/src/BacktraceCoreClient.ts
@@ -25,6 +25,11 @@ import { SingleSessionProvider } from './modules/metrics/SingleSessionProvider';
 import { RateLimitWatcher } from './modules/rateLimiter/RateLimitWatcher';
 export abstract class BacktraceCoreClient {
     /**
+     * Backtrace client instance
+     */
+    protected static _instance?: BacktraceCoreClient;
+
+    /**
      * Determines if the client is enabled.
      */
     public get enabled() {


### PR DESCRIPTION
# Why

Right now each client implements how to deal with the Backtrace "instance". The code is redundant. In addition to that storing the instance in a library "instance" instead of globally for every other instance might create some weird issues - for example: The error boundary won't find an instance. 

This diff fixes the behavior and forces all clients to use one single instance. 