### PR TITLE
node build and node example improvements

### DIFF
--- a/examples/sdk/node/.gitignore
+++ b/examples/sdk/node/.gitignore
@@ -1,2 +1,2 @@
-./database
+/database
 ./src/consts.ts

--- a/examples/sdk/node/package-lock.json
+++ b/examples/sdk/node/package-lock.json
@@ -8,12 +8,41 @@
             "name": "@backtrace-labs/node-example",
             "version": "1.0.0",
             "license": "MIT",
+            "dependencies": {
+                "@backtrace-labs/node": "file:../../../packages/node"
+            },
             "devDependencies": {
                 "typescript": "^5.1.3"
             },
             "engines": {
                 "node": ">=14"
             }
+        },
+        "../../../packages/node": {
+            "version": "0.0.4",
+            "license": "MIT",
+            "dependencies": {
+                "@backtrace-labs/sdk-core": "^0.0.4",
+                "form-data": "^4.0.0",
+                "native-reg": "^1.1.1"
+            },
+            "devDependencies": {
+                "@types/jest": "^29.5.1",
+                "jest": "^29.5.0",
+                "ts-jest": "^29.1.0",
+                "ts-loader": "^9.4.3",
+                "typescript": "^5.0.4",
+                "webpack": "^5.87.0",
+                "webpack-cli": "^5.1.4",
+                "webpack-node-externals": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@backtrace-labs/node": {
+            "resolved": "../../../packages/node",
+            "link": true
         },
         "node_modules/typescript": {
             "version": "5.2.2",
@@ -30,6 +59,22 @@
         }
     },
     "dependencies": {
+        "@backtrace-labs/node": {
+            "version": "file:../../../packages/node",
+            "requires": {
+                "@backtrace-labs/sdk-core": "^0.0.4",
+                "@types/jest": "^29.5.1",
+                "form-data": "^4.0.0",
+                "jest": "^29.5.0",
+                "native-reg": "^1.1.1",
+                "ts-jest": "^29.1.0",
+                "ts-loader": "^9.4.3",
+                "typescript": "^5.0.4",
+                "webpack": "^5.87.0",
+                "webpack-cli": "^5.1.4",
+                "webpack-node-externals": "^3.0.0"
+            }
+        },
         "typescript": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",

--- a/examples/sdk/node/package.json
+++ b/examples/sdk/node/package.json
@@ -36,5 +36,8 @@
     "homepage": "https://github.com/backtrace-labs/backtrace-javascript#readme",
     "devDependencies": {
         "typescript": "^5.1.3"
+    },
+    "dependencies": {
+        "@backtrace-labs/node": "file:../../../packages/node"
     }
 }

--- a/examples/sdk/node/src/index.ts
+++ b/examples/sdk/node/src/index.ts
@@ -1,4 +1,4 @@
-import { BacktraceClient } from '@backtrace-labs/node';
+import { BacktraceClient, BreadcrumbLogLevel } from '@backtrace-labs/node';
 import fs from 'fs';
 import path from 'path';
 import { exit } from 'process';
@@ -65,6 +65,13 @@ function sendMetrics() {
     }
     client.metrics.send();
 }
+function addBreadcrumb(message: string, attributes: Record<string, number>) {
+    if (!client.breadcrumbs) {
+        console.log('breadcrumbs are not available');
+        return;
+    }
+    client.breadcrumbs.log(message, BreadcrumbLogLevel.Info, attributes);
+}
 
 function oom() {
     function allocateMemory(size: number) {
@@ -100,6 +107,7 @@ function showMenu() {
         ['Throw rejected promise', () => rejectPromise('Rejected promise')],
         ['OOM', oom],
         ['Add a new summed event', (attributes: Record<string, number>) => addEvent('Option clicked', attributes)],
+        ['Add a breadcrumb', (attributes: Record<string, number>) => addBreadcrumb('Breadcrumb added', attributes)],
         ['Send all metrics', sendMetrics],
     ] as const;
 

--- a/packages/node/webpack.config.js
+++ b/packages/node/webpack.config.js
@@ -7,7 +7,7 @@ const nodeExternals = require('webpack-node-externals');
 module.exports = {
     ...webpackTypescriptConfig,
     mode: process.env.NODE_ENV ?? 'production',
-    devtool: 'source-map',
+    devtool: 'nosources-source-map',
     entry: './src/index.ts',
     target: 'node',
     externalsPresets: { node: true },
@@ -20,6 +20,9 @@ module.exports = {
         filename: 'index.js',
         path: path.join(__dirname, 'lib'),
         libraryTarget: 'commonjs2',
+        devtoolModuleFilenameTemplate(info) {
+            return path.relative(path.join(__dirname, 'lib'), info.absoluteResourcePath);
+        },
     },
     plugins: [agentDefinitionPlugin(path.join(__dirname, 'package.json'))],
     optimization: {


### PR DESCRIPTION
This PR adds some improvements and fixes to node and node examples:
* node package will no longer contain source code in sourcemaps, and the sources will point to the original sources
* node example has now an option to add breadcrumb
* fix ignoring database directory in node example
* fix @backtrace-labs/node dependency in node example