### PR TITLE
Error event fallback if the error object is not available

### DIFF
--- a/packages/browser/src/BacktraceClient.ts
+++ b/packages/browser/src/BacktraceClient.ts
@@ -88,9 +88,9 @@ export class BacktraceClient extends BacktraceCoreClient {
         if (captureUnhandledExceptions) {
             window.addEventListener(
                 'error',
-                async (errorEvent: ErrorEvent) => {
-                    await this.send(
-                        new BacktraceReport(errorEvent.error, {
+                (errorEvent: ErrorEvent) => {
+                    this.send(
+                        new BacktraceReport(errorEvent.error ?? errorEvent.message, {
                             'error.type': 'Unhandled exception',
                         }),
                     );
@@ -104,8 +104,8 @@ export class BacktraceClient extends BacktraceCoreClient {
         if (captureUnhandledRejections) {
             window.addEventListener(
                 'unhandledrejection',
-                async (errorEvent: PromiseRejectionEvent) => {
-                    await this.send(
+                (errorEvent: PromiseRejectionEvent) => {
+                    this.send(
                         new BacktraceReport(
                             errorEvent.reason,
                             {


### PR DESCRIPTION
# Why

When the error object is unavailable (for example script error), the backtrace report has a null as an error message. Instead we can fallback to the errorEvent message. With the error message users can detect/recognize errors like scripting errors). In addition to that, when the error object is not available (means the stack trace object is also empty) then we generate a stack trace based on current stack trace (including async frames). By removing async from the method we will avoid generating useless stack frames.