### PR TITLE
Native Submission URLs

### DIFF
--- a/packages/sdk-core/src/model/http/SubmissionUrlInformation.ts
+++ b/packages/sdk-core/src/model/http/SubmissionUrlInformation.ts
@@ -31,6 +31,22 @@ export class SubmissionUrlInformation {
     }
 
     /**
+     * Converts full submission JSON URL to PlCrashReporter submission URL
+     * @param submissionUrl Backtrace Submission URL
+     */
+    public static toPlCrashReporterSubmissionUrl(submissionUrl: string): string {
+        return this.changeSubmissionFormat(submissionUrl, 'minidump');
+    }
+
+    /**
+     * Converts full submission JSON URL to minidump submission URL
+     * @param submissionUrl Backtrace Submission URL
+     */
+    public static toMinidumpSubmissionUrl(submissionUrl: string): string {
+        return this.changeSubmissionFormat(submissionUrl, 'minidump');
+    }
+
+    /**
      * Find the universe based on the submission URL
      * @param submissionUrl submission URL
      * @returns universe name
@@ -70,5 +86,16 @@ export class SubmissionUrlInformation {
         const url = new URL(submissionUrl);
 
         return url.searchParams.get('token');
+    }
+
+    public static changeSubmissionFormat(submissionUrl: string, desiredFormat: 'json' | 'plcrash' | 'minidump') {
+        const submitIndex = submissionUrl.indexOf(this.SUBMIT_PREFIX);
+        const url = new URL(submissionUrl);
+        if (submitIndex !== -1) {
+            url.pathname = url.pathname.replace('/json', `/${desiredFormat}`);
+        } else {
+            url.searchParams.set('format', desiredFormat);
+        }
+        return url.href;
     }
 }

--- a/packages/sdk-core/src/model/http/SubmissionUrlInformation.ts
+++ b/packages/sdk-core/src/model/http/SubmissionUrlInformation.ts
@@ -92,7 +92,17 @@ export class SubmissionUrlInformation {
         const submitIndex = submissionUrl.indexOf(this.SUBMIT_PREFIX);
         const url = new URL(submissionUrl);
         if (submitIndex !== -1) {
-            url.pathname = url.pathname.substring(0, url.pathname.lastIndexOf('/')) + `/${desiredFormat}`;
+            const pathParts = url.pathname.split('/');
+            // path parts are prefixed with '/' character. Expected and valid submit format is:
+            // /universe/token/format
+            // splitting pathname should generate at least 4 elements ('', universe, token, format)
+            // if pathParts length is not equal to 4 then the invalid were passed.
+            const expectedMinimalPathParts = 4;
+            if (pathParts.length < expectedMinimalPathParts) {
+                return submissionUrl;
+            }
+            pathParts[3] = desiredFormat;
+            url.pathname = pathParts.join('/');
         } else {
             url.searchParams.set('format', desiredFormat);
         }

--- a/packages/sdk-core/src/model/http/SubmissionUrlInformation.ts
+++ b/packages/sdk-core/src/model/http/SubmissionUrlInformation.ts
@@ -35,7 +35,7 @@ export class SubmissionUrlInformation {
      * @param submissionUrl Backtrace Submission URL
      */
     public static toPlCrashReporterSubmissionUrl(submissionUrl: string): string {
-        return this.changeSubmissionFormat(submissionUrl, 'minidump');
+        return this.changeSubmissionFormat(submissionUrl, 'plcrash');
     }
 
     /**
@@ -92,7 +92,7 @@ export class SubmissionUrlInformation {
         const submitIndex = submissionUrl.indexOf(this.SUBMIT_PREFIX);
         const url = new URL(submissionUrl);
         if (submitIndex !== -1) {
-            url.pathname = url.pathname.replace('/json', `/${desiredFormat}`);
+            url.pathname = url.pathname.substring(0, url.pathname.lastIndexOf('/')) + `/${desiredFormat}`;
         } else {
             url.searchParams.set('format', desiredFormat);
         }

--- a/packages/sdk-core/tests/http/submissionUrlGenerationTests.spec.ts
+++ b/packages/sdk-core/tests/http/submissionUrlGenerationTests.spec.ts
@@ -25,10 +25,20 @@ describe('Submission Url generation tests', () => {
                     );
                 });
 
-                it(`Should convert submission URL to the minidump ${submissionType} URL and ignore query parameters`, () => {
+                it(`Should convert submission URL to the ${submissionType} URL and ignore query parameters`, () => {
                     const queryParameters = '?foo=bar&baz=123';
                     const expectedUrl = createSubmissionUrl(submissionType) + queryParameters;
                     const submissionUrl = createSubmissionUrl() + queryParameters;
+
+                    expect(SubmissionUrlInformation.changeSubmissionFormat(submissionUrl, submissionType)).toBe(
+                        expectedUrl,
+                    );
+                });
+
+                it(`Should convert submission URL to the ${submissionType} with multiple empty path parts`, () => {
+                    const emptyPathParts = '//////';
+                    const expectedUrl = createSubmissionUrl(submissionType) + emptyPathParts;
+                    const submissionUrl = createSubmissionUrl() + emptyPathParts;
 
                     expect(SubmissionUrlInformation.changeSubmissionFormat(submissionUrl, submissionType)).toBe(
                         expectedUrl,

--- a/packages/sdk-core/tests/http/submissionUrlGenerationTests.spec.ts
+++ b/packages/sdk-core/tests/http/submissionUrlGenerationTests.spec.ts
@@ -1,7 +1,11 @@
 import { SubmissionUrlInformation } from '../../src/model/http';
 describe('Submission Url generation tests', () => {
+    const submissionTypes: Array<'plcrash' | 'minidump'> = ['minidump', 'plcrash'];
     describe('Submit', () => {
-        const sampleSubmitUrl = `https://submit.backtrace.io/name/000000000000a1eb7ae344f6e002de2e20c81fbdedf6991c2f3bb45b11111111/json`;
+        function createSubmissionUrl(format = 'json') {
+            return `https://submit.backtrace.io/name/000000000000a1eb7ae344f6e002de2e20c81fbdedf6991c2f3bb45b11111111/${format}`;
+        }
+        const sampleSubmitUrl = createSubmissionUrl();
         it('Should use submit url from the configuration options', () => {
             expect(SubmissionUrlInformation.toJsonReportSubmissionUrl(sampleSubmitUrl)).toBe(sampleSubmitUrl);
         });
@@ -9,12 +13,39 @@ describe('Submission Url generation tests', () => {
         it(`Shouldnt mix token with the submission url`, () => {
             expect(SubmissionUrlInformation.toJsonReportSubmissionUrl(sampleSubmitUrl, '123')).toBe(sampleSubmitUrl);
         });
+
+        for (const submissionType of submissionTypes) {
+            describe(`${submissionType} submission url`, () => {
+                it(`Should convert submission URL to the ${submissionType} submission URL`, () => {
+                    const expectedUrl = createSubmissionUrl(submissionType);
+                    const submissionUrl = createSubmissionUrl();
+
+                    expect(SubmissionUrlInformation.changeSubmissionFormat(submissionUrl, submissionType)).toBe(
+                        expectedUrl,
+                    );
+                });
+
+                it(`Should convert submission URL to the minidump ${submissionType} URL and ignore query parameters`, () => {
+                    const queryParameters = '?foo=bar&baz=123';
+                    const expectedUrl = createSubmissionUrl(submissionType) + queryParameters;
+                    const submissionUrl = createSubmissionUrl() + queryParameters;
+
+                    expect(SubmissionUrlInformation.changeSubmissionFormat(submissionUrl, submissionType)).toBe(
+                        expectedUrl,
+                    );
+                });
+            });
+        }
     });
 
     describe('Direct URL', () => {
+        function createDirectUrl(format = 'json') {
+            return `${hostname}/post?format=${format}&token=${token}`;
+        }
+
         const hostname = `https://instance.sp.backtrace.io`;
         const token = `000000000000a1eb7ae344f6e002de2e20c81fbdedf6991c2f3bb45b11111111`;
-        const fullUrl = `${hostname}/post?format=json&token=${token}`;
+        const fullUrl = createDirectUrl();
         it('Should use the direct url if the token is not available', () => {
             expect(SubmissionUrlInformation.toJsonReportSubmissionUrl(fullUrl)).toBe(fullUrl);
         });
@@ -33,5 +64,28 @@ describe('Submission Url generation tests', () => {
 
             expect(SubmissionUrlInformation.toJsonReportSubmissionUrl(fullUrl, testedToken)).toBe(expectedUrl);
         });
+
+        for (const submissionType of submissionTypes) {
+            describe(`${submissionType} submission url`, () => {
+                it(`Should convert submission URL to the ${submissionType} submission URL`, () => {
+                    const expectedUrl = createDirectUrl(submissionType);
+                    const submissionUrl = createDirectUrl();
+
+                    expect(SubmissionUrlInformation.changeSubmissionFormat(submissionUrl, submissionType)).toBe(
+                        expectedUrl,
+                    );
+                });
+
+                it(`Should convert submission URL to the minidump ${submissionType} URL and ignore query parameters`, () => {
+                    const queryParameters = '&foo=bar&baz=123';
+                    const expectedUrl = createDirectUrl(submissionType) + queryParameters;
+                    const submissionUrl = createDirectUrl() + queryParameters;
+
+                    expect(SubmissionUrlInformation.changeSubmissionFormat(submissionUrl, submissionType)).toBe(
+                        expectedUrl,
+                    );
+                });
+            });
+        }
     });
 });


### PR DESCRIPTION
# Why

Most of the time our libraries need to send json reports - this is why submission URL class has helpers around a json format. However other our libraries like react-native or electron will need to use different URLs to submit different types of data - like minidumps or plcrashreporter crashes. 

This diff extends the submission URL class and allow to transform the URL to the plcrashreporter or minidump format