### PR TITLE
Allow to modify error boundary by other clients

### DIFF
--- a/packages/react/src/ErrorBoundary.tsx
+++ b/packages/react/src/ErrorBoundary.tsx
@@ -4,30 +4,29 @@ import { BacktraceClient } from './BacktraceClient';
 
 type RenderFallback = (error: Error) => ReactElement;
 
-export interface Props {
+export interface BacktraceErrorBoundaryProps {
     children: ReactNode;
     fallback?: ReactElement | RenderFallback;
     name?: string;
 }
 
-export interface State {
+export interface BacktraceErrorBoundaryState {
     error?: Error;
 }
 
-export class ErrorBoundary extends Component<Props, State> {
-    private _client: BacktraceClient;
+export class ErrorBoundary extends Component<BacktraceErrorBoundaryProps, BacktraceErrorBoundaryState> {
     private COMPONENT_THREAD_NAME = 'component-stack';
-    constructor(props: Props) {
+    constructor(
+        props: BacktraceErrorBoundaryProps,
+        private readonly _client: BacktraceClient = BacktraceClient.instance as BacktraceClient,
+    ) {
         super(props);
+        if (!this._client) {
+            throw new Error('BacktraceClient is uninitialized. Call "BacktraceClient.initialize" function first.');
+        }
         this.state = {
             error: undefined,
         };
-        // grabbing here so it will fail fast if BacktraceClient is uninitialized
-        const client = BacktraceClient.instance;
-        if (!client) {
-            throw new Error('BacktraceClient is uninitialized. Call "BacktraceClient.initialize" function first.');
-        }
-        this._client = client;
     }
 
     public static getDerivedStateFromError(error: Error) {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,5 @@
 export * from '@backtrace-labs/browser';
 export { BacktraceClient } from './BacktraceClient';
+export * from './builder/BacktraceReactClientBuilder';
+export * from './converters/ReactStackTraceConverter';
 export * from './ErrorBoundary';


### PR DESCRIPTION
# Why

Error boundary was designed for react use cases. However, the same error boundary should be used by the react-native client and react-native client needs to override/expose some information from it.

This diff changes:
* default name from "generic" to "backtrace" specific. Other people now instead of importing prop will import something that is not as generic as it was
* allow to use any backtrace client we want - needed if the instance in the react client is not available, but is in the react-native. 