### PR TITLE
add events and modules to core client

### DIFF
--- a/packages/browser/src/builder/BacktraceClientBuilder.ts
+++ b/packages/browser/src/builder/BacktraceClientBuilder.ts
@@ -43,14 +43,16 @@ export class BacktraceClientBuilder extends BacktraceCoreClientBuilder<Backtrace
     }
 
     public build(): BacktraceClient {
-        return new BacktraceClient(
+        const instance = new BacktraceClient(
             this.options,
             this.handler,
             this.attributeProviders,
             this.stackTraceConverter ?? this.generateStackTraceConverter(),
             this.breadcrumbsSubscribers,
             this.sessionProvider,
-        ).initialize();
+        );
+        instance.initialize();
+        return instance;
     }
 
     protected generateStackTraceConverter(): BacktraceStackTraceConverter {

--- a/packages/browser/src/builder/BacktraceClientBuilder.ts
+++ b/packages/browser/src/builder/BacktraceClientBuilder.ts
@@ -50,7 +50,7 @@ export class BacktraceClientBuilder extends BacktraceCoreClientBuilder<Backtrace
             this.stackTraceConverter ?? this.generateStackTraceConverter(),
             this.breadcrumbsSubscribers,
             this.sessionProvider,
-        );
+        ).initialize();
     }
 
     protected generateStackTraceConverter(): BacktraceStackTraceConverter {

--- a/packages/node/src/builder/BacktraceClientBuilder.ts
+++ b/packages/node/src/builder/BacktraceClientBuilder.ts
@@ -46,11 +46,13 @@ export class BacktraceClientBuilder extends BacktraceCoreClientBuilder<Backtrace
     }
 
     public build(): BacktraceClient {
-        return new BacktraceClient(
+        const instance = new BacktraceClient(
             { ...this._options, attachments: this.transformAttachments() },
             this.handler,
             this.attributeProviders,
             this.breadcrumbsSubscribers,
-        ).initialize();
+        );
+        instance.initialize();
+        return instance;
     }
 }

--- a/packages/node/src/builder/BacktraceClientBuilder.ts
+++ b/packages/node/src/builder/BacktraceClientBuilder.ts
@@ -51,6 +51,6 @@ export class BacktraceClientBuilder extends BacktraceCoreClientBuilder<Backtrace
             this.handler,
             this.attributeProviders,
             this.breadcrumbsSubscribers,
-        );
+        ).initialize();
     }
 }

--- a/packages/react/src/builder/BacktraceReactClientBuilder.ts
+++ b/packages/react/src/builder/BacktraceReactClientBuilder.ts
@@ -21,6 +21,6 @@ export class BacktraceReactClientBuilder extends BacktraceClientBuilder {
             this.stackTraceConverter ?? new ReactStackTraceConverter(this.generateStackTraceConverter()),
             this.breadcrumbsSubscribers,
             this.sessionProvider,
-        );
+        ).initialize();
     }
 }

--- a/packages/react/src/builder/BacktraceReactClientBuilder.ts
+++ b/packages/react/src/builder/BacktraceReactClientBuilder.ts
@@ -14,13 +14,15 @@ export class BacktraceReactClientBuilder extends BacktraceClientBuilder {
     }
 
     public build(): BacktraceClient {
-        return new BacktraceClient(
+        const instance = new BacktraceClient(
             this.options,
             this.handler,
             this.attributeProviders,
             this.stackTraceConverter ?? new ReactStackTraceConverter(this.generateStackTraceConverter()),
             this.breadcrumbsSubscribers,
             this.sessionProvider,
-        ).initialize();
+        );
+        instance.initialize();
+        return instance;
     }
 }

--- a/packages/sdk-core/src/BacktraceCoreClient.ts
+++ b/packages/sdk-core/src/BacktraceCoreClient.ts
@@ -187,7 +187,6 @@ export abstract class BacktraceCoreClient {
             this._modules.set(BreadcrumbsManager, breadcrumbsManager);
         }
 
-        this.initialize();
         this._enabled = true;
     }
 

--- a/packages/sdk-core/src/BacktraceCoreClient.ts
+++ b/packages/sdk-core/src/BacktraceCoreClient.ts
@@ -185,8 +185,6 @@ export abstract class BacktraceCoreClient {
             }
             module.initialize();
         }
-
-        return this;
     }
 
     /**

--- a/packages/sdk-core/src/BacktraceCoreClient.ts
+++ b/packages/sdk-core/src/BacktraceCoreClient.ts
@@ -106,7 +106,7 @@ export abstract class BacktraceCoreClient {
     }
 
     /**
-     * Modules used by client
+     * Modules used by the client
      */
     public get modules(): ReadonlyBacktraceModules {
         return this._modules;
@@ -192,7 +192,10 @@ export abstract class BacktraceCoreClient {
 
     public initialize() {
         for (const module of this._modules.values()) {
-            module.initialize(this);
+            if (module.bind) {
+                module.bind(this);
+            }
+            module.initialize();
         }
 
         return this;

--- a/packages/sdk-core/src/BacktraceCoreClient.ts
+++ b/packages/sdk-core/src/BacktraceCoreClient.ts
@@ -13,6 +13,7 @@ import { ReportEvents } from './events/ReportEvents';
 import { AttributeType, BacktraceData } from './model/data/BacktraceData';
 import { BacktraceReportSubmission } from './model/http/BacktraceReportSubmission';
 import { BacktraceReport } from './model/report/BacktraceReport';
+import { BacktraceModuleBindData } from './modules/BacktraceModule';
 import { BacktraceModules, ReadonlyBacktraceModules } from './modules/BacktraceModules';
 import { AttributeManager } from './modules/attribute/AttributeManager';
 import { ClientAttributeProvider } from './modules/attribute/ClientAttributeProvider';
@@ -100,8 +101,7 @@ export abstract class BacktraceCoreClient {
         return this._modules;
     }
 
-    public readonly reportEvents: Events<ReportEvents>;
-
+    protected readonly reportEvents: Events<ReportEvents>;
     protected readonly attributeManager: AttributeManager;
     protected readonly options: BacktraceConfiguration;
 
@@ -181,7 +181,7 @@ export abstract class BacktraceCoreClient {
     public initialize() {
         for (const module of this._modules.values()) {
             if (module.bind) {
-                module.bind(this);
+                module.bind(this.getModuleBindData());
             }
             module.initialize();
         }
@@ -297,5 +297,12 @@ export abstract class BacktraceCoreClient {
 
     private isReport(data: BacktraceReport | Error | string): data is BacktraceReport {
         return data instanceof BacktraceReport;
+    }
+
+    private getModuleBindData(): BacktraceModuleBindData {
+        return {
+            client: this,
+            reportEvents: this.reportEvents,
+        };
     }
 }

--- a/packages/sdk-core/src/BacktraceCoreClient.ts
+++ b/packages/sdk-core/src/BacktraceCoreClient.ts
@@ -3,14 +3,13 @@ import {
     BacktraceAttributeProvider,
     BacktraceBreadcrumbs,
     BacktraceConfiguration,
-    BacktraceReportSubmissionResult,
     BacktraceSessionProvider,
-    BacktraceSubmissionResponse,
     DebugIdProvider,
     SdkOptions,
 } from '.';
 import { CoreClientSetup } from './builder/CoreClientSetup';
 import { Events } from './common/Events';
+import { ReportEvents } from './events/ReportEvents';
 import { AttributeType, BacktraceData } from './model/data/BacktraceData';
 import { BacktraceReportSubmission } from './model/http/BacktraceReportSubmission';
 import { BacktraceReport } from './model/report/BacktraceReport';
@@ -26,17 +25,6 @@ import { BacktraceMetrics } from './modules/metrics/BacktraceMetrics';
 import { MetricsBuilder } from './modules/metrics/MetricsBuilder';
 import { SingleSessionProvider } from './modules/metrics/SingleSessionProvider';
 import { RateLimitWatcher } from './modules/rateLimiter/RateLimitWatcher';
-
-export type ReportEvents = {
-    'before-skip'(report: BacktraceReport): void;
-    'before-send'(report: BacktraceReport, data: BacktraceData, attachments: BacktraceAttachment[]): void;
-    'after-send'(
-        report: BacktraceReport,
-        data: BacktraceData,
-        attachments: BacktraceAttachment[],
-        result: BacktraceReportSubmissionResult<BacktraceSubmissionResponse>,
-    ): void;
-};
 
 export abstract class BacktraceCoreClient {
     /**
@@ -108,7 +96,7 @@ export abstract class BacktraceCoreClient {
     /**
      * Modules used by the client
      */
-    public get modules(): ReadonlyBacktraceModules {
+    protected get modules(): ReadonlyBacktraceModules {
         return this._modules;
     }
 

--- a/packages/sdk-core/src/common/Events.ts
+++ b/packages/sdk-core/src/common/Events.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 interface EventCallback {
     callback: (...args: any[]) => unknown;
     once?: boolean;

--- a/packages/sdk-core/src/common/Events.ts
+++ b/packages/sdk-core/src/common/Events.ts
@@ -1,0 +1,75 @@
+interface EventCallback {
+    callback: (...args: any[]) => unknown;
+    once?: boolean;
+}
+
+export class Events<
+    const E extends Record<string | number | symbol, (...args: any[]) => unknown> = Record<
+        string | number | symbol,
+        (...args: any[]) => unknown
+    >,
+> {
+    private readonly _callbacks: Partial<Record<keyof E, EventCallback[]>> = {};
+
+    public on<N extends keyof E>(event: N, callback: E[N]): this {
+        this.addCallback(event, { callback });
+        return this;
+    }
+
+    public once<N extends keyof E>(event: N, callback: E[N]): this {
+        this.addCallback(event, { callback, once: true });
+        return this;
+    }
+
+    public off<N extends keyof E>(event: N, callback: E[N]): this {
+        this.removeCallback(event, callback);
+        return this;
+    }
+
+    public emit<N extends keyof E>(event: N, ...args: Parameters<E[N]>): boolean {
+        const callbacks = this._callbacks[event];
+        if (!callbacks || !callbacks.length) {
+            return false;
+        }
+
+        for (const { callback, once } of [...callbacks]) {
+            try {
+                callback(...args);
+            } catch {
+                // Do nothing
+            }
+
+            if (once) {
+                this.removeCallback(event, callback);
+            }
+        }
+
+        return true;
+    }
+
+    private addCallback(event: keyof E, callback: EventCallback) {
+        const list = this._callbacks[event];
+        if (list) {
+            list.push(callback);
+        } else {
+            this._callbacks[event] = [callback];
+        }
+    }
+
+    private removeCallback(event: keyof E, callback: EventCallback['callback']) {
+        const list = this._callbacks[event];
+        if (!list) {
+            return;
+        }
+
+        const index = list.findIndex((el) => el.callback === callback);
+        if (index === -1) {
+            return;
+        }
+
+        list.splice(index, 1);
+        if (!list.length) {
+            delete this._callbacks[event];
+        }
+    }
+}

--- a/packages/sdk-core/src/events/ReportEvents.ts
+++ b/packages/sdk-core/src/events/ReportEvents.ts
@@ -1,0 +1,15 @@
+import { BacktraceAttachment } from '../model/attachment';
+import { BacktraceData } from '../model/data';
+import { BacktraceReportSubmissionResult, BacktraceSubmissionResponse } from '../model/http';
+import { BacktraceReport } from '../model/report/BacktraceReport';
+
+export type ReportEvents = {
+    'before-skip'(report: BacktraceReport): void;
+    'before-send'(report: BacktraceReport, data: BacktraceData, attachments: BacktraceAttachment[]): void;
+    'after-send'(
+        report: BacktraceReport,
+        data: BacktraceData,
+        attachments: BacktraceAttachment[],
+        result: BacktraceReportSubmissionResult<BacktraceSubmissionResponse>,
+    ): void;
+};

--- a/packages/sdk-core/src/modules/BacktraceModule.ts
+++ b/packages/sdk-core/src/modules/BacktraceModule.ts
@@ -1,6 +1,7 @@
 import { BacktraceCoreClient } from '..';
 
 export interface BacktraceModule {
-    initialize(client: BacktraceCoreClient): void;
+    bind?(client: BacktraceCoreClient): void;
+    initialize(): void;
     dispose?(): void;
 }

--- a/packages/sdk-core/src/modules/BacktraceModule.ts
+++ b/packages/sdk-core/src/modules/BacktraceModule.ts
@@ -1,7 +1,14 @@
 import { BacktraceCoreClient } from '..';
+import { Events } from '../common/Events';
+import { ReportEvents } from '../events/ReportEvents';
+
+export interface BacktraceModuleBindData {
+    readonly client: BacktraceCoreClient;
+    readonly reportEvents: Events<ReportEvents>;
+}
 
 export interface BacktraceModule {
-    bind?(client: BacktraceCoreClient): void;
+    bind?(client: BacktraceModuleBindData): void;
     initialize(): void;
     dispose?(): void;
 }

--- a/packages/sdk-core/src/modules/BacktraceModule.ts
+++ b/packages/sdk-core/src/modules/BacktraceModule.ts
@@ -1,0 +1,6 @@
+import { BacktraceCoreClient } from '..';
+
+export interface BacktraceModule {
+    initialize(client: BacktraceCoreClient): void;
+    dispose?(): void;
+}

--- a/packages/sdk-core/src/modules/BacktraceModules.ts
+++ b/packages/sdk-core/src/modules/BacktraceModules.ts
@@ -1,0 +1,12 @@
+import { BacktraceModule } from './BacktraceModule';
+
+type BacktraceModuleCtor<T extends BacktraceModule = BacktraceModule> = new (...args: never[]) => T;
+
+export interface ReadonlyBacktraceModules extends ReadonlyMap<BacktraceModuleCtor, BacktraceModule> {
+    get<T extends BacktraceModule>(type: BacktraceModuleCtor<T>): T | undefined;
+}
+
+export interface BacktraceModules extends Map<BacktraceModuleCtor, BacktraceModule> {
+    set<T extends BacktraceModule>(type: BacktraceModuleCtor<T>, instance: T): this;
+    get<T extends BacktraceModule>(type: BacktraceModuleCtor<T>): T | undefined;
+}

--- a/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
@@ -2,20 +2,22 @@ import {
     BacktraceBreadcrumbs,
     BreadcrumbLogLevel,
     BreadcrumbType,
+    BreadcrumbsSetup,
     defaultBreadcrumbsLogLevel,
     defaultBreadcurmbType,
 } from '.';
+import { BacktraceCoreClient } from '../..';
 import { BacktraceBreadcrumbsSettings } from '../../model/configuration/BacktraceConfiguration';
 import { AttributeType } from '../../model/data/BacktraceData';
 import { BacktraceReport } from '../../model/report/BacktraceReport';
-import { BreadcrumbsSetup } from './BreadcrumbsSetup';
+import { BacktraceModule } from '../BacktraceModule';
 import { BreadcrumbsEventSubscriber } from './events/BreadcrurmbsEventSubscriber';
 import { ConsoleEventSubscriber } from './events/ConsoleEventSubscriber';
 import { RawBreadcrumb } from './model/RawBreadcrumb';
 import { BreadcrumbsStorage } from './storage/BreadcrumbsStorage';
 import { InMemoryBreadcrumbsStorage } from './storage/InMemoryBreadcrumbsStorage';
 
-export class BreadcrumbsManager implements BacktraceBreadcrumbs {
+export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule {
     /**
      * Breadcrumbs type
      */
@@ -66,10 +68,12 @@ export class BreadcrumbsManager implements BacktraceBreadcrumbs {
         };
     }
 
-    public start() {
+    public initialize(client: BacktraceCoreClient) {
         for (const subscriber of this._eventSubscribers) {
             subscriber.start(this);
         }
+
+        client.reportEvents.on('before-skip', (report) => this.logReport(report));
     }
 
     public verbose(message: string, attributes?: Record<string, AttributeType> | undefined): boolean {

--- a/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
@@ -68,12 +68,14 @@ export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule
         };
     }
 
-    public initialize(client: BacktraceCoreClient) {
+    public bind(client: BacktraceCoreClient): void {
+        client.reportEvents.on('before-skip', (report) => this.logReport(report));
+    }
+
+    public initialize() {
         for (const subscriber of this._eventSubscribers) {
             subscriber.start(this);
         }
-
-        client.reportEvents.on('before-skip', (report) => this.logReport(report));
     }
 
     public verbose(message: string, attributes?: Record<string, AttributeType> | undefined): boolean {

--- a/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
@@ -6,11 +6,10 @@ import {
     defaultBreadcrumbsLogLevel,
     defaultBreadcurmbType,
 } from '.';
-import { BacktraceCoreClient } from '../..';
 import { BacktraceBreadcrumbsSettings } from '../../model/configuration/BacktraceConfiguration';
 import { AttributeType } from '../../model/data/BacktraceData';
 import { BacktraceReport } from '../../model/report/BacktraceReport';
-import { BacktraceModule } from '../BacktraceModule';
+import { BacktraceModule, BacktraceModuleBindData } from '../BacktraceModule';
 import { BreadcrumbsEventSubscriber } from './events/BreadcrurmbsEventSubscriber';
 import { ConsoleEventSubscriber } from './events/ConsoleEventSubscriber';
 import { RawBreadcrumb } from './model/RawBreadcrumb';
@@ -68,8 +67,8 @@ export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule
         };
     }
 
-    public bind(client: BacktraceCoreClient): void {
-        client.reportEvents.on('before-skip', (report) => this.logReport(report));
+    public bind({ reportEvents }: BacktraceModuleBindData): void {
+        reportEvents.on('before-skip', (report) => this.logReport(report));
     }
 
     public initialize() {

--- a/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
+++ b/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
@@ -1,11 +1,10 @@
-import { BacktraceCoreClient } from '../..';
 import { IdGenerator } from '../../common/IdGenerator';
 import { TimeHelper } from '../../common/TimeHelper';
 import { BacktraceAttachment } from '../../model/attachment';
 import { BacktraceDatabaseConfiguration } from '../../model/configuration/BacktraceDatabaseConfiguration';
 import { BacktraceData } from '../../model/data/BacktraceData';
 import { BacktraceReportSubmission } from '../../model/http/BacktraceReportSubmission';
-import { BacktraceModule } from '../BacktraceModule';
+import { BacktraceModule, BacktraceModuleBindData } from '../BacktraceModule';
 import { BacktraceDatabaseContext } from './BacktraceDatabaseContext';
 import { BacktraceDatabaseStorageProvider } from './BacktraceDatabaseStorageProvider';
 import { BacktraceDatabaseRecord } from './model/BacktraceDatabaseRecord';
@@ -62,7 +61,7 @@ export class BacktraceDatabase implements BacktraceModule {
         return true;
     }
 
-    public bind(client: BacktraceCoreClient): void {
+    public bind({ reportEvents }: BacktraceModuleBindData): void {
         if (this._enabled) {
             return;
         }
@@ -71,7 +70,7 @@ export class BacktraceDatabase implements BacktraceModule {
             return;
         }
 
-        client.reportEvents.on('before-send', (_, data, attachments) => {
+        reportEvents.on('before-send', (_, data, attachments) => {
             const record = this.add(data, attachments);
 
             if (!record || record.locked || record.count !== 1) {
@@ -81,7 +80,7 @@ export class BacktraceDatabase implements BacktraceModule {
             record.locked = true;
         });
 
-        client.reportEvents.on('after-send', (_, data, __, submissionResult) => {
+        reportEvents.on('after-send', (_, data, __, submissionResult) => {
             const record = this._databaseRecordContext.find((record) => record.data.uuid === data.uuid);
             if (!record) {
                 return;

--- a/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
+++ b/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
@@ -82,7 +82,7 @@ export class BacktraceDatabase implements BacktraceModule {
         });
 
         client.reportEvents.on('after-send', (_, data, __, submissionResult) => {
-            const record = this._databaseRecordContext.find((record) => record.data === data);
+            const record = this._databaseRecordContext.find((record) => record.data.uuid === data.uuid);
             if (!record) {
                 return;
             }

--- a/packages/sdk-core/src/modules/metrics/BacktraceMetrics.ts
+++ b/packages/sdk-core/src/modules/metrics/BacktraceMetrics.ts
@@ -1,6 +1,7 @@
 import { TimeHelper } from '../../common/TimeHelper';
 import { BacktraceMetricsOptions } from '../../model/configuration/BacktraceConfiguration';
 import { AttributeType } from '../../model/data/BacktraceData';
+import { BacktraceModule } from '../BacktraceModule';
 import { AttributeManager } from '../attribute/AttributeManager';
 import { ReportDataBuilder } from '../attribute/ReportDataBuilder';
 import { BacktraceSessionProvider } from './BacktraceSessionProvider';
@@ -8,7 +9,7 @@ import { MetricsQueue } from './MetricsQueue';
 import { SummedEvent } from './model/SummedEvent';
 import { UniqueEvent } from './model/UniqueEvent';
 
-export class BacktraceMetrics {
+export class BacktraceMetrics implements BacktraceModule {
     /**
      * Returns current session id.
      */
@@ -38,7 +39,7 @@ export class BacktraceMetrics {
     /**
      * Starts metrics submission.
      */
-    public start() {
+    public initialize() {
         if (!this._sessionProvider.newSession) {
             return;
         }

--- a/packages/sdk-core/tests/breadcrumbs/breadcrumbsCreationTests.spec.ts
+++ b/packages/sdk-core/tests/breadcrumbs/breadcrumbsCreationTests.spec.ts
@@ -1,5 +1,5 @@
-import { BreadcrumbLogLevel, BreadcrumbType } from '../../lib/modules/breadcrumbs';
-import { BreadcrumbsManager } from '../../lib/modules/breadcrumbs/BreadcrumbsManager';
+import { BreadcrumbLogLevel, BreadcrumbType } from '../../src/modules/breadcrumbs';
+import { BreadcrumbsManager } from '../../src/modules/breadcrumbs/BreadcrumbsManager';
 
 describe('Breadcrumbs creation tests', () => {
     it('Last breadcrumb id attribute should be equal to last bredcrumb id in the array', () => {

--- a/packages/sdk-core/tests/breadcrumbs/breadcrumbsFilteringOptionsTests.spec.ts
+++ b/packages/sdk-core/tests/breadcrumbs/breadcrumbsFilteringOptionsTests.spec.ts
@@ -1,5 +1,5 @@
-import { BreadcrumbLogLevel, BreadcrumbType } from '../../lib/modules/breadcrumbs';
-import { BreadcrumbsManager } from '../../lib/modules/breadcrumbs/BreadcrumbsManager';
+import { BreadcrumbLogLevel, BreadcrumbType } from '../../src/modules/breadcrumbs';
+import { BreadcrumbsManager } from '../../src/modules/breadcrumbs/BreadcrumbsManager';
 
 describe('Breadcrumbs filtering options tests', () => {
     describe('Event type tests', () => {

--- a/packages/sdk-core/tests/common/Events.spec.ts
+++ b/packages/sdk-core/tests/common/Events.spec.ts
@@ -1,0 +1,136 @@
+import { Events } from '../../src/common/Events';
+
+describe('Events', () => {
+    it('should call every callback once', () => {
+        const event = 'event';
+        const fn1 = jest.fn();
+        const fn2 = jest.fn();
+        const fn3 = jest.fn();
+
+        const events = new Events();
+        events.on(event, fn1);
+        events.on(event, fn2);
+        events.on(event, fn3);
+
+        events.emit(event);
+
+        expect(fn1).toBeCalledTimes(1);
+        expect(fn2).toBeCalledTimes(1);
+        expect(fn3).toBeCalledTimes(1);
+    });
+
+    it('should pass args to callback', () => {
+        const event = 'event';
+        const fn = jest.fn();
+        const args = ['a', 1, true];
+
+        const events = new Events();
+        events.on(event, fn);
+
+        events.emit(event, ...args);
+
+        expect(fn).toBeCalledWith(...args);
+    });
+
+    it('should call each callback in order', () => {
+        const event = 'event';
+        const fn1 = jest.fn();
+        const fn2 = jest.fn();
+        const fn3 = jest.fn();
+
+        const events = new Events();
+        events.on(event, fn1);
+        events.on(event, fn2);
+        events.on(event, fn3);
+
+        events.emit(event);
+
+        expect(fn1.mock.invocationCallOrder[0]).toBeLessThan(fn2.mock.invocationCallOrder[0]);
+        expect(fn2.mock.invocationCallOrder[0]).toBeLessThan(fn3.mock.invocationCallOrder[0]);
+    });
+
+    it('should call once callback only once', () => {
+        const event = 'event';
+        const fn = jest.fn();
+
+        const events = new Events();
+        events.once(event, fn);
+
+        events.emit(event);
+        events.emit(event);
+
+        expect(fn).toBeCalledTimes(1);
+    });
+
+    it('should call callback every time', () => {
+        const event = 'event';
+        const fn = jest.fn();
+
+        const events = new Events();
+        events.on(event, fn);
+
+        events.emit(event);
+        events.emit(event);
+
+        expect(fn).toBeCalledTimes(2);
+    });
+
+    it('should return false from emit when there are no listeners', () => {
+        const events = new Events();
+        expect(events.emit('event')).toEqual(false);
+    });
+
+    it('should return true from emit when there are listeners', () => {
+        const event = 'event';
+        const fn = jest.fn();
+
+        const events = new Events();
+        events.on(event, fn);
+
+        expect(events.emit('event')).toEqual(true);
+    });
+
+    it('should no longer call removed callback', () => {
+        const event = 'event';
+        const fn = jest.fn();
+
+        const events = new Events();
+        events.on(event, fn);
+        events.emit(event);
+        events.off(event, fn);
+        events.emit(event);
+
+        expect(fn).toBeCalledTimes(1);
+    });
+
+    it('should not throw when callback throws', () => {
+        const event = 'event';
+        const fn = jest.fn().mockImplementation(() => {
+            throw new Error('abc');
+        });
+
+        const events = new Events();
+        events.on(event, fn);
+
+        expect(() => events.emit(event)).not.toThrow();
+    });
+
+    it('should execute other callbacks when callback throws', () => {
+        const event = 'event';
+        const fn1 = jest.fn();
+        const fn2 = jest.fn().mockImplementation(() => {
+            throw new Error('abc');
+        });
+        const fn3 = jest.fn();
+
+        const events = new Events();
+        events.on(event, fn1);
+        events.on(event, fn2);
+        events.on(event, fn3);
+        events.emit(event);
+
+        expect(fn1).toBeCalledTimes(1);
+        expect(fn2).toBeCalledTimes(1);
+        expect(fn3).toBeCalledTimes(1);
+    });
+});

--- a/packages/sdk-core/tests/database/databaseSetupTests.spec.ts
+++ b/packages/sdk-core/tests/database/databaseSetupTests.spec.ts
@@ -1,7 +1,7 @@
 import { BacktraceData } from '../../src';
 import { BacktraceReportSubmission } from '../../src/model/http/BacktraceReportSubmission';
 import { BacktraceDatabase } from '../../src/modules/database/BacktraceDatabase';
-import { TEST_SUBMISSION_URL } from '../mocks/BacktraceTestClient';
+import { BacktraceTestClient, TEST_SUBMISSION_URL } from '../mocks/BacktraceTestClient';
 import { testHttpClient } from '../mocks/testHttpClient';
 import { testStorageProvider } from '../mocks/testStorageProvider';
 
@@ -35,7 +35,7 @@ describe('Database setup tests', () => {
             ),
         );
 
-        const databaseStartResult = database.start();
+        const databaseStartResult = database.initialize(BacktraceTestClient.buildFakeClient());
 
         expect(databaseStartResult).toBeTruthy();
         expect(database.enabled).toBeTruthy();
@@ -53,7 +53,7 @@ describe('Database setup tests', () => {
             ),
         );
 
-        const databaseStartResult = database.start();
+        const databaseStartResult = database.initialize(BacktraceTestClient.buildFakeClient());
 
         expect(databaseStartResult).toBeFalsy();
         expect(database.enabled).toBeFalsy();
@@ -75,7 +75,7 @@ describe('Database setup tests', () => {
         );
         jest.spyOn(testStorageProvider, 'start').mockReturnValue(false);
 
-        const databaseStartResult = database.start();
+        const databaseStartResult = database.initialize(BacktraceTestClient.buildFakeClient());
 
         expect(databaseStartResult).toBeFalsy();
         expect(database.enabled).toBeFalsy();
@@ -93,7 +93,7 @@ describe('Database setup tests', () => {
             ),
         );
 
-        database.start();
+        database.initialize(BacktraceTestClient.buildFakeClient());
         database.dispose();
 
         expect(database.enabled).toBeFalsy();

--- a/packages/sdk-core/tests/database/databaseSetupTests.spec.ts
+++ b/packages/sdk-core/tests/database/databaseSetupTests.spec.ts
@@ -1,7 +1,7 @@
 import { BacktraceData } from '../../src';
 import { BacktraceReportSubmission } from '../../src/model/http/BacktraceReportSubmission';
 import { BacktraceDatabase } from '../../src/modules/database/BacktraceDatabase';
-import { BacktraceTestClient, TEST_SUBMISSION_URL } from '../mocks/BacktraceTestClient';
+import { TEST_SUBMISSION_URL } from '../mocks/BacktraceTestClient';
 import { testHttpClient } from '../mocks/testHttpClient';
 import { testStorageProvider } from '../mocks/testStorageProvider';
 
@@ -35,7 +35,7 @@ describe('Database setup tests', () => {
             ),
         );
 
-        const databaseStartResult = database.initialize(BacktraceTestClient.buildFakeClient());
+        const databaseStartResult = database.initialize();
 
         expect(databaseStartResult).toBeTruthy();
         expect(database.enabled).toBeTruthy();
@@ -53,7 +53,7 @@ describe('Database setup tests', () => {
             ),
         );
 
-        const databaseStartResult = database.initialize(BacktraceTestClient.buildFakeClient());
+        const databaseStartResult = database.initialize();
 
         expect(databaseStartResult).toBeFalsy();
         expect(database.enabled).toBeFalsy();
@@ -75,7 +75,7 @@ describe('Database setup tests', () => {
         );
         jest.spyOn(testStorageProvider, 'start').mockReturnValue(false);
 
-        const databaseStartResult = database.initialize(BacktraceTestClient.buildFakeClient());
+        const databaseStartResult = database.initialize();
 
         expect(databaseStartResult).toBeFalsy();
         expect(database.enabled).toBeFalsy();
@@ -93,7 +93,7 @@ describe('Database setup tests', () => {
             ),
         );
 
-        database.initialize(BacktraceTestClient.buildFakeClient());
+        database.initialize();
         database.dispose();
 
         expect(database.enabled).toBeFalsy();

--- a/packages/sdk-core/tests/metrics/summedEventTests.spec.ts
+++ b/packages/sdk-core/tests/metrics/summedEventTests.spec.ts
@@ -58,7 +58,7 @@ describe('Summed events tests', () => {
             },
         };
 
-        metrics.start();
+        metrics.initialize();
 
         expect(testHttpClient.post).toBeCalledWith(summedEventsSubmissionUrl, JSON.stringify(expectedJson));
     });
@@ -96,7 +96,7 @@ describe('Summed events tests', () => {
             },
         };
 
-        metrics.start();
+        metrics.initialize();
 
         expect(testHttpClient.post).toBeCalledWith(summedEventsSubmissionUrl, JSON.stringify(expectedJson));
     });
@@ -132,7 +132,7 @@ describe('Summed events tests', () => {
             },
         };
 
-        metrics.start();
+        metrics.initialize();
 
         expect(attributeManager.get().attributes).toMatchObject(customAttributes);
         expect(testHttpClient.post).toBeCalledWith(expect.anything(), JSON.stringify(expectedJson));
@@ -154,7 +154,7 @@ describe('Summed events tests', () => {
         if (!metrics) {
             fail('Metrics are not defined');
         }
-        metrics.start();
+        metrics.initialize();
         const addResult = metrics.addSummedEvent('test-metric');
 
         expect(addResult).toBeTruthy();
@@ -181,7 +181,7 @@ describe('Summed events tests', () => {
             fail('Metrics are not defined');
         }
 
-        metrics.start();
+        metrics.initialize();
 
         for (let index = 0; index < maximumNumberOfEvents; index++) {
             const addResult = metrics.addSummedEvent('test-metric');

--- a/packages/sdk-core/tests/metrics/uniqueEventTests.spec.ts
+++ b/packages/sdk-core/tests/metrics/uniqueEventTests.spec.ts
@@ -59,7 +59,7 @@ describe('Unique events tests', () => {
             },
         };
 
-        metrics.start();
+        metrics.initialize();
 
         expect(testHttpClient.post).toBeCalledWith(uniqueEventsSubmissionUrl, JSON.stringify(expectedJson));
     });
@@ -88,7 +88,7 @@ describe('Unique events tests', () => {
             TEST_SUBMISSION_URL,
         );
 
-        metrics.start();
+        metrics.initialize();
 
         expect(testHttpClient.post).toBeCalledWith(uniqueEventsSubmissionUrl, expect.anything());
     });
@@ -164,7 +164,7 @@ describe('Unique events tests', () => {
             },
         };
 
-        metrics.start();
+        metrics.initialize();
 
         expect(attributeManager.get().attributes).toMatchObject(customAttributes);
         expect(testHttpClient.post).toBeCalledWith(uniqueEventsSubmissionUrl, JSON.stringify(expectedJson));

--- a/packages/sdk-core/tests/mocks/BacktraceTestClient.ts
+++ b/packages/sdk-core/tests/mocks/BacktraceTestClient.ts
@@ -63,6 +63,12 @@ export class BacktraceTestClient extends BacktraceCoreClient {
                 };
             },
         });
-        return new BacktraceTestClient(options, testHttpClient, attributeProviders, attachments, storageProvider);
+        return new BacktraceTestClient(
+            options,
+            testHttpClient,
+            attributeProviders,
+            attachments,
+            storageProvider,
+        ).initialize();
     }
 }

--- a/packages/sdk-core/tests/mocks/BacktraceTestClient.ts
+++ b/packages/sdk-core/tests/mocks/BacktraceTestClient.ts
@@ -63,12 +63,14 @@ export class BacktraceTestClient extends BacktraceCoreClient {
                 };
             },
         });
-        return new BacktraceTestClient(
+        const instance = new BacktraceTestClient(
             options,
             testHttpClient,
             attributeProviders,
             attachments,
             storageProvider,
-        ).initialize();
+        );
+        instance.initialize();
+        return instance;
     }
 }


### PR DESCRIPTION
This diff aims to reduce coupling between some modules and the core client. The main reason is to make the client less dependent on the external modules, which the client can function perfectly fine without.

* `Events` class was added, which is an event emitter similar to Node's `EventEmitter`, but not node-dependent,
* module map was added,
* database, metrics, breadcrumbs were moved to modules,
* database and breadcrumbs are no longer called by the client directly, but rather through Events.

Also moved `initialize` out of constructor and to the builders. The reason for that is to defer initialization of modules to after the class has been constructed.