### PR TITLE
Sdk-Core release 0.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12177,7 +12177,7 @@
             "version": "0.0.3",
             "license": "MIT",
             "dependencies": {
-                "@backtrace-labs/sdk-core": "^0.0.3",
+                "@backtrace-labs/sdk-core": "^0.0.4",
                 "ua-parser-js": "^1.0.35"
             },
             "devDependencies": {
@@ -12198,7 +12198,7 @@
             "version": "0.0.3",
             "license": "MIT",
             "dependencies": {
-                "@backtrace-labs/sdk-core": "^0.0.3",
+                "@backtrace-labs/sdk-core": "^0.0.4",
                 "form-data": "^4.0.0",
                 "native-reg": "^1.1.1"
             },
@@ -12222,7 +12222,7 @@
             "license": "MIT",
             "dependencies": {
                 "@backtrace-labs/browser": "^0.0.3",
-                "@backtrace-labs/sdk-core": "^0.0.3"
+                "@backtrace-labs/sdk-core": "^0.0.4"
             },
             "devDependencies": {
                 "@testing-library/react": "^14.0.0",
@@ -12241,7 +12241,7 @@
         },
         "packages/sdk-core": {
             "name": "@backtrace-labs/sdk-core",
-            "version": "0.0.3",
+            "version": "0.0.4",
             "license": "MIT",
             "devDependencies": {
                 "@types/jest": "^29.5.1",
@@ -12809,7 +12809,7 @@
         "@backtrace-labs/browser": {
             "version": "file:packages/browser",
             "requires": {
-                "@backtrace-labs/sdk-core": "^0.0.3",
+                "@backtrace-labs/sdk-core": "^0.0.4",
                 "@reduxjs/toolkit": "^1.9.5",
                 "@types/jest": "^29.5.1",
                 "@types/ua-parser-js": "^0.7.36",
@@ -12843,7 +12843,7 @@
         "@backtrace-labs/node": {
             "version": "file:packages/node",
             "requires": {
-                "@backtrace-labs/sdk-core": "0.0.3",
+                "@backtrace-labs/sdk-core": "^0.0.4",
                 "@types/jest": "^29.5.1",
                 "form-data": "^4.0.0",
                 "jest": "^29.5.0",
@@ -12860,7 +12860,7 @@
             "version": "file:packages/react",
             "requires": {
                 "@backtrace-labs/browser": "^0.0.3",
-                "@backtrace-labs/sdk-core": "^0.0.3",
+                "@backtrace-labs/sdk-core": "^0.0.4",
                 "@testing-library/react": "^14.0.0",
                 "@types/react": "^18.2.14",
                 "jest": "^29.5.0",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -49,7 +49,7 @@
         "webpack-cli": "^5.1.4"
     },
     "dependencies": {
-        "@backtrace-labs/sdk-core": "^0.0.3",
+        "@backtrace-labs/sdk-core": "^0.0.4",
         "ua-parser-js": "^1.0.35"
     }
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -49,7 +49,7 @@
         "webpack-node-externals": "^3.0.0"
     },
     "dependencies": {
-        "@backtrace-labs/sdk-core": "^0.0.3",
+        "@backtrace-labs/sdk-core": "^0.0.4",
         "form-data": "^4.0.0",
         "native-reg": "^1.1.1"
     }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -48,7 +48,7 @@
     },
     "dependencies": {
         "@backtrace-labs/browser": "^0.0.3",
-        "@backtrace-labs/sdk-core": "^0.0.3"
+        "@backtrace-labs/sdk-core": "^0.0.4"
     },
     "peerDependencies": {
         "react": ">=16.8.0"

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace-labs/sdk-core",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "Backtrace-JavaScript SDK core library",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",


### PR DESCRIPTION
This diff updates sdk-core package to version 0.0.4.

What's new? 
- addAttachment method
- native submission URL generator
- SDK attribute manager API
- small improvements/adjustements in the API