### PR TITLE
node: attributes from previous session in native crashes

### DIFF
--- a/examples/sdk/node/src/index.ts
+++ b/examples/sdk/node/src/index.ts
@@ -108,6 +108,7 @@ function showMenu() {
         ['OOM', oom],
         ['Add a new summed event', (attributes: Record<string, number>) => addEvent('Option clicked', attributes)],
         ['Add a breadcrumb', (attributes: Record<string, number>) => addBreadcrumb('Breadcrumb added', attributes)],
+        ['Add random attribute', () => client.addAttribute({ random: Math.random() })],
         ['Send all metrics', sendMetrics],
     ] as const;
 

--- a/packages/node/src/BacktraceClient.ts
+++ b/packages/node/src/BacktraceClient.ts
@@ -7,6 +7,7 @@ import {
     BreadcrumbsManager,
     BacktraceConfiguration as CoreConfiguration,
     DebugIdContainer,
+    FileAttributeManager,
     FileSystem,
     SessionFiles,
     VariableDebugIdMapProvider,
@@ -46,6 +47,10 @@ export class BacktraceClient extends BacktraceCoreClient {
             breadcrumbsManager.setStorage(
                 FileBreadcrumbsStorage.create(this.sessionFiles, options.breadcrumbs?.maximumBreadcrumbs ?? 100),
             );
+        }
+
+        if (this.sessionFiles && this.fileSystem && options.database?.captureNativeCrashes) {
+            this.addModule(FileAttributeManager, FileAttributeManager.create(this.fileSystem));
         }
     }
 
@@ -295,6 +300,9 @@ export class BacktraceClient extends BacktraceCoreClient {
                     if (breadcrumbsStorage) {
                         report.attachments.push(...breadcrumbsStorage.getAttachments());
                     }
+
+                    const fileAttributes = FileAttributeManager.createFromSession(session, this.fileSystem);
+                    Object.assign(report.attributes, await fileAttributes.get());
 
                     report.attributes['application.session'] = session.sessionId;
                 } else {

--- a/packages/sdk-core/src/BacktraceCoreClient.ts
+++ b/packages/sdk-core/src/BacktraceCoreClient.ts
@@ -15,8 +15,8 @@ import { ReportEvents } from './events/ReportEvents';
 import { AttributeType, BacktraceData } from './model/data/BacktraceData';
 import { BacktraceReportSubmission } from './model/http/BacktraceReportSubmission';
 import { BacktraceReport } from './model/report/BacktraceReport';
-import { BacktraceModuleBindData } from './modules/BacktraceModule';
-import { BacktraceModules, ReadonlyBacktraceModules } from './modules/BacktraceModules';
+import { BacktraceModule, BacktraceModuleBindData } from './modules/BacktraceModule';
+import { BacktraceModuleCtor, BacktraceModules, ReadonlyBacktraceModules } from './modules/BacktraceModules';
 import { AttributeManager } from './modules/attribute/AttributeManager';
 import { ClientAttributeProvider } from './modules/attribute/ClientAttributeProvider';
 import { UserAttributeProvider } from './modules/attribute/UserAttributeProvider';
@@ -218,7 +218,9 @@ export abstract class BacktraceCoreClient {
                 module.bind(this.getModuleBindData());
             }
 
-            module.initialize();
+            if (module.initialize) {
+                module.initialize();
+            }
         }
 
         this.sessionFiles?.clearPreviousSessions();
@@ -313,6 +315,10 @@ export abstract class BacktraceCoreClient {
         }
     }
 
+    protected addModule<T extends BacktraceModule>(type: BacktraceModuleCtor<T>, module: T) {
+        this._modules.set(type, module);
+    }
+
     protected generateSubmissionData(report: BacktraceReport): BacktraceData | undefined {
         const backtraceData = this._dataBuilder.build(report);
         if (!this.options.beforeSend) {
@@ -340,6 +346,7 @@ export abstract class BacktraceCoreClient {
         return {
             client: this,
             reportEvents: this.reportEvents,
+            attributeManager: this.attributeManager,
             sessionFiles: this.sessionFiles,
         };
     }

--- a/packages/sdk-core/src/events/AttributeEvents.ts
+++ b/packages/sdk-core/src/events/AttributeEvents.ts
@@ -1,0 +1,5 @@
+import { ReportData } from '../model/report/ReportData';
+
+export type AttributeEvents = {
+    'scoped-attributes-updated'(attributes: ReportData): void;
+};

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -11,6 +11,7 @@ export * from './model/data/';
 export * from './model/http';
 export * from './model/report/BacktraceErrorType';
 export * from './model/report/BacktraceReport';
+export * from './modules/attribute';
 export * from './modules/attribute/BacktraceAttributeProvider';
 export * from './modules/breadcrumbs';
 export * from './modules/converter';

--- a/packages/sdk-core/src/modules/BacktraceModule.ts
+++ b/packages/sdk-core/src/modules/BacktraceModule.ts
@@ -1,15 +1,17 @@
 import { BacktraceCoreClient, SessionFiles } from '..';
 import { Events } from '../common/Events';
 import { ReportEvents } from '../events/ReportEvents';
+import { AttributeManager } from './attribute/AttributeManager';
 
 export interface BacktraceModuleBindData {
     readonly client: BacktraceCoreClient;
+    readonly attributeManager: AttributeManager;
     readonly reportEvents: Events<ReportEvents>;
     readonly sessionFiles?: SessionFiles;
 }
 
 export interface BacktraceModule {
     bind?(client: BacktraceModuleBindData): void;
-    initialize(): void;
+    initialize?(): void;
     dispose?(): void;
 }

--- a/packages/sdk-core/src/modules/BacktraceModules.ts
+++ b/packages/sdk-core/src/modules/BacktraceModules.ts
@@ -1,6 +1,6 @@
 import { BacktraceModule } from './BacktraceModule';
 
-type BacktraceModuleCtor<T extends BacktraceModule = BacktraceModule> = new (...args: never[]) => T;
+export type BacktraceModuleCtor<T extends BacktraceModule = BacktraceModule> = new (...args: never[]) => T;
 
 export interface ReadonlyBacktraceModules extends ReadonlyMap<BacktraceModuleCtor, BacktraceModule> {
     get<T extends BacktraceModule>(type: BacktraceModuleCtor<T>): T | undefined;

--- a/packages/sdk-core/src/modules/attribute/AttributeManager.ts
+++ b/packages/sdk-core/src/modules/attribute/AttributeManager.ts
@@ -1,11 +1,16 @@
+import { Events } from '../../common/Events';
+import { AttributeEvents } from '../../events/AttributeEvents';
 import { ReportData } from '../../model/report/ReportData';
 import { BacktraceAttributeProvider } from './BacktraceAttributeProvider';
 import { ReportDataBuilder } from './ReportDataBuilder';
 
 export class AttributeManager {
+    public readonly attributeEvents: Events<AttributeEvents>;
+
     private readonly _attributeProviders: BacktraceAttributeProvider[] = [];
 
     constructor(providers: BacktraceAttributeProvider[]) {
+        this.attributeEvents = new Events();
         for (const provider of providers) {
             this.addProvider(provider);
         }
@@ -38,6 +43,7 @@ export class AttributeManager {
                 type: 'scoped',
                 get: () => attributes,
             });
+            this.attributeEvents.emit('scoped-attributes-updated', this.get('scoped'));
         }
     }
 

--- a/packages/sdk-core/src/modules/attribute/FileAttributeManager.ts
+++ b/packages/sdk-core/src/modules/attribute/FileAttributeManager.ts
@@ -1,4 +1,5 @@
 import { jsonEscaper } from '../../common/jsonEscaper';
+import { AttributeType } from '../../model/data';
 import { BacktraceModule, BacktraceModuleBindData } from '../BacktraceModule';
 import { FileSystem, SessionFiles } from '../storage';
 import { AttributeManager } from './AttributeManager';
@@ -23,7 +24,7 @@ export class FileAttributeManager implements BacktraceModule {
         this.saveAttributes();
     }
 
-    public bind?({ attributeManager, sessionFiles }: BacktraceModuleBindData): void {
+    public bind({ attributeManager, sessionFiles }: BacktraceModuleBindData): void {
         if (this._fileName) {
             throw new Error('This instance is already bound.');
         }
@@ -37,11 +38,11 @@ export class FileAttributeManager implements BacktraceModule {
         attributeManager.attributeEvents.on('scoped-attributes-updated', () => this.saveAttributes());
     }
 
-    public dispose?(): void {
+    public dispose(): void {
         this._fileName = undefined;
     }
 
-    public async get(): Promise<Record<string, unknown>> {
+    public async get(): Promise<Record<string, AttributeType>> {
         if (!this._fileName) {
             return {};
         }

--- a/packages/sdk-core/src/modules/attribute/FileAttributeManager.ts
+++ b/packages/sdk-core/src/modules/attribute/FileAttributeManager.ts
@@ -1,0 +1,65 @@
+import { jsonEscaper } from '../../common/jsonEscaper';
+import { BacktraceModule, BacktraceModuleBindData } from '../BacktraceModule';
+import { FileSystem, SessionFiles } from '../storage';
+import { AttributeManager } from './AttributeManager';
+
+const ATTRIBUTE_FILE_NAME = 'bt-attributes';
+
+export class FileAttributeManager implements BacktraceModule {
+    private _attributeManager?: AttributeManager;
+
+    constructor(private readonly _fileSystem: FileSystem, private _fileName?: string) {}
+
+    public static create(fileSystem: FileSystem) {
+        return new FileAttributeManager(fileSystem);
+    }
+
+    public static createFromSession(sessionFiles: SessionFiles, fileSystem: FileSystem) {
+        const fileName = sessionFiles.getFileName(ATTRIBUTE_FILE_NAME);
+        return new FileAttributeManager(fileSystem, fileName);
+    }
+
+    public initialize(): void {
+        this.saveAttributes();
+    }
+
+    public bind?({ attributeManager, sessionFiles }: BacktraceModuleBindData): void {
+        if (this._fileName) {
+            throw new Error('This instance is already bound.');
+        }
+
+        if (!sessionFiles) {
+            return;
+        }
+
+        this._fileName = sessionFiles.getFileName(ATTRIBUTE_FILE_NAME);
+        this._attributeManager = attributeManager;
+        attributeManager.attributeEvents.on('scoped-attributes-updated', () => this.saveAttributes());
+    }
+
+    public dispose?(): void {
+        this._fileName = undefined;
+    }
+
+    public async get(): Promise<Record<string, unknown>> {
+        if (!this._fileName) {
+            return {};
+        }
+
+        try {
+            const content = await this._fileSystem.readFile(this._fileName);
+            return JSON.parse(content);
+        } catch {
+            return {};
+        }
+    }
+
+    private async saveAttributes() {
+        if (!this._fileName || !this._attributeManager) {
+            return;
+        }
+
+        const reportData = this._attributeManager.get('scoped');
+        await this._fileSystem.writeFile(this._fileName, JSON.stringify(reportData.attributes, jsonEscaper()));
+    }
+}

--- a/packages/sdk-core/src/modules/attribute/index.ts
+++ b/packages/sdk-core/src/modules/attribute/index.ts
@@ -1,0 +1,1 @@
+export * from './FileAttributeManager';


### PR DESCRIPTION
This PR adds attributes from previous session in native crashes:
* if database and native crashes are enabled, the attributes will be saved to disk,
* every time the scoped attributes change, attributes will be resaved,
* when loading native crashes, attributes from previous session will be also loaded.

Jira task: BT-586