### PR TITLE
cli: various fixes

### DIFF
--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -51,9 +51,6 @@ A handy shortcut for executing all commands. Executes commands in order:
 1. [`add-sources`](#add-sources)
 1. [`upload`](#upload)
 
-Requires the config file to function. `run` accepts some common options, but command-specific options are taken from the
-config.
-
 ### Options
 
 #### `--process`
@@ -68,6 +65,10 @@ Runs the [`add-sources`](#add-sources) command.
 
 Runs the [`upload`](#upload) command.
 
+#### `--dry-run`, `-n`
+
+Will not modify the files and not upload them.
+
 #### `<path>`, `--path <string>`, `-p <string>`
 
 Searches for files within provided paths. This is the default positional argument. If not provided, will search in the
@@ -80,6 +81,31 @@ Forces processing of already processed files. May result in duplicate appended d
 #### `--pass-with-no-files`
 
 By default, `run` will return a non-zero exit code when no files are found. Pass this to return 0.
+
+#### `--output <string>`, `-o <string>`
+
+Specify this to output the archive to a file instead of uploading it to Backtrace. Cannot be used with uploading.
+
+#### `--url <string>`, `-u <string>`
+
+URL to upload the sourcemaps to. Cannot be used with `--subdomain`.
+
+#### `--subdomain <string>`, `-s <string>`
+
+Subdomain to use for upload. You must also specify the `--token`. Cannot be used with `--url`.
+
+#### `--token <string>`, `-t <string>`
+
+Token to use with the upload. Usable only with `--subdomain`.
+
+#### `--include-sources`
+
+By default, the sources in sourcemap file will NOT be uploaded to Backtrace. Specify this to include `sourcesContent`
+key in sourcemaps.
+
+#### `--insecure`, `-k`
+
+Disables HTTPS certificate checking.
 
 ## `process`
 
@@ -180,8 +206,7 @@ current directory.
 
 #### `--url <string>`, `-u <string>`
 
-URL to upload the sourcemaps to. You can use also `BACKTRACE_JS_UPLOAD_URL` environment variable. Cannot be used with
-`--subdomain`.
+URL to upload the sourcemaps to. Cannot be used with `--subdomain`.
 
 #### `--subdomain <string>`, `-s <string>`
 

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -94,6 +94,9 @@ URL to upload the sourcemaps to. Cannot be used with `--subdomain`.
 
 Subdomain to use for upload. You must also specify the `--token`. Cannot be used with `--url`.
 
+**Warning**: this will most likely not work on on-premise environments, due to the URL having format of
+`https://submit.backtrace.io/{{subdomain}}/{{token}}/sourcemap`.
+
 #### `--token <string>`, `-t <string>`
 
 Token to use with the upload. Usable only with `--subdomain`.
@@ -211,6 +214,9 @@ URL to upload the sourcemaps to. Cannot be used with `--subdomain`.
 #### `--subdomain <string>`, `-s <string>`
 
 Subdomain to use for upload. You must also specify the `--token`. Cannot be used with `--url`.
+
+**Warning**: this will most likely not work on on-premise environments, due to the URL having format of
+`https://submit.backtrace.io/{{subdomain}}/{{token}}/sourcemap`.
 
 #### `--token <string>`, `-t <string>`
 

--- a/tools/cli/src/options/loadOptions.ts
+++ b/tools/cli/src/options/loadOptions.ts
@@ -17,7 +17,7 @@ export function loadOptionsForCommand(path?: string) {
             path,
             (path) => (!readOptions ? loadOptions(path) : Ok(readOptions)),
             R.map((data) => (data ? (readOptions = data) : data)),
-            R.map((data) => (data ? joinOptions(key, defaults) : {})),
+            R.map((data) => (data ? joinOptions(key, defaults)(data) : {})),
         );
     };
 }

--- a/tools/cli/src/sourcemaps/run.ts
+++ b/tools/cli/src/sourcemaps/run.ts
@@ -331,7 +331,7 @@ export async function runSourcemapCommands({ opts, logger, getHelpMessage }: Com
                       : failIfEmpty('no processed sourcemaps found, make sure to run process'),
                   R.map(uniqueBy((asset) => asset.content.debugId)),
                   R.map((assets) =>
-                      opts['dry-run']
+                      uploadOptions['dry-run']
                           ? Ok({ rxid: '<dry-run>' })
                           : assets.length
                           ? saveArchiveCommand(assets)

--- a/tools/cli/src/sourcemaps/run.ts
+++ b/tools/cli/src/sourcemaps/run.ts
@@ -369,16 +369,23 @@ export async function runSourcemapCommands({ opts, logger, getHelpMessage }: Com
         R.map(flow(mapAsync(handleAssetCommand(runProcess, runAddSources)), R.flatMap)),
         R.map(filterBehaviorSkippedElements),
         R.map(
-            logInfo(
-                (assets) =>
-                    `processed ${assets.reduce((sum, r) => sum + (r.processed ? 1 : 0), 0)} source and sourcemaps`,
-            ),
+            runProcess
+                ? logInfo(
+                      (assets) =>
+                          `processed ${assets.reduce(
+                              (sum, r) => sum + (r.processed ? 1 : 0),
+                              0,
+                          )} source and sourcemaps`,
+                  )
+                : pass,
         ),
         R.map(
-            logInfo(
-                (assets) =>
-                    `added sources to ${assets.reduce((sum, r) => sum + (r.sourceAdded ? 1 : 0), 0)} sourcemaps`,
-            ),
+            runAddSources
+                ? logInfo(
+                      (assets) =>
+                          `added sources to ${assets.reduce((sum, r) => sum + (r.sourceAdded ? 1 : 0), 0)} sourcemaps`,
+                  )
+                : pass,
         ),
         R.map(uploadCommand ?? Ok),
     );

--- a/tools/cli/src/sourcemaps/run.ts
+++ b/tools/cli/src/sourcemaps/run.ts
@@ -112,7 +112,7 @@ export const runCmd = new Command<RunOptions>({
     .option({
         name: 'subdomain',
         type: String,
-        description: 'Subdomain to upload to.',
+        description: 'Subdomain to upload to. Do not use on on-premise environments.',
         alias: 's',
     })
     .option({

--- a/tools/cli/src/sourcemaps/run.ts
+++ b/tools/cli/src/sourcemaps/run.ts
@@ -326,7 +326,7 @@ export async function runSourcemapCommands({ opts, logger, getHelpMessage }: Com
                   logDebug(`running upload...`),
                   map((t) => t.sourceMap),
                   filterProcessedAssetsCommand,
-                  opts['pass-with-no-files']
+                  uploadOptions['pass-with-no-files']
                       ? Ok
                       : failIfEmpty('no processed sourcemaps found, make sure to run process'),
                   R.map(uniqueBy((asset) => asset.content.debugId)),

--- a/tools/cli/src/sourcemaps/upload.ts
+++ b/tools/cli/src/sourcemaps/upload.ts
@@ -97,7 +97,7 @@ export const uploadCmd = new Command<UploadOptions>({
     .option({
         name: 'subdomain',
         type: String,
-        description: 'Subdomain to upload to.',
+        description: 'Subdomain to upload to. Do not use on on-premise environments.',
         alias: 's',
     })
     .option({

--- a/tools/cli/src/sourcemaps/upload.ts
+++ b/tools/cli/src/sourcemaps/upload.ts
@@ -44,6 +44,8 @@ import { findConfig, loadOptionsForCommand } from '../options/loadOptions';
 
 export interface UploadOptions extends GlobalOptions {
     readonly url: string;
+    readonly subdomain: string;
+    readonly token: string;
     readonly path: string | string[];
     readonly include: string | string[];
     readonly exclude: string | string[];
@@ -91,6 +93,18 @@ export const uploadCmd = new Command<UploadOptions>({
         type: String,
         description: 'URL to upload to.',
         alias: 'u',
+    })
+    .option({
+        name: 'subdomain',
+        type: String,
+        description: 'Subdomain to upload to.',
+        alias: 's',
+    })
+    .option({
+        name: 'token',
+        type: String,
+        description: 'Symbol submission token. Required when subdomain is provided.',
+        alias: 't',
     })
     .option({
         name: 'include-sources',
@@ -227,7 +241,7 @@ export async function uploadSourcemaps({ opts, logger, getHelpMessage }: Command
         );
 
     const saveArchiveCommandResult = await uploadOrSaveAssets(
-        opts.url,
+        uploadUrl,
         opts.output,
         (url) => uploadAssets(url, { ignoreSsl: opts.insecure ?? false }, opts['include-sources'] ?? false),
         (path) => flow(saveAssets(path, opts['include-sources'] ?? false), Ok),
@@ -346,9 +360,21 @@ function pipeAssets(assets: AssetWithContent<RawSourceMapWithDebugId>[], include
     };
 }
 
-function getUploadUrl(opts: Partial<UploadOptions>): Result<string | undefined, string> {
+export function getUploadUrl(opts: Partial<UploadOptions>): Result<string | undefined, string> {
+    if (opts.url && opts.subdomain) {
+        return Err('--url and --subdomain are exclusive');
+    }
+
     if (opts.url) {
         return validateUrl(opts.url);
+    }
+
+    if (opts.subdomain) {
+        if (!opts.token) {
+            return Err('token is required with subdomain');
+        }
+
+        return Ok(`https://submit.backtrace.io/${opts.subdomain}/${opts.token}/sourcemap`);
     }
 
     return Ok(undefined);


### PR DESCRIPTION
This PR fixes some errors with CLI:
* bring back `subdomain` and `token` options
* display process and add-sources messages in run only if enabled
* fix loading config for subcommands
* fix dry-run and pass-with-no-files for upload
* update README