### PR TITLE
cli: fix unit tests

### DIFF
--- a/tools/cli/src/logger.ts
+++ b/tools/cli/src/logger.ts
@@ -57,7 +57,7 @@ export class CliLogger implements Logger {
     public log(level: CliLogLevel, value: unknown | Error, ...args: unknown[]) {
         const isOutput = level === 'output';
 
-        if (this.options.silent && !isOutput) {
+        if (this.options.silent) {
             return;
         }
 

--- a/tools/cli/tests/sourcemaps/run.spec.ts
+++ b/tools/cli/tests/sourcemaps/run.spec.ts
@@ -16,7 +16,7 @@ import { hashFiles, withWorkingCopy } from '../_helpers/testFiles';
 async function mockOptions(workingDir: string, options: CliOptions) {
     const configName = `${randomUUID()}.backtracejsrc`;
     const fullPath = path.join(workingDir, configName);
-    fs.promises.writeFile(fullPath, JSON.stringify(options));
+    await fs.promises.writeFile(fullPath, JSON.stringify(options));
     return fullPath;
 }
 

--- a/tools/sourcemap-tools/src/helpers/common.ts
+++ b/tools/sourcemap-tools/src/helpers/common.ts
@@ -10,7 +10,7 @@ export async function readFile(file: string): ResultPromise<string, string> {
     try {
         return Ok(await fs.promises.readFile(file, 'utf-8'));
     } catch (err) {
-        return Err(`failed to read file: ${err instanceof Error ? err.message : 'unknown error'}`);
+        return Err(`failed to read file: ${err}`);
     }
 }
 
@@ -20,7 +20,7 @@ export function writeFile(path: string) {
             await fs.promises.writeFile(path, content);
             return Ok(content);
         } catch (err) {
-            return Err(`failed to write file: ${err instanceof Error ? err.message : 'unknown error'}`);
+            return Err(`failed to write file: ${err}`);
         }
     };
 }
@@ -29,7 +29,7 @@ export function createWriteStream(path: string) {
     try {
         return Ok(fs.createWriteStream(path));
     } catch (err) {
-        return Err(`failed to create write stream to file: ${err instanceof Error ? err.message : 'unknown error'}`);
+        return Err(`failed to create write stream to file: ${err}`);
     }
 }
 
@@ -52,7 +52,7 @@ export async function writeStream(file: StreamFile) {
             output.on('finish', () => resolve(Ok(file)));
         });
     } catch (err) {
-        return Err(`failed to write file: ${err instanceof Error ? err.message : 'unknown error'}`);
+        return Err(`failed to write file: ${err}`);
     }
 }
 
@@ -60,7 +60,7 @@ export function parseJSON<T>(content: string): Result<T, string> {
     try {
         return Ok(JSON.parse(content));
     } catch (err) {
-        return Err(`failed to parse content: ${err instanceof Error ? err.message : 'unknown error'}`);
+        return Err(`failed to parse content: ${err}`);
     }
 }
 


### PR DESCRIPTION
This PR fixes tests and how they are run:
* a missing `await` was probably causing race conditions with some test runs
* logger no longer is spamming when set to silent
* errors should be more meaningful