### PR TITLE
node: breadcrumbs from previous session in database

### DIFF
--- a/packages/node/src/BacktraceClient.ts
+++ b/packages/node/src/BacktraceClient.ts
@@ -4,6 +4,7 @@ import {
     BacktraceReport,
     BacktraceRequestHandler,
     BreadcrumbsEventSubscriber,
+    BreadcrumbsManager,
     BacktraceConfiguration as CoreConfiguration,
     DebugIdContainer,
     FileSystem,
@@ -12,6 +13,7 @@ import {
 import path from 'path';
 import { BacktraceConfiguration } from './BacktraceConfiguration';
 import { AGENT } from './agentDefinition';
+import { FileBreadcrumbsStorage } from './breadcrumbs/FileBreadcrumbsStorage';
 import { BacktraceClientBuilder } from './builder/BacktraceClientBuilder';
 import { NodeOptionReader } from './common/NodeOptionReader';
 import { NodeDiagnosticReportConverter } from './converter/NodeDiagnosticReportConverter';
@@ -37,6 +39,13 @@ export class BacktraceClient extends BacktraceCoreClient {
             },
             fileSystem,
         });
+
+        const breadcrumbsManager = this.modules.get(BreadcrumbsManager);
+        if (breadcrumbsManager && this.sessionFiles) {
+            breadcrumbsManager.setStorage(
+                FileBreadcrumbsStorage.create(this.sessionFiles, options.breadcrumbs?.maximumBreadcrumbs ?? 100),
+            );
+        }
     }
 
     public initialize(): void {

--- a/packages/node/src/breadcrumbs/FileBreadcrumbsStorage.ts
+++ b/packages/node/src/breadcrumbs/FileBreadcrumbsStorage.ts
@@ -24,8 +24,12 @@ export class FileBreadcrumbsStorage implements BreadcrumbsStorage {
 
     private readonly _writer: AlternatingFileWriter;
 
-    constructor(private readonly _file1: string, private readonly _file2: string, maximumBreadcrumbs: number) {
-        this._writer = new AlternatingFileWriter(_file1, _file2, maximumBreadcrumbs);
+    constructor(
+        private readonly _mainFile: string,
+        private readonly _fallbackFile: string,
+        maximumBreadcrumbs: number,
+    ) {
+        this._writer = new AlternatingFileWriter(_mainFile, _fallbackFile, maximumBreadcrumbs);
     }
 
     public static createFromSession(session: SessionFiles): FileBreadcrumbsStorage | undefined {
@@ -49,8 +53,8 @@ export class FileBreadcrumbsStorage implements BreadcrumbsStorage {
 
     public getAttachments(): BacktraceAttachment<unknown>[] {
         return [
-            new BacktraceFileAttachment(this._file1, 'bt-breadcrumbs-0'),
-            new BacktraceFileAttachment(this._file2, 'bt-breadcrumbs-1'),
+            new BacktraceFileAttachment(this._mainFile, 'bt-breadcrumbs-0'),
+            new BacktraceFileAttachment(this._fallbackFile, 'bt-breadcrumbs-1'),
         ];
     }
 

--- a/packages/node/src/breadcrumbs/FileBreadcrumbsStorage.ts
+++ b/packages/node/src/breadcrumbs/FileBreadcrumbsStorage.ts
@@ -1,0 +1,77 @@
+import {
+    BacktraceAttachment,
+    Breadcrumb,
+    BreadcrumbLogLevel,
+    BreadcrumbType,
+    BreadcrumbsStorage,
+    RawBreadcrumb,
+    SessionFiles,
+    TimeHelper,
+    jsonEscaper,
+} from '@backtrace-labs/sdk-core';
+import path from 'path';
+import { BacktraceFileAttachment } from '../attachment';
+import { AlternatingFileWriter } from '../common/AlternatingFileWriter';
+
+const FILE_PREFIX = 'breadcrumbs';
+
+export class FileBreadcrumbsStorage implements BreadcrumbsStorage {
+    public get lastBreadcrumbId(): number {
+        return this._lastBreadcrumbId;
+    }
+
+    private _lastBreadcrumbId: number = TimeHelper.toTimestampInSec(TimeHelper.now());
+
+    private readonly _writer: AlternatingFileWriter;
+
+    constructor(private readonly _file1: string, private readonly _file2: string, maximumBreadcrumbs: number) {
+        this._writer = new AlternatingFileWriter(_file1, _file2, maximumBreadcrumbs);
+    }
+
+    public static createFromSession(session: SessionFiles): FileBreadcrumbsStorage | undefined {
+        const files = session
+            .getSessionFiles()
+            .filter((f) => path.basename(f).startsWith(FILE_PREFIX))
+            .slice(0, 2);
+
+        if (!files.length) {
+            return undefined;
+        }
+
+        return new FileBreadcrumbsStorage(files[0], files[1], 1);
+    }
+
+    public static create(session: SessionFiles, maximumBreadcrumbs: number) {
+        const file1 = session.getFileName(this.getFileName(0));
+        const file2 = session.getFileName(this.getFileName(1));
+        return new FileBreadcrumbsStorage(file1, file2, maximumBreadcrumbs);
+    }
+
+    public getAttachments(): BacktraceAttachment<unknown>[] {
+        return [
+            new BacktraceFileAttachment(this._file1, 'bt-breadcrumbs-0'),
+            new BacktraceFileAttachment(this._file2, 'bt-breadcrumbs-1'),
+        ];
+    }
+
+    public add(rawBreadcrumb: RawBreadcrumb): number {
+        this._lastBreadcrumbId++;
+        const id = this._lastBreadcrumbId;
+        const breadcrumb: Breadcrumb = {
+            id,
+            message: rawBreadcrumb.message,
+            timestamp: TimeHelper.now(),
+            type: BreadcrumbType[rawBreadcrumb.type].toLowerCase(),
+            level: BreadcrumbLogLevel[rawBreadcrumb.level].toLowerCase(),
+        };
+
+        const breadcrumbJson = JSON.stringify(breadcrumb, jsonEscaper());
+        this._writer.writeLine(breadcrumbJson);
+
+        return id;
+    }
+
+    private static getFileName(index: number) {
+        return `${FILE_PREFIX}-${index}`;
+    }
+}

--- a/packages/node/src/common/AlternatingFileWriter.ts
+++ b/packages/node/src/common/AlternatingFileWriter.ts
@@ -1,0 +1,46 @@
+import fs from 'fs';
+
+export class AlternatingFileWriter {
+    private _fileStream?: fs.WriteStream;
+    private _count = 0;
+    private _disposed = false;
+
+    constructor(
+        private readonly _mainFile: string,
+        private readonly _fallbackFile: string,
+        private readonly _fileCapacity: number,
+    ) {
+        if (this._fileCapacity <= 0) {
+            throw new Error('File capacity may not be less or equal to 0.');
+        }
+    }
+
+    public async writeLine(value: string): Promise<this> {
+        if (this._disposed) {
+            throw new Error('This instance has been disposed.');
+        }
+
+        if (!this._fileStream) {
+            this._fileStream = fs.createWriteStream(this._mainFile, 'utf-8');
+        } else if (this._count >= this._fileCapacity) {
+            this._fileStream.close();
+            await fs.promises.rename(this._mainFile, this._fallbackFile);
+            this._count = 0;
+            this._fileStream = fs.createWriteStream(this._mainFile);
+        }
+
+        await this.writeAsync(this._fileStream, value + '\n');
+        this._count++;
+
+        return this;
+    }
+
+    private writeAsync(fs: fs.WriteStream, data: unknown) {
+        return new Promise<void>((resolve, reject) => fs.write(data, (err) => (err ? reject(err) : resolve())));
+    }
+
+    public dispose() {
+        this._fileStream?.close();
+        this._disposed = true;
+    }
+}

--- a/packages/node/src/common/AlternatingFileWriter.ts
+++ b/packages/node/src/common/AlternatingFileWriter.ts
@@ -26,7 +26,7 @@ export class AlternatingFileWriter {
             this._fileStream.close();
             await fs.promises.rename(this._mainFile, this._fallbackFile);
             this._count = 0;
-            this._fileStream = fs.createWriteStream(this._mainFile);
+            this._fileStream = fs.createWriteStream(this._mainFile, 'utf-8');
         }
 
         await this.writeAsync(this._fileStream, value + '\n');

--- a/packages/node/tests/.gitignore
+++ b/packages/node/tests/.gitignore
@@ -1,0 +1,1 @@
+_testOutput

--- a/packages/node/tests/common/alternatingFile.spec.ts
+++ b/packages/node/tests/common/alternatingFile.spec.ts
@@ -11,10 +11,13 @@ function unlinkSafe(file: string) {
 }
 
 describe('AlternatingFileWriter', () => {
-    const file1 = path.join(__dirname, '../_testOutput', 'alternating_file1');
-    const file2 = path.join(__dirname, '../_testOutput', 'alternating_file2');
+    const dir = path.join(__dirname, '../_testOutput');
+    const file1 = path.join(dir, 'alternating_file1');
+    const file2 = path.join(dir, 'alternating_file2');
 
     beforeAll(() => {
+        fs.mkdirSync(dir, { recursive: true });
+
         unlinkSafe(file1);
         unlinkSafe(file2);
     });

--- a/packages/node/tests/common/alternatingFile.spec.ts
+++ b/packages/node/tests/common/alternatingFile.spec.ts
@@ -1,0 +1,93 @@
+import fs from 'fs';
+import path from 'path';
+import { AlternatingFileWriter } from '../../src/common/AlternatingFileWriter';
+
+function unlinkSafe(file: string) {
+    try {
+        fs.unlinkSync(file);
+    } catch {
+        // Do nothing
+    }
+}
+
+describe('AlternatingFileWriter', () => {
+    const file1 = path.join(__dirname, '../_testOutput', 'alternating_file1');
+    const file2 = path.join(__dirname, '../_testOutput', 'alternating_file2');
+
+    beforeAll(() => {
+        unlinkSafe(file1);
+        unlinkSafe(file2);
+    });
+
+    afterEach(() => {
+        unlinkSafe(file1);
+        unlinkSafe(file2);
+    });
+
+    it('should add line to the main file', async () => {
+        const writer = new AlternatingFileWriter(file1, file2, 10);
+        await writer.writeLine('value');
+        writer.dispose();
+
+        const mainFile = await fs.promises.readFile(file1, 'utf-8');
+        expect(mainFile).toEqual('value\n');
+    });
+
+    it('should not move main file to fallback file before adding with fileCapacity reached', async () => {
+        const count = 5;
+        const writer = new AlternatingFileWriter(file1, file2, count);
+        for (let i = 0; i < count; i++) {
+            await writer.writeLine(`value-${i}`);
+        }
+        writer.dispose();
+
+        await expect(fs.promises.stat(file2)).rejects.toThrowError();
+    });
+
+    it('should move main file to fallback file after adding with fileCapacity reached', async () => {
+        const count = 5;
+        const writer = new AlternatingFileWriter(file1, file2, count);
+        for (let i = 0; i < count; i++) {
+            await writer.writeLine(`value-${i}`);
+        }
+
+        const mainFile = await fs.promises.readFile(file1, 'utf-8');
+        await writer.writeLine('value-x');
+        writer.dispose();
+
+        const fallbackFile = await fs.promises.readFile(file2, 'utf-8');
+        expect(fallbackFile).toEqual(mainFile);
+    });
+
+    it('should add line to the main file after adding with fileCapacity reached', async () => {
+        const count = 5;
+        const writer = new AlternatingFileWriter(file1, file2, count);
+        for (let i = 0; i < count; i++) {
+            await writer.writeLine(`value-${i}`);
+        }
+
+        await writer.writeLine('value-x');
+        writer.dispose();
+
+        const mainFile = await fs.promises.readFile(file1, 'utf-8');
+        expect(mainFile).toEqual('value-x\n');
+    });
+
+    it('should throw after adding line when disposed', async () => {
+        const writer = new AlternatingFileWriter(file1, file2, 10);
+        writer.dispose();
+        await expect(writer.writeLine('value-x')).rejects.toThrowError('This instance has been disposed.');
+    });
+
+    it('should throw when fileCapacity is 0', () => {
+        expect(() => new AlternatingFileWriter(file1, file2, 0)).toThrowError(
+            'File capacity may not be less or equal to 0.',
+        );
+    });
+
+    it('should throw when fileCapacity is less than 0', () => {
+        expect(() => new AlternatingFileWriter(file1, file2, -1)).toThrowError(
+            'File capacity may not be less or equal to 0.',
+        );
+    });
+});

--- a/packages/sdk-core/src/BacktraceCoreClient.ts
+++ b/packages/sdk-core/src/BacktraceCoreClient.ts
@@ -163,7 +163,12 @@ export abstract class BacktraceCoreClient {
             );
 
             if (this.fileSystem) {
-                const sessionFiles = new SessionFiles(this.fileSystem, this.options.database.path, this.sessionId);
+                const sessionFiles = new SessionFiles(
+                    this.fileSystem,
+                    this.options.database.path,
+                    this.sessionId,
+                    this.options.database.maximumOldSessions ?? 1,
+                );
                 this._modules.set(SessionFiles, sessionFiles);
             }
 

--- a/packages/sdk-core/src/BacktraceCoreClient.ts
+++ b/packages/sdk-core/src/BacktraceCoreClient.ts
@@ -307,7 +307,7 @@ export abstract class BacktraceCoreClient {
         }
     }
 
-    private generateSubmissionData(report: BacktraceReport): BacktraceData | undefined {
+    protected generateSubmissionData(report: BacktraceReport): BacktraceData | undefined {
         const backtraceData = this._dataBuilder.build(report);
         if (!this.options.beforeSend) {
             return backtraceData;

--- a/packages/sdk-core/src/BacktraceCoreClient.ts
+++ b/packages/sdk-core/src/BacktraceCoreClient.ts
@@ -7,6 +7,7 @@ import {
     DebugIdProvider,
     FileSystem,
     SdkOptions,
+    SessionFiles,
 } from '.';
 import { CoreClientSetup } from './builder/CoreClientSetup';
 import { Events } from './common/Events';
@@ -103,6 +104,10 @@ export abstract class BacktraceCoreClient {
         return this._modules;
     }
 
+    protected get sessionFiles() {
+        return this._modules.get(SessionFiles);
+    }
+
     protected readonly reportEvents: Events<ReportEvents>;
     protected readonly attributeManager: AttributeManager;
     protected readonly options: BacktraceConfiguration;
@@ -161,6 +166,11 @@ export abstract class BacktraceCoreClient {
                 const database = new BacktraceDatabase(this.options.database, provider, this._reportSubmission);
                 this._modules.set(BacktraceDatabase, database);
             }
+
+            if (this.fileSystem) {
+                const sessionFiles = new SessionFiles(this.fileSystem, this.options.database.path, this.sessionId);
+                this._modules.set(SessionFiles, sessionFiles);
+            }
         }
 
         const metrics = new MetricsBuilder(
@@ -197,8 +207,11 @@ export abstract class BacktraceCoreClient {
             if (module.bind) {
                 module.bind(this.getModuleBindData());
             }
+
             module.initialize();
         }
+
+        this.sessionFiles?.clearPreviousSessions();
     }
 
     /**

--- a/packages/sdk-core/src/BacktraceCoreClient.ts
+++ b/packages/sdk-core/src/BacktraceCoreClient.ts
@@ -238,10 +238,6 @@ export abstract class BacktraceCoreClient {
         this.attributeManager.add(attributes);
     }
 
-    public addAttributeProvider(attributeProvider: BacktraceAttributeProvider) {
-        this.attributeManager.addProvider(attributeProvider);
-    }
-
     /**
      * Add attachment to the client
      * @param attachment attachment

--- a/packages/sdk-core/src/BacktraceCoreClient.ts
+++ b/packages/sdk-core/src/BacktraceCoreClient.ts
@@ -176,8 +176,6 @@ export abstract class BacktraceCoreClient {
 
         if (this.options.breadcrumbs?.enable !== false) {
             const breadcrumbsManager = new BreadcrumbsManager(this.options?.breadcrumbs, this._setup.breadcrumbsSetup);
-            this._attachments.push(breadcrumbsManager.breadcrumbsStorage);
-            this.attributeManager.addProvider(breadcrumbsManager);
             this._modules.set(BreadcrumbsManager, breadcrumbsManager);
         }
 
@@ -215,6 +213,10 @@ export abstract class BacktraceCoreClient {
     public addAttribute(attributes: () => Record<string, unknown>): void;
     public addAttribute(attributes: Record<string, unknown> | (() => Record<string, unknown>)) {
         this.attributeManager.add(attributes);
+    }
+
+    public addAttributeProvider(attributeProvider: BacktraceAttributeProvider) {
+        this.attributeManager.addProvider(attributeProvider);
     }
 
     /**

--- a/packages/sdk-core/src/BacktraceCoreClient.ts
+++ b/packages/sdk-core/src/BacktraceCoreClient.ts
@@ -162,14 +162,19 @@ export abstract class BacktraceCoreClient {
                 this.options.database,
             );
 
-            if (provider) {
-                const database = new BacktraceDatabase(this.options.database, provider, this._reportSubmission);
-                this._modules.set(BacktraceDatabase, database);
-            }
-
             if (this.fileSystem) {
                 const sessionFiles = new SessionFiles(this.fileSystem, this.options.database.path, this.sessionId);
                 this._modules.set(SessionFiles, sessionFiles);
+            }
+
+            if (provider) {
+                const database = new BacktraceDatabase(
+                    this.options.database,
+                    provider,
+                    this._reportSubmission,
+                    this.sessionFiles,
+                );
+                this._modules.set(BacktraceDatabase, database);
             }
         }
 
@@ -334,6 +339,7 @@ export abstract class BacktraceCoreClient {
         return {
             client: this,
             reportEvents: this.reportEvents,
+            sessionFiles: this.sessionFiles,
         };
     }
 }

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -2,6 +2,7 @@ export * from './BacktraceCoreClient';
 export * from './builder/BacktraceCoreClientBuilder';
 export * from './builder/SdkOptions';
 export * from './common/IdGenerator';
+export * from './common/TimeHelper';
 export * from './common/jsonEscaper';
 export * from './model/attachment';
 export * from './model/configuration/BacktraceConfiguration';

--- a/packages/sdk-core/src/model/configuration/BacktraceDatabaseConfiguration.ts
+++ b/packages/sdk-core/src/model/configuration/BacktraceDatabaseConfiguration.ts
@@ -46,6 +46,8 @@ export interface EnabledBacktraceDatabaseConfiguration {
 
     /**
      * Controls how much previous session caches to preserve before sending data from previous sessions.
+     * This does not remove unsent reports, only session files, like breadcrumbs stored on disk.
+     *
      * The default value is 1
      */
     maximumOldSessions?: number;

--- a/packages/sdk-core/src/model/configuration/BacktraceDatabaseConfiguration.ts
+++ b/packages/sdk-core/src/model/configuration/BacktraceDatabaseConfiguration.ts
@@ -43,6 +43,12 @@ export interface EnabledBacktraceDatabaseConfiguration {
      * A crash report is generated, stored locally, and uploaded upon next start.
      */
     captureNativeCrashes?: boolean;
+
+    /**
+     * Controls how much previous session caches to preserve before sending data from previous sessions.
+     * The default value is 1
+     */
+    maximumOldSessions?: number;
 }
 
 export interface DisabledBacktraceDatabaseConfiguration

--- a/packages/sdk-core/src/modules/BacktraceModule.ts
+++ b/packages/sdk-core/src/modules/BacktraceModule.ts
@@ -1,10 +1,11 @@
-import { BacktraceCoreClient } from '..';
+import { BacktraceCoreClient, SessionFiles } from '..';
 import { Events } from '../common/Events';
 import { ReportEvents } from '../events/ReportEvents';
 
 export interface BacktraceModuleBindData {
     readonly client: BacktraceCoreClient;
     readonly reportEvents: Events<ReportEvents>;
+    readonly sessionFiles?: SessionFiles;
 }
 
 export interface BacktraceModule {

--- a/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
@@ -16,13 +16,13 @@ import { ConsoleEventSubscriber } from './events/ConsoleEventSubscriber';
 import { RawBreadcrumb } from './model/RawBreadcrumb';
 import { InMemoryBreadcrumbsStorage } from './storage/InMemoryBreadcrumbsStorage';
 
+const BREADCRUMB_ATTRIBUTE_NAME = 'breadcrumbs.lastId';
+
 export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule {
     /**
      * Breadcrumbs type
      */
     public readonly breadcrumbsType: BreadcrumbType;
-
-    public readonly BREADCRUMB_ATTRIBUTE_NAME = 'breadcrumbs.lastId';
 
     /**
      * Breadcrumbs Log level
@@ -63,7 +63,7 @@ export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule
             client.addAttachment(attachment);
         }
         client.addAttribute(() => ({
-            [this.BREADCRUMB_ATTRIBUTE_NAME]: this._storage.lastBreadcrumbId,
+            [BREADCRUMB_ATTRIBUTE_NAME]: this._storage.lastBreadcrumbId,
         }));
 
         reportEvents.on('before-skip', (report) => this.logReport(report));

--- a/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
@@ -3,6 +3,7 @@ import {
     BreadcrumbLogLevel,
     BreadcrumbType,
     BreadcrumbsSetup,
+    BreadcrumbsStorage,
     defaultBreadcrumbsLogLevel,
     defaultBreadcurmbType,
 } from '.';
@@ -13,7 +14,6 @@ import { BacktraceModule, BacktraceModuleBindData } from '../BacktraceModule';
 import { BreadcrumbsEventSubscriber } from './events/BreadcrurmbsEventSubscriber';
 import { ConsoleEventSubscriber } from './events/ConsoleEventSubscriber';
 import { RawBreadcrumb } from './model/RawBreadcrumb';
-import { BreadcrumbsStorage } from './storage/BreadcrumbsStorage';
 import { InMemoryBreadcrumbsStorage } from './storage/InMemoryBreadcrumbsStorage';
 
 export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule {
@@ -33,25 +33,27 @@ export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule
         return 'dynamic';
     }
 
-    public readonly breadcrumbsStorage: BreadcrumbsStorage;
-
     /**
      * Determines if the breadcrumb manager is enabled.
      */
     private _enabled = true;
 
     private readonly _eventSubscribers: BreadcrumbsEventSubscriber[] = [new ConsoleEventSubscriber()];
-
     private readonly _interceptor?: (breadcrumb: RawBreadcrumb) => RawBreadcrumb | undefined;
+    private _storage: BreadcrumbsStorage;
 
     constructor(configuration?: BacktraceBreadcrumbsSettings, options?: BreadcrumbsSetup) {
         this.breadcrumbsType = configuration?.eventType ?? defaultBreadcurmbType;
         this.logLevel = configuration?.logLevel ?? defaultBreadcrumbsLogLevel;
-        this.breadcrumbsStorage = options?.storage ?? new InMemoryBreadcrumbsStorage(configuration?.maximumBreadcrumbs);
+        this._storage = options?.storage ?? new InMemoryBreadcrumbsStorage(configuration?.maximumBreadcrumbs);
         this._interceptor = configuration?.intercept;
         if (options?.subscribers) {
             this._eventSubscribers.push(...options.subscribers);
         }
+    }
+
+    public setStorage(storage: BreadcrumbsStorage) {
+        this._storage = storage;
     }
 
     public dispose(): void {
@@ -63,11 +65,16 @@ export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule
 
     public get(): Record<string, number> {
         return {
-            [this.BREADCRUMB_ATTRIBUTE_NAME]: this.breadcrumbsStorage.lastBreadcrumbId,
+            [this.BREADCRUMB_ATTRIBUTE_NAME]: this._storage.lastBreadcrumbId,
         };
     }
 
-    public bind({ reportEvents }: BacktraceModuleBindData): void {
+    public bind({ client, reportEvents }: BacktraceModuleBindData): void {
+        for (const attachment of this._storage.getAttachments()) {
+            client.addAttachment(attachment);
+        }
+        client.addAttributeProvider(this);
+
         reportEvents.on('before-skip', (report) => this.logReport(report));
     }
 
@@ -136,7 +143,7 @@ export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule
             return false;
         }
 
-        this.breadcrumbsStorage.add(rawBreadcrumb);
+        this._storage.add(rawBreadcrumb);
         return true;
     }
 }

--- a/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
@@ -28,11 +28,6 @@ export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule
      * Breadcrumbs Log level
      */
     public readonly logLevel: BreadcrumbLogLevel;
-
-    get type(): 'scoped' | 'dynamic' {
-        return 'dynamic';
-    }
-
     /**
      * Determines if the breadcrumb manager is enabled.
      */
@@ -63,17 +58,13 @@ export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule
         }
     }
 
-    public get(): Record<string, number> {
-        return {
-            [this.BREADCRUMB_ATTRIBUTE_NAME]: this._storage.lastBreadcrumbId,
-        };
-    }
-
     public bind({ client, reportEvents }: BacktraceModuleBindData): void {
         for (const attachment of this._storage.getAttachments()) {
             client.addAttachment(attachment);
         }
-        client.addAttributeProvider(this);
+        client.addAttribute(() => ({
+            [this.BREADCRUMB_ATTRIBUTE_NAME]: this._storage.lastBreadcrumbId,
+        }));
 
         reportEvents.on('before-skip', (report) => this.logReport(report));
     }

--- a/packages/sdk-core/src/modules/breadcrumbs/index.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/index.ts
@@ -2,6 +2,7 @@ export * from './BacktraceBreadcrumbs';
 export * from './BreadcrumbsManager';
 export * from './BreadcrumbsSetup';
 export * from './events/BreadcrurmbsEventSubscriber';
+export * from './model/Breadcrumb';
 export * from './model/BreadcrumbLogLevel';
 export * from './model/BreadcrumbType';
 export * from './model/RawBreadcrumb';

--- a/packages/sdk-core/src/modules/breadcrumbs/storage/BreadcrumbsStorage.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/storage/BreadcrumbsStorage.ts
@@ -1,7 +1,7 @@
 import { BacktraceAttachment } from '../../../model/attachment';
 import { RawBreadcrumb } from '../model/RawBreadcrumb';
 
-export interface BreadcrumbsStorage extends BacktraceAttachment {
+export interface BreadcrumbsStorage {
     /**
      * Id of the last breadcrumb added to the SDK
      */
@@ -12,4 +12,9 @@ export interface BreadcrumbsStorage extends BacktraceAttachment {
      * @param rawBreadcrumb breadcrumb data
      */
     add(rawBreadcrumb: RawBreadcrumb): number;
+
+    /**
+     * Gets attachments associated with this storage.
+     */
+    getAttachments(): BacktraceAttachment[];
 }

--- a/packages/sdk-core/src/modules/breadcrumbs/storage/InMemoryBreadcrumbsStorage.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/storage/InMemoryBreadcrumbsStorage.ts
@@ -1,13 +1,14 @@
 import { jsonEscaper } from '../../../common/jsonEscaper';
 import { TimeHelper } from '../../../common/TimeHelper';
 import { OverwritingArray } from '../../../dataStructures/OverwritingArray';
+import { BacktraceAttachment } from '../../../model/attachment';
 import { Breadcrumb } from '../model/Breadcrumb';
 import { BreadcrumbLogLevel } from '../model/BreadcrumbLogLevel';
 import { BreadcrumbType } from '../model/BreadcrumbType';
 import { RawBreadcrumb } from '../model/RawBreadcrumb';
 import { BreadcrumbsStorage } from './BreadcrumbsStorage';
 
-export class InMemoryBreadcrumbsStorage implements BreadcrumbsStorage {
+export class InMemoryBreadcrumbsStorage implements BreadcrumbsStorage, BacktraceAttachment {
     public get lastBreadcrumbId(): number {
         return this._lastBreadcrumbId;
     }
@@ -21,6 +22,10 @@ export class InMemoryBreadcrumbsStorage implements BreadcrumbsStorage {
 
     constructor(maximumBreadcrumbs = 100) {
         this._breadcrumbs = new OverwritingArray<Breadcrumb>(maximumBreadcrumbs);
+    }
+
+    public getAttachments(): BacktraceAttachment<unknown>[] {
+        return [this];
     }
 
     /**

--- a/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
+++ b/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
@@ -5,6 +5,7 @@ import { BacktraceDatabaseConfiguration } from '../../model/configuration/Backtr
 import { BacktraceData } from '../../model/data/BacktraceData';
 import { BacktraceReportSubmission } from '../../model/http/BacktraceReportSubmission';
 import { BacktraceModule, BacktraceModuleBindData } from '../BacktraceModule';
+import { SessionFiles } from '../storage';
 import { BacktraceDatabaseContext } from './BacktraceDatabaseContext';
 import { BacktraceDatabaseStorageProvider } from './BacktraceDatabaseStorageProvider';
 import { BacktraceDatabaseRecord } from './model/BacktraceDatabaseRecord';
@@ -30,6 +31,7 @@ export class BacktraceDatabase implements BacktraceModule {
         private readonly _options: BacktraceDatabaseConfiguration | undefined,
         private readonly _storageProvider: BacktraceDatabaseStorageProvider,
         private readonly _requestHandler: BacktraceReportSubmission,
+        private readonly _sessionFiles?: SessionFiles,
     ) {
         this._databaseRecordContext = new BacktraceDatabaseContext(this._options?.maximumRetries);
         this._maximumRecords = this._options?.maximumNumberOfRecords ?? 8;
@@ -54,9 +56,13 @@ export class BacktraceDatabase implements BacktraceModule {
             return false;
         }
 
-        this.loadReports().then(async () => {
-            await this.setupDatabaseAutoSend();
-        });
+        const lockId = this._sessionFiles?.lockPreviousSessions();
+        this.loadReports()
+            .then(() => {
+                this.setupDatabaseAutoSend();
+            })
+            .finally(() => lockId && this._sessionFiles?.unlockPreviousSessions(lockId));
+
         this._enabled = true;
         return true;
     }
@@ -88,6 +94,7 @@ export class BacktraceDatabase implements BacktraceModule {
             record.locked = false;
             if (submissionResult.status === 'Ok') {
                 this.remove(record);
+                this._sessionFiles?.unlockPreviousSessions(record.id);
             }
         });
     }
@@ -124,6 +131,7 @@ export class BacktraceDatabase implements BacktraceModule {
         }
 
         this._databaseRecordContext.add(record);
+        this.lockSessionWithRecord(record);
 
         return record;
     }
@@ -198,6 +206,7 @@ export class BacktraceDatabase implements BacktraceModule {
                     const result = await this._requestHandler.send(record.data, record.attachments);
                     if (result.status === 'Ok') {
                         this.remove(record);
+                        this._sessionFiles?.unlockPreviousSessions(record.id);
                         continue;
                     }
                     this._databaseRecordContext.increaseBucket(bucketIndex);
@@ -224,13 +233,17 @@ export class BacktraceDatabase implements BacktraceModule {
         }
     }
 
-    private async loadReports(): Promise<void> {
+    private async loadReports() {
         const records = await this._storageProvider.get();
         if (records.length > this._maximumRecords) {
             records.length = this._maximumRecords;
         }
         this.prepareDatabase(records.length);
         this._databaseRecordContext.load(records);
+
+        for (const record of records) {
+            this.lockSessionWithRecord(record);
+        }
     }
 
     private async setupDatabaseAutoSend() {
@@ -243,5 +256,20 @@ export class BacktraceDatabase implements BacktraceModule {
         };
         this._intervalId = setInterval(sendDatabaseReports, this._retryInterval);
         await this.send();
+    }
+
+    private lockSessionWithRecord(record: BacktraceDatabaseRecord) {
+        if (!this._sessionFiles) {
+            return;
+        }
+
+        const sessionId = record.data.attributes['application.session'];
+        if (typeof sessionId !== 'string') {
+            this._sessionFiles.lockPreviousSessions(record.id);
+            return;
+        }
+
+        const session = this._sessionFiles.getSessionWithId(sessionId);
+        session?.lock(record.id);
     }
 }

--- a/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
+++ b/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
@@ -263,7 +263,7 @@ export class BacktraceDatabase implements BacktraceModule {
             return;
         }
 
-        const sessionId = record.data.attributes['application.session'];
+        const sessionId = record.data.attributes?.['application.session'];
         if (typeof sessionId !== 'string') {
             this._sessionFiles.lockPreviousSessions(record.id);
             return;

--- a/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
+++ b/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
@@ -170,6 +170,7 @@ export class BacktraceDatabase implements BacktraceModule {
         }
         this._databaseRecordContext.remove(record);
         this._storageProvider.delete(record);
+        this._sessionFiles?.unlockPreviousSessions(record.id);
     }
 
     public addStorageProvider(storageProvider: BacktraceDatabaseStorageProvider) {
@@ -206,7 +207,6 @@ export class BacktraceDatabase implements BacktraceModule {
                     const result = await this._requestHandler.send(record.data, record.attachments);
                     if (result.status === 'Ok') {
                         this.remove(record);
-                        this._sessionFiles?.unlockPreviousSessions(record.id);
                         continue;
                     }
                     this._databaseRecordContext.increaseBucket(bucketIndex);

--- a/packages/sdk-core/src/modules/storage/SessionFiles.ts
+++ b/packages/sdk-core/src/modules/storage/SessionFiles.ts
@@ -1,0 +1,213 @@
+import { Events } from '../../common/Events';
+import { IdGenerator } from '../../common/IdGenerator';
+import { BacktraceModule } from '../BacktraceModule';
+import { FileSystem } from './FileSystem';
+
+interface FileSession {
+    readonly file: string;
+    readonly sessionId: string;
+    readonly escapedSessionId: string;
+    readonly timestamp: number;
+}
+
+type SessionEvents = {
+    unlocked(): void;
+};
+
+const SESSION_MARKER_PREFIX = 'bt-session';
+
+const isDefined = <T>(t: T | undefined): t is T => !!t;
+
+export class SessionFiles implements BacktraceModule {
+    private readonly _timestamp: number;
+    private readonly _events = new Events<SessionEvents>();
+    private readonly _escapedSessionId: string;
+    private readonly _locks: string[] = [];
+    private _previousSession?: SessionFiles;
+    private _cleared = false;
+
+    constructor(
+        private readonly _fileSystem: FileSystem,
+        private readonly _directory: string,
+        private readonly _sessionId: string,
+        timestamp?: number,
+    ) {
+        this._timestamp = timestamp ?? Date.now();
+        this._escapedSessionId = SessionFiles.escapeFileName(_sessionId);
+    }
+
+    public initialize(): void {
+        this.createSessionMarker();
+    }
+
+    public static create(fileSystem: FileSystem, directory: string, sessionId: string, timestamp?: number) {
+        const sessionFiles = new SessionFiles(fileSystem, directory, sessionId, timestamp);
+        return sessionFiles;
+    }
+
+    public getPreviousSession() {
+        if (this._previousSession) {
+            return this._previousSession;
+        }
+
+        const directoryFiles = this.readDirectoryFiles();
+        if (!directoryFiles.length) {
+            return undefined;
+        }
+
+        const sessionMarkers = directoryFiles
+            .filter((f) => f.startsWith(SESSION_MARKER_PREFIX))
+            .map((f) => SessionFiles.getFileSession(f))
+            .filter(isDefined);
+
+        const currentSessionMarker = sessionMarkers.find((s) => s.sessionId === this._sessionId);
+
+        const lastSessionMarker = directoryFiles
+            .filter((f) => f.startsWith(SESSION_MARKER_PREFIX))
+            .map((file) => SessionFiles.getFileSession(file))
+            .filter(isDefined)
+            .sort((a, b) => b.timestamp - a.timestamp)
+            .filter(({ timestamp }) => !currentSessionMarker || currentSessionMarker.timestamp > timestamp)[0];
+
+        if (!lastSessionMarker) {
+            return undefined;
+        }
+
+        return (this._previousSession = new SessionFiles(
+            this._fileSystem,
+            this._directory,
+            lastSessionMarker.sessionId,
+            lastSessionMarker.timestamp,
+        ));
+    }
+
+    public clearPreviousSessions() {
+        let current = this.getPreviousSession();
+        while (current) {
+            current.clearSession();
+            current = current.getPreviousSession();
+        }
+    }
+
+    public getFileName(prefix: string) {
+        this.throwIfCleared();
+
+        return (
+            this._directory +
+            '/' +
+            `${SessionFiles.escapeFileName(prefix)}_${this._escapedSessionId}_${this._timestamp}`
+        );
+    }
+
+    public getSessionFiles() {
+        this.throwIfCleared();
+
+        const files = this.readDirectoryFiles();
+        return files
+            .map((file) => SessionFiles.getFileSession(file))
+            .filter(isDefined)
+            .filter(({ sessionId }) => sessionId === this._sessionId)
+            .map(({ file }) => this._directory + '/' + file);
+    }
+
+    public clearSession(deleteMarker = true) {
+        if (this._locks.length > 0) {
+            this._events.once('unlocked', () => this.clearSession(deleteMarker));
+            return;
+        }
+
+        if (this._cleared) {
+            return;
+        }
+
+        try {
+            const sessionFiles = this.getSessionFiles();
+            for (const file of sessionFiles) {
+                if (!deleteMarker && file.startsWith(SESSION_MARKER_PREFIX)) {
+                    continue;
+                }
+
+                this._fileSystem.unlinkSync(file);
+            }
+        } catch {
+            // Don't propagate errors
+        } finally {
+            this._cleared = true;
+        }
+    }
+
+    public lock() {
+        const lockId = IdGenerator.uuid();
+        this._locks.push(lockId);
+        return lockId;
+    }
+
+    public unlock(lockId: string) {
+        const index = this._locks.indexOf(lockId);
+        if (index === -1) {
+            return;
+        }
+
+        this._locks.splice(index, 1);
+        if (this._locks.length === 0) {
+            this._events.emit('unlocked');
+        }
+    }
+
+    private static getFileSession(file: string): FileSession | undefined {
+        const [escapedSessionId, rawTimestamp] = this.splitByOneChar(file, '_').slice(-2);
+        const timestamp = parseInt(rawTimestamp);
+        if (isNaN(timestamp)) {
+            return undefined;
+        }
+
+        return { file, escapedSessionId, timestamp, sessionId: this.unescapeFileName(escapedSessionId) };
+    }
+
+    private readDirectoryFiles() {
+        try {
+            return this._fileSystem.readDirSync(this._directory);
+        } catch {
+            return [];
+        }
+    }
+
+    private createSessionMarker() {
+        const fileName = this.getFileName(SESSION_MARKER_PREFIX);
+        this._fileSystem.writeFileSync(fileName, '');
+    }
+
+    private static escapeFileName(name: string) {
+        return name.replace(/_/g, '__');
+    }
+
+    private static unescapeFileName(name: string) {
+        return name.replace(/__/g, '_');
+    }
+
+    private static splitByOneChar(str: string, char: string) {
+        const result: string[] = [];
+        let start = 0;
+        let index = str.indexOf(char);
+
+        while (index !== -1) {
+            if (str[index + 1] === char) {
+                index = str.indexOf(char, index + 2);
+            } else {
+                result.push(str.substring(start, index));
+                start = index + 1;
+                index = str.indexOf(char, start);
+            }
+        }
+
+        result.push(str.substring(start));
+
+        return result;
+    }
+
+    private throwIfCleared() {
+        if (this._cleared) {
+            throw new Error('This session files are cleared.');
+        }
+    }
+}

--- a/packages/sdk-core/src/modules/storage/SessionFiles.ts
+++ b/packages/sdk-core/src/modules/storage/SessionFiles.ts
@@ -56,13 +56,14 @@ export class SessionFiles implements BacktraceModule {
         const sessionMarkers = directoryFiles
             .filter((f) => f.startsWith(SESSION_MARKER_PREFIX))
             .map((f) => this.getFileSession(f))
-            .filter(isDefined);
+            .filter(isDefined)
+            .sort((a, b) => b.timestamp - a.timestamp);
 
         const currentSessionMarker = sessionMarkers.find((s) => s.sessionId === this.sessionId);
 
-        const lastSessionMarker = sessionMarkers
-            .sort((a, b) => b.timestamp - a.timestamp)
-            .filter(({ timestamp }) => !currentSessionMarker || currentSessionMarker.timestamp > timestamp)[0];
+        const lastSessionMarker = currentSessionMarker
+            ? sessionMarkers.filter(({ timestamp }) => currentSessionMarker.timestamp > timestamp)[0]
+            : sessionMarkers[0];
 
         if (!lastSessionMarker) {
             return undefined;

--- a/packages/sdk-core/src/modules/storage/index.ts
+++ b/packages/sdk-core/src/modules/storage/index.ts
@@ -1,1 +1,2 @@
 export * from './FileSystem';
+export * from './SessionFiles';

--- a/packages/sdk-core/tests/breadcrumbs/breadcrumbsCreationTests.spec.ts
+++ b/packages/sdk-core/tests/breadcrumbs/breadcrumbsCreationTests.spec.ts
@@ -5,13 +5,12 @@ import { InMemoryBreadcrumbsStorage } from '../../src/modules/breadcrumbs/storag
 describe('Breadcrumbs creation tests', () => {
     it('Last breadcrumb id attribute should be equal to last bredcrumb id in the array', () => {
         const storage = new InMemoryBreadcrumbsStorage(100);
-        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage });
-        breadcrumbsManager.info('test');
+        storage.add({ level: BreadcrumbLogLevel.Info, message: 'test', type: BreadcrumbType.Manual });
 
-        const attributes = breadcrumbsManager.get();
+        const lastBreadcrumbId = storage.lastBreadcrumbId;
         const [breadcrumb] = JSON.parse(storage.get() as string);
 
-        expect(breadcrumb.id).toEqual(attributes[breadcrumbsManager.BREADCRUMB_ATTRIBUTE_NAME]);
+        expect(breadcrumb.id).toEqual(lastBreadcrumbId);
     });
 
     it('Each breadcrumb should have different id', () => {
@@ -26,16 +25,14 @@ describe('Breadcrumbs creation tests', () => {
     });
 
     it('Should update breadcrumb id every time after adding a breadcrumb', () => {
-        const breadcrumbsManager = new BreadcrumbsManager();
+        const storage = new InMemoryBreadcrumbsStorage(100);
 
-        breadcrumbsManager.info('test');
-        const attributes1 = breadcrumbsManager.get();
-        breadcrumbsManager.info('test2');
-        const attributes2 = breadcrumbsManager.get();
+        storage.add({ level: BreadcrumbLogLevel.Info, message: 'test', type: BreadcrumbType.Manual });
+        const breadcrumbId1 = storage.lastBreadcrumbId;
+        storage.add({ level: BreadcrumbLogLevel.Info, message: 'test', type: BreadcrumbType.Manual });
+        const breadcrumbId2 = storage.lastBreadcrumbId;
 
-        expect(attributes1[breadcrumbsManager.BREADCRUMB_ATTRIBUTE_NAME] as number).toBeLessThan(
-            attributes2[breadcrumbsManager.BREADCRUMB_ATTRIBUTE_NAME] as number,
-        );
+        expect(breadcrumbId1).toBeLessThan(breadcrumbId2);
     });
 
     it('Should set expected breadcrumb message', () => {

--- a/packages/sdk-core/tests/breadcrumbs/breadcrumbsCreationTests.spec.ts
+++ b/packages/sdk-core/tests/breadcrumbs/breadcrumbsCreationTests.spec.ts
@@ -1,23 +1,26 @@
 import { BreadcrumbLogLevel, BreadcrumbType } from '../../src/modules/breadcrumbs';
 import { BreadcrumbsManager } from '../../src/modules/breadcrumbs/BreadcrumbsManager';
+import { InMemoryBreadcrumbsStorage } from '../../src/modules/breadcrumbs/storage/InMemoryBreadcrumbsStorage';
 
 describe('Breadcrumbs creation tests', () => {
     it('Last breadcrumb id attribute should be equal to last bredcrumb id in the array', () => {
-        const breadcrumbsManager = new BreadcrumbsManager();
+        const storage = new InMemoryBreadcrumbsStorage(100);
+        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage });
         breadcrumbsManager.info('test');
 
         const attributes = breadcrumbsManager.get();
-        const [breadcrumb] = JSON.parse(breadcrumbsManager.breadcrumbsStorage.get() as string);
+        const [breadcrumb] = JSON.parse(storage.get() as string);
 
         expect(breadcrumb.id).toEqual(attributes[breadcrumbsManager.BREADCRUMB_ATTRIBUTE_NAME]);
     });
 
     it('Each breadcrumb should have different id', () => {
-        const breadcrumbsManager = new BreadcrumbsManager();
+        const storage = new InMemoryBreadcrumbsStorage(100);
+        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage });
         breadcrumbsManager.info('test');
         breadcrumbsManager.info('test2');
 
-        const attachment = JSON.parse(breadcrumbsManager.breadcrumbsStorage.get() as string);
+        const attachment = JSON.parse(storage.get() as string);
 
         expect(attachment[0].id).toBeLessThan(attachment[1].id);
     });
@@ -37,9 +40,10 @@ describe('Breadcrumbs creation tests', () => {
 
     it('Should set expected breadcrumb message', () => {
         const message = 'test';
-        const breadcrumbsManager = new BreadcrumbsManager();
+        const storage = new InMemoryBreadcrumbsStorage(100);
+        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage });
         breadcrumbsManager.info(message);
-        const [breadcrumb] = JSON.parse(breadcrumbsManager.breadcrumbsStorage.get() as string);
+        const [breadcrumb] = JSON.parse(storage.get() as string);
 
         expect(breadcrumb.message).toEqual(message);
     });
@@ -47,9 +51,10 @@ describe('Breadcrumbs creation tests', () => {
     it('Should set expected breadcrumb level', () => {
         const message = 'test';
         const level = BreadcrumbLogLevel.Warning;
-        const breadcrumbsManager = new BreadcrumbsManager();
+        const storage = new InMemoryBreadcrumbsStorage(100);
+        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage });
         breadcrumbsManager.log(message, level);
-        const [breadcrumb] = JSON.parse(breadcrumbsManager.breadcrumbsStorage.get() as string);
+        const [breadcrumb] = JSON.parse(storage.get() as string);
 
         expect(breadcrumb.level).toEqual(BreadcrumbLogLevel[level].toLowerCase());
     });
@@ -58,9 +63,10 @@ describe('Breadcrumbs creation tests', () => {
         const message = 'test';
         const level = BreadcrumbLogLevel.Warning;
         const type = BreadcrumbType.Configuration;
-        const breadcrumbsManager = new BreadcrumbsManager();
+        const storage = new InMemoryBreadcrumbsStorage(100);
+        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage });
         breadcrumbsManager.addBreadcrumb(message, level, type);
-        const [breadcrumb] = JSON.parse(breadcrumbsManager.breadcrumbsStorage.get() as string);
+        const [breadcrumb] = JSON.parse(storage.get() as string);
 
         expect(breadcrumb.type).toEqual(BreadcrumbType[type].toLowerCase());
     });
@@ -69,9 +75,10 @@ describe('Breadcrumbs creation tests', () => {
         const message = 'test';
         const level = BreadcrumbLogLevel.Warning;
         const attributes = { foo: 'bar', baz: 1 };
-        const breadcrumbsManager = new BreadcrumbsManager();
+        const storage = new InMemoryBreadcrumbsStorage(100);
+        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage });
         breadcrumbsManager.log(message, level, attributes);
-        const [breadcrumb] = JSON.parse(breadcrumbsManager.breadcrumbsStorage.get() as string);
+        const [breadcrumb] = JSON.parse(storage.get() as string);
 
         expect(breadcrumb.attributes).toMatchObject(attributes);
     });

--- a/packages/sdk-core/tests/breadcrumbs/breadcrumbsFilteringOptionsTests.spec.ts
+++ b/packages/sdk-core/tests/breadcrumbs/breadcrumbsFilteringOptionsTests.spec.ts
@@ -1,16 +1,23 @@
 import { BreadcrumbLogLevel, BreadcrumbType } from '../../src/modules/breadcrumbs';
 import { BreadcrumbsManager } from '../../src/modules/breadcrumbs/BreadcrumbsManager';
+import { InMemoryBreadcrumbsStorage } from '../../src/modules/breadcrumbs/storage/InMemoryBreadcrumbsStorage';
 
 describe('Breadcrumbs filtering options tests', () => {
     describe('Event type tests', () => {
         it('Should filter out breadcrumbs based on the event type', () => {
             const message = 'test';
-            const breadcrumbsManager = new BreadcrumbsManager({
-                eventType: BreadcrumbType.Configuration,
-            });
+            const storage = new InMemoryBreadcrumbsStorage(100);
+            const breadcrumbsManager = new BreadcrumbsManager(
+                {
+                    eventType: BreadcrumbType.Configuration,
+                },
+                {
+                    storage,
+                },
+            );
 
             const result = breadcrumbsManager.addBreadcrumb(message, BreadcrumbLogLevel.Debug, BreadcrumbType.Http);
-            const breadcrumbs = JSON.parse(breadcrumbsManager.breadcrumbsStorage.get() as string);
+            const breadcrumbs = JSON.parse(storage.get() as string);
             expect(result).toBeFalsy();
             expect(breadcrumbs.length).toEqual(0);
         });
@@ -18,12 +25,18 @@ describe('Breadcrumbs filtering options tests', () => {
         it('Should allow to add a breadcrumb with allowed event type', () => {
             const message = 'test';
             const allowedBreadcrumbType = BreadcrumbType.Configuration;
-            const breadcrumbsManager = new BreadcrumbsManager({
-                eventType: allowedBreadcrumbType,
-            });
+            const storage = new InMemoryBreadcrumbsStorage(100);
+            const breadcrumbsManager = new BreadcrumbsManager(
+                {
+                    eventType: allowedBreadcrumbType,
+                },
+                {
+                    storage,
+                },
+            );
 
             const result = breadcrumbsManager.addBreadcrumb(message, BreadcrumbLogLevel.Debug, allowedBreadcrumbType);
-            const [breadcrumb] = JSON.parse(breadcrumbsManager.breadcrumbsStorage.get() as string);
+            const [breadcrumb] = JSON.parse(storage.get() as string);
             expect(result).toBeTruthy();
             expect(breadcrumb.type).toEqual(BreadcrumbType[allowedBreadcrumbType].toLowerCase());
         });
@@ -32,12 +45,18 @@ describe('Breadcrumbs filtering options tests', () => {
     describe('Log level tests', () => {
         it('Should filter out breadcrumbs based on the log level', () => {
             const message = 'test';
-            const breadcrumbsManager = new BreadcrumbsManager({
-                logLevel: BreadcrumbLogLevel.Error,
-            });
+            const storage = new InMemoryBreadcrumbsStorage(100);
+            const breadcrumbsManager = new BreadcrumbsManager(
+                {
+                    logLevel: BreadcrumbLogLevel.Error,
+                },
+                {
+                    storage,
+                },
+            );
 
             const result = breadcrumbsManager.addBreadcrumb(message, BreadcrumbLogLevel.Debug, BreadcrumbType.Http);
-            const breadcrumbs = JSON.parse(breadcrumbsManager.breadcrumbsStorage.get() as string);
+            const breadcrumbs = JSON.parse(storage.get() as string);
             expect(result).toBeFalsy();
             expect(breadcrumbs.length).toEqual(0);
         });
@@ -45,12 +64,18 @@ describe('Breadcrumbs filtering options tests', () => {
         it('Should allow to add a breadcrumb with allowed log level', () => {
             const message = 'test';
             const allowedLogLevel = BreadcrumbLogLevel.Debug;
-            const breadcrumbsManager = new BreadcrumbsManager({
-                logLevel: allowedLogLevel,
-            });
+            const storage = new InMemoryBreadcrumbsStorage(100);
+            const breadcrumbsManager = new BreadcrumbsManager(
+                {
+                    logLevel: allowedLogLevel,
+                },
+                {
+                    storage,
+                },
+            );
 
             const result = breadcrumbsManager.addBreadcrumb(message, allowedLogLevel, BreadcrumbType.Http);
-            const [breadcrumb] = JSON.parse(breadcrumbsManager.breadcrumbsStorage.get() as string);
+            const [breadcrumb] = JSON.parse(storage.get() as string);
             expect(result).toBeTruthy();
             expect(breadcrumb.level).toEqual(BreadcrumbLogLevel[allowedLogLevel].toLowerCase());
         });
@@ -91,9 +116,15 @@ describe('Breadcrumbs filtering options tests', () => {
     describe('Breadcrumbs overflow tests', () => {
         it('Should always store maximum breadcrumbs', () => {
             const maximumBreadcrumbs = 2;
-            const breadcrumbsManager = new BreadcrumbsManager({
-                maximumBreadcrumbs,
-            });
+            const storage = new InMemoryBreadcrumbsStorage(maximumBreadcrumbs);
+            const breadcrumbsManager = new BreadcrumbsManager(
+                {
+                    maximumBreadcrumbs,
+                },
+                {
+                    storage,
+                },
+            );
             for (let index = 0; index < maximumBreadcrumbs; index++) {
                 breadcrumbsManager.error(index.toString());
             }
@@ -103,7 +134,7 @@ describe('Breadcrumbs filtering options tests', () => {
                 BreadcrumbLogLevel.Debug,
                 BreadcrumbType.Configuration,
             );
-            const breadcrumbs = JSON.parse(breadcrumbsManager.breadcrumbsStorage.get() as string);
+            const breadcrumbs = JSON.parse(storage.get() as string);
 
             expect(addResult).toBeTruthy();
             expect(breadcrumbs.length).toEqual(maximumBreadcrumbs);
@@ -111,9 +142,15 @@ describe('Breadcrumbs filtering options tests', () => {
 
         it('Should drop the oldest event to free up the space for the new one', () => {
             const maximumBreadcrumbs = 2;
-            const breadcrumbsManager = new BreadcrumbsManager({
-                maximumBreadcrumbs,
-            });
+            const storage = new InMemoryBreadcrumbsStorage(maximumBreadcrumbs);
+            const breadcrumbsManager = new BreadcrumbsManager(
+                {
+                    maximumBreadcrumbs,
+                },
+                {
+                    storage,
+                },
+            );
             const expectedBreadcrumbMessage = 'after free space';
             for (let index = 0; index < maximumBreadcrumbs; index++) {
                 breadcrumbsManager.error(index.toString());
@@ -124,7 +161,7 @@ describe('Breadcrumbs filtering options tests', () => {
                 BreadcrumbLogLevel.Debug,
                 BreadcrumbType.Configuration,
             );
-            const breadcrumbs = JSON.parse(breadcrumbsManager.breadcrumbsStorage.get() as string);
+            const breadcrumbs = JSON.parse(storage.get() as string);
 
             expect(addResult).toBeTruthy();
             expect(breadcrumbs[breadcrumbs.length - 1].message).toEqual(expectedBreadcrumbMessage);

--- a/packages/sdk-core/tests/breadcrumbs/breadcrumbsInterceptorTests.spec.ts
+++ b/packages/sdk-core/tests/breadcrumbs/breadcrumbsInterceptorTests.spec.ts
@@ -1,26 +1,39 @@
 import { BreadcrumbsManager } from '../../src/modules/breadcrumbs/BreadcrumbsManager';
 import { Breadcrumb } from '../../src/modules/breadcrumbs/model/Breadcrumb';
+import { InMemoryBreadcrumbsStorage } from '../../src/modules/breadcrumbs/storage/InMemoryBreadcrumbsStorage';
 describe('Breadcrumbs interceptor tests', () => {
     it('Should filter out the breadcrumb', () => {
-        const breadcrumbsManager = new BreadcrumbsManager({
-            intercept: () => undefined,
-        });
+        const storage = new InMemoryBreadcrumbsStorage(100);
+        const breadcrumbsManager = new BreadcrumbsManager(
+            {
+                intercept: () => undefined,
+            },
+            {
+                storage,
+            },
+        );
         breadcrumbsManager.info('test');
-        const breadcrumbs = JSON.parse(breadcrumbsManager.breadcrumbsStorage.get() as string) as Breadcrumb[];
+        const breadcrumbs = JSON.parse(storage.get() as string) as Breadcrumb[];
         expect(breadcrumbs.length).toBe(0);
     });
 
     it('Should remove pii information from breadcrumb', () => {
         const expectedBreadcrumbMessage = 'bar';
-        const breadcrumbsManager = new BreadcrumbsManager({
-            intercept: (breadcrumb) => {
-                breadcrumb.message = expectedBreadcrumbMessage;
-                return breadcrumb;
+        const storage = new InMemoryBreadcrumbsStorage(100);
+        const breadcrumbsManager = new BreadcrumbsManager(
+            {
+                intercept: (breadcrumb) => {
+                    breadcrumb.message = expectedBreadcrumbMessage;
+                    return breadcrumb;
+                },
             },
-        });
+            {
+                storage,
+            },
+        );
         breadcrumbsManager.info('test');
 
-        const [breadcrumb] = JSON.parse(breadcrumbsManager.breadcrumbsStorage.get() as string) as Breadcrumb[];
+        const [breadcrumb] = JSON.parse(storage.get() as string) as Breadcrumb[];
         expect(breadcrumb.message).toEqual(expectedBreadcrumbMessage);
     });
 });

--- a/packages/sdk-core/tests/storage/SessionFiles.spec.ts
+++ b/packages/sdk-core/tests/storage/SessionFiles.spec.ts
@@ -1,0 +1,423 @@
+import assert from 'assert';
+import { SessionFiles } from '../../src/modules/storage/SessionFiles';
+import { mockFileSystem } from '../_mocks/fileSystem';
+
+describe('SessionFiles', () => {
+    it('should create empty session marker on initialize', () => {
+        const fileSystem = mockFileSystem();
+        const session = new SessionFiles(fileSystem, '.', 'sessionId');
+        session.initialize();
+
+        expect(fileSystem.readFileSync(session.marker)).toEqual('');
+    });
+
+    describe('getPreviousSession', () => {
+        it('should return undefined if no previous session marker exists', () => {
+            const fileSystem = mockFileSystem();
+            const session = new SessionFiles(fileSystem, '.', 'sessionId');
+            session.initialize();
+
+            const previous = session.getPreviousSession();
+            expect(previous).toBeUndefined();
+        });
+
+        it('should return previous session if previous session marker exists', () => {
+            const fileSystem = mockFileSystem();
+            const previousSession = new SessionFiles(fileSystem, '.', 'previousSessionId', undefined, 10);
+            previousSession.initialize();
+
+            const session = new SessionFiles(fileSystem, '.', 'sessionId', undefined, 20);
+            session.initialize();
+
+            const previous = session.getPreviousSession();
+            expect(previous?.sessionId).toEqual(previousSession.sessionId);
+        });
+
+        it('should return previous session if previous session contains underscores', () => {
+            const fileSystem = mockFileSystem();
+            const previousSession = new SessionFiles(fileSystem, '.', 'previous_session_id', undefined, 10);
+            previousSession.initialize();
+
+            const session = new SessionFiles(fileSystem, '.', 'sessionId', undefined, 20);
+            session.initialize();
+
+            const previous = session.getPreviousSession();
+            expect(previous?.sessionId).toEqual(previousSession.sessionId);
+        });
+
+        it('should return session older than current if multiple previous session markers exist', () => {
+            const fileSystem = mockFileSystem();
+            const oldPreviousSession = new SessionFiles(fileSystem, '.', 'oldPreviousSessionId', undefined, 5);
+            const previousSession = new SessionFiles(fileSystem, '.', 'previousSessionId', undefined, 10);
+            const nextSession = new SessionFiles(fileSystem, '.', 'nextSessionId', undefined, 25);
+            oldPreviousSession.initialize();
+            previousSession.initialize();
+            nextSession.initialize();
+
+            const session = new SessionFiles(fileSystem, '.', 'sessionId', undefined, 20);
+            session.initialize();
+
+            const previous = session.getPreviousSession();
+            expect(previous?.sessionId).toEqual(previousSession.sessionId);
+        });
+
+        it('should return previous session of each session', () => {
+            const fileSystem = mockFileSystem();
+            const session1 = new SessionFiles(fileSystem, '.', 'session1', undefined, 5);
+            const session2 = new SessionFiles(fileSystem, '.', 'session2', undefined, 10);
+            const session3 = new SessionFiles(fileSystem, '.', 'session3', undefined, 15);
+            session1.initialize();
+            session2.initialize();
+            session3.initialize();
+
+            const session = new SessionFiles(fileSystem, '.', 'sessionId', undefined, 20);
+            session.initialize();
+
+            const actualSession3 = session.getPreviousSession();
+            const actualSession2 = actualSession3?.getPreviousSession();
+            const actualSession1 = actualSession2?.getPreviousSession();
+            const notExistingSession = actualSession1?.getPreviousSession();
+
+            expect(actualSession3?.sessionId).toEqual(session3.sessionId);
+            expect(actualSession2?.sessionId).toEqual(session2.sessionId);
+            expect(actualSession1?.sessionId).toEqual(session1.sessionId);
+            expect(notExistingSession).toBeUndefined();
+        });
+
+        it('should return non-lockable session when maxPreviousLockedSessions is 0', () => {
+            const fileSystem = mockFileSystem();
+            const session1 = new SessionFiles(fileSystem, '.', 'session1', undefined, 5);
+            const session2 = new SessionFiles(fileSystem, '.', 'session2', undefined, 10);
+            const session3 = new SessionFiles(fileSystem, '.', 'session3', undefined, 15);
+            session1.initialize();
+            session2.initialize();
+            session3.initialize();
+
+            const session = new SessionFiles(fileSystem, '.', 'sessionId', 0, 20);
+            session.initialize();
+
+            const previousSession = session.getPreviousSession();
+            assert(previousSession);
+
+            expect(previousSession.lock()).toBeUndefined();
+        });
+
+        it('should return lockable session when maxPreviousLockedSessions is larger than 0', () => {
+            const fileSystem = mockFileSystem();
+            const session1 = new SessionFiles(fileSystem, '.', 'session1', undefined, 5);
+            const session2 = new SessionFiles(fileSystem, '.', 'session2', undefined, 10);
+            const session3 = new SessionFiles(fileSystem, '.', 'session3', undefined, 15);
+            session1.initialize();
+            session2.initialize();
+            session3.initialize();
+
+            const session = new SessionFiles(fileSystem, '.', 'sessionId', 1, 20);
+            session.initialize();
+
+            const previousSession = session.getPreviousSession();
+            assert(previousSession);
+
+            expect(previousSession.lock()).not.toBeUndefined();
+        });
+
+        it('should return non-lockable session from previous session when maxPreviousLockedSessions is 1', () => {
+            const fileSystem = mockFileSystem();
+            const session1 = new SessionFiles(fileSystem, '.', 'session1', undefined, 5);
+            const session2 = new SessionFiles(fileSystem, '.', 'session2', undefined, 10);
+            const session3 = new SessionFiles(fileSystem, '.', 'session3', undefined, 15);
+            session1.initialize();
+            session2.initialize();
+            session3.initialize();
+
+            const session = new SessionFiles(fileSystem, '.', 'sessionId', 0, 20);
+            session.initialize();
+
+            const previousSession = session.getPreviousSession()?.getPreviousSession();
+            assert(previousSession);
+
+            expect(previousSession.lock()).toBeUndefined();
+        });
+    });
+
+    describe('getPreviousSessions', () => {
+        it('should return all previous sessions', () => {
+            const fileSystem = mockFileSystem();
+            const session1 = new SessionFiles(fileSystem, '.', 'session1', undefined, 5);
+            const session2 = new SessionFiles(fileSystem, '.', 'session2', undefined, 10);
+            const session3 = new SessionFiles(fileSystem, '.', 'session3', undefined, 15);
+            session1.initialize();
+            session2.initialize();
+            session3.initialize();
+
+            const session = new SessionFiles(fileSystem, '.', 'sessionId', undefined, 20);
+            session.initialize();
+
+            const previousSessions = session.getPreviousSessions();
+
+            expect(previousSessions.map((s) => s.sessionId)).toEqual([
+                session3.sessionId,
+                session2.sessionId,
+                session1.sessionId,
+            ]);
+        });
+
+        it('should return previous sessions limited by count', () => {
+            const fileSystem = mockFileSystem();
+            const session1 = new SessionFiles(fileSystem, '.', 'session1', undefined, 5);
+            const session2 = new SessionFiles(fileSystem, '.', 'session2', undefined, 10);
+            const session3 = new SessionFiles(fileSystem, '.', 'session3', undefined, 15);
+            session1.initialize();
+            session2.initialize();
+            session3.initialize();
+
+            const session = new SessionFiles(fileSystem, '.', 'sessionId', undefined, 20);
+            session.initialize();
+
+            const previousSessions = session.getPreviousSessions(2);
+
+            expect(previousSessions.map((s) => s.sessionId)).toEqual([session3.sessionId, session2.sessionId]);
+        });
+    });
+
+    describe('getFileName', () => {
+        it('should return file name with escaped session ID', () => {
+            const fileSystem = mockFileSystem();
+            const session = new SessionFiles(fileSystem, '.', 'sessionId');
+
+            const filename = session.getFileName('file_name');
+            expect(filename).toContain('file__name');
+        });
+
+        it('should return file name with escaped file name', () => {
+            const fileSystem = mockFileSystem();
+            const session = new SessionFiles(fileSystem, '.', 'session_id');
+
+            const filename = session.getFileName('file_name');
+            expect(filename).toContain('session__id');
+        });
+
+        it('should return file name with session timestamp', () => {
+            const fileSystem = mockFileSystem();
+            const timestamp = 123812412;
+            const session = new SessionFiles(fileSystem, '.', 'session_id', undefined, timestamp);
+
+            const filename = session.getFileName('file_name');
+            expect(filename).toContain(timestamp.toString());
+        });
+
+        it('should throw after clearing', () => {
+            const fileSystem = mockFileSystem();
+            const session = new SessionFiles(fileSystem, '.', 'session_id');
+            session.initialize();
+
+            session.clearSession();
+
+            expect(() => session.getFileName('filename')).toThrowError('This session files are cleared.');
+        });
+    });
+
+    describe('getSessionFiles', () => {
+        it('should return files matching session', () => {
+            const fileSystem = mockFileSystem();
+
+            const session = new SessionFiles(fileSystem, '.', 'sessionId');
+            session.initialize();
+
+            const files = [session.getFileName('file1'), session.getFileName('file2'), session.getFileName('file3')];
+            for (const file of files) {
+                fileSystem.writeFileSync(file, '');
+            }
+
+            const actual = session.getSessionFiles();
+            expect(actual).toEqual(expect.arrayContaining(files));
+        });
+
+        it('should not return files not matching session', () => {
+            const fileSystem = mockFileSystem();
+
+            const session = new SessionFiles(fileSystem, '.', 'sessionId');
+            session.initialize();
+
+            const session1 = new SessionFiles(fileSystem, '.', 'session1');
+            const session2 = new SessionFiles(fileSystem, '.', 'session2');
+            const session3 = new SessionFiles(fileSystem, '.', 'session3');
+
+            const files = [session1.getFileName('file1'), session2.getFileName('file2'), session3.getFileName('file3')];
+            for (const file of files) {
+                fileSystem.writeFileSync(file, '');
+            }
+
+            const actual = session.getSessionFiles();
+            expect(actual.length).not.toEqual(expect.arrayContaining(files));
+        });
+
+        it('should throw after clearing', () => {
+            const fileSystem = mockFileSystem();
+            const session = new SessionFiles(fileSystem, '.', 'session_id');
+            session.initialize();
+
+            session.clearSession();
+
+            expect(() => session.getSessionFiles()).toThrowError('This session files are cleared.');
+        });
+    });
+
+    describe('clearSession', () => {
+        it('should remove all files matching session', () => {
+            const fileSystem = mockFileSystem();
+            const session = new SessionFiles(fileSystem, '.', 'sessionId');
+            session.initialize();
+
+            const files = [session.getFileName('file1'), session.getFileName('file2'), session.getFileName('file3')];
+            for (const file of files) {
+                fileSystem.writeFileSync(file, 'abc');
+            }
+
+            session.clearSession();
+
+            for (const file of files) {
+                expect(fileSystem.files[file]).toBeUndefined();
+            }
+        });
+
+        it('should not remove files not matching session', () => {
+            const fileSystem = mockFileSystem();
+            const session = new SessionFiles(fileSystem, '.', 'sessionId');
+            session.initialize();
+
+            const session1 = new SessionFiles(fileSystem, '.', 'session1');
+            const session2 = new SessionFiles(fileSystem, '.', 'session2');
+            const session3 = new SessionFiles(fileSystem, '.', 'session3');
+
+            const files = [session1.getFileName('file1'), session2.getFileName('file2'), session3.getFileName('file3')];
+            for (const file of files) {
+                fileSystem.writeFileSync(file, 'abc');
+            }
+
+            session.clearSession();
+
+            for (const file of files) {
+                expect(fileSystem.readFileSync(file)).toEqual('abc');
+            }
+        });
+
+        it('should remove session marker', () => {
+            const fileSystem = mockFileSystem();
+            const session = new SessionFiles(fileSystem, '.', 'sessionId');
+            session.initialize();
+
+            session.clearSession();
+
+            expect(fileSystem.readFileSync(session.marker)).toBeUndefined();
+        });
+    });
+
+    describe('locking and unlocking', () => {
+        describe('lock', () => {
+            it('should return non-empty lock id when lock id is not provided', () => {
+                const fileSystem = mockFileSystem();
+                const session = new SessionFiles(fileSystem, '.', 'sessionId');
+
+                session.initialize();
+                const lockId = session.lock();
+
+                expect(lockId).toMatch(/.+/);
+            });
+
+            it('should return provided lock id when lock id is provided', () => {
+                const fileSystem = mockFileSystem();
+                const session = new SessionFiles(fileSystem, '.', 'sessionId');
+
+                session.initialize();
+                const lockId = session.lock('lockId');
+
+                expect(lockId).toEqual('lockId');
+            });
+
+            it('should return undefined after cleared', () => {
+                const fileSystem = mockFileSystem();
+                const session = new SessionFiles(fileSystem, '.', 'sessionId');
+
+                session.initialize();
+                session.clearSession();
+                const lockId = session.lock();
+
+                expect(lockId).toBeUndefined();
+            });
+
+            it('should return undefined when not lockable', () => {
+                const fileSystem = mockFileSystem();
+                const session = new SessionFiles(fileSystem, '.', 'sessionId', undefined, undefined, false);
+
+                session.initialize();
+                session.clearSession();
+                const lockId = session.lock();
+
+                expect(lockId).toBeUndefined();
+            });
+        });
+
+        describe('clearSession', () => {
+            it('should not clear files when session is locked', () => {
+                const fileSystem = mockFileSystem();
+                const session = new SessionFiles(fileSystem, '.', 'sessionId');
+                session.initialize();
+
+                const expected = { ...fileSystem.files };
+
+                session.lock();
+
+                session.clearSession();
+
+                expect(fileSystem.files).toEqual(expected);
+            });
+
+            it('should clear files after unlocking when clearSession is called before', () => {
+                const fileSystem = mockFileSystem();
+                const session = new SessionFiles(fileSystem, '.', 'sessionId');
+                session.initialize();
+
+                const expected = { ...fileSystem.files };
+
+                const lockId = session.lock();
+                assert(lockId);
+
+                session.clearSession();
+                session.unlock(lockId);
+
+                expect(fileSystem.files).not.toEqual(expected);
+            });
+
+            it('should not clear files after unlocking when clearSession is not called before', () => {
+                const fileSystem = mockFileSystem();
+                const session = new SessionFiles(fileSystem, '.', 'sessionId');
+                session.initialize();
+
+                const expected = { ...fileSystem.files };
+
+                const lockId = session.lock();
+                assert(lockId);
+                session.unlock(lockId);
+
+                expect(fileSystem.files).toEqual(expected);
+            });
+
+            it('should not clear files after unlocking when locked with other locks', () => {
+                const fileSystem = mockFileSystem();
+                const session = new SessionFiles(fileSystem, '.', 'sessionId');
+                session.initialize();
+
+                const expected = { ...fileSystem.files };
+
+                session.lock();
+                const lockId = session.lock();
+                assert(lockId);
+
+                session.clearSession();
+                session.unlock(lockId);
+
+                expect(fileSystem.files).toEqual(expected);
+            });
+        });
+    });
+});


### PR DESCRIPTION
This PR adds the functionality of storing breadcrumbs from previous session in database.

The way it works is with a new `SessionFiles` class, which manages all previous sessions. The sessions are cleared after initialization, however, a module may lock the session before to delay the clearing. After the module unlocks the session, it is cleared automatically. This helps to remove sessions that are not used by pending reports, and not to remove those that are used.

By default, the previous sessions are limited to 1. Meaning, that if more than one previous session is available, only the most recent one will be able to be locked.

The breadcrumbs are stored on disk as each line representing a JSON breadcrumb. It is not a JSON array. Two files are used to preserve breadcrumbs. After reaching maximum breadcrumbs in one file, the main file will be moved to a fallback file, and new breadcrumbs will be written to the main file. Both files will be uploaded to a crash.

Jira task: BT-585