### PR TITLE
Adding jsonEscaper to JSON.stringify() and not assuming action exists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13315,7 +13315,7 @@
             "version": "0.0.4",
             "license": "MIT",
             "dependencies": {
-                "@backtrace-labs/sdk-core": "^0.0.4",
+                "@backtrace-labs/sdk-core": "^0.0.5",
                 "ua-parser-js": "^1.0.35"
             },
             "devDependencies": {
@@ -13384,13 +13384,18 @@
                 "node": ">=14"
             }
         },
+        "packages/node/node_modules/@backtrace-labs/sdk-core": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/@backtrace-labs/sdk-core/-/sdk-core-0.0.4.tgz",
+            "integrity": "sha512-kQUy/6dhAD/zN3OQmQsoLe5BnPjm7qRunZfklYiZ7ENdDDOTeRu3w1eyoAe7kO3/kCzdk0o6KeEf7PHSeUr2kA=="
+        },
         "packages/react": {
             "name": "@backtrace-labs/react",
             "version": "0.0.4",
             "license": "MIT",
             "dependencies": {
                 "@backtrace-labs/browser": "^0.0.4",
-                "@backtrace-labs/sdk-core": "^0.0.4"
+                "@backtrace-labs/sdk-core": "^0.0.5"
             },
             "devDependencies": {
                 "@testing-library/react": "^14.0.0",
@@ -13977,7 +13982,7 @@
         "@backtrace-labs/browser": {
             "version": "file:packages/browser",
             "requires": {
-                "@backtrace-labs/sdk-core": "^0.0.4",
+                "@backtrace-labs/sdk-core": "^0.0.5",
                 "@reduxjs/toolkit": "^1.9.5",
                 "@types/jest": "^29.5.1",
                 "@types/ua-parser-js": "^0.7.36",
@@ -14042,13 +14047,20 @@
                 "webpack": "^5.87.0",
                 "webpack-cli": "^5.1.4",
                 "webpack-node-externals": "^3.0.0"
+            },
+            "dependencies": {
+                "@backtrace-labs/sdk-core": {
+                    "version": "0.0.4",
+                    "resolved": "https://registry.npmjs.org/@backtrace-labs/sdk-core/-/sdk-core-0.0.4.tgz",
+                    "integrity": "sha512-kQUy/6dhAD/zN3OQmQsoLe5BnPjm7qRunZfklYiZ7ENdDDOTeRu3w1eyoAe7kO3/kCzdk0o6KeEf7PHSeUr2kA=="
+                }
             }
         },
         "@backtrace-labs/react": {
             "version": "file:packages/react",
             "requires": {
                 "@backtrace-labs/browser": "^0.0.4",
-                "@backtrace-labs/sdk-core": "^0.0.4",
+                "@backtrace-labs/sdk-core": "^0.0.5",
                 "@testing-library/react": "^14.0.0",
                 "@types/react": "^18.2.14",
                 "jest": "^29.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13409,7 +13409,7 @@
         },
         "packages/sdk-core": {
             "name": "@backtrace-labs/sdk-core",
-            "version": "0.0.4",
+            "version": "0.0.5",
             "license": "MIT",
             "devDependencies": {
                 "@types/jest": "^29.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13366,7 +13366,7 @@
             "version": "0.0.4",
             "license": "MIT",
             "dependencies": {
-                "@backtrace-labs/sdk-core": "^0.0.4",
+                "@backtrace-labs/sdk-core": "^0.0.5",
                 "form-data": "^4.0.0",
                 "native-reg": "^1.1.1"
             },
@@ -13383,11 +13383,6 @@
             "engines": {
                 "node": ">=14"
             }
-        },
-        "packages/node/node_modules/@backtrace-labs/sdk-core": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/@backtrace-labs/sdk-core/-/sdk-core-0.0.4.tgz",
-            "integrity": "sha512-kQUy/6dhAD/zN3OQmQsoLe5BnPjm7qRunZfklYiZ7ENdDDOTeRu3w1eyoAe7kO3/kCzdk0o6KeEf7PHSeUr2kA=="
         },
         "packages/react": {
             "name": "@backtrace-labs/react",
@@ -14036,7 +14031,7 @@
         "@backtrace-labs/node": {
             "version": "file:packages/node",
             "requires": {
-                "@backtrace-labs/sdk-core": "^0.0.4",
+                "@backtrace-labs/sdk-core": "^0.0.5",
                 "@types/jest": "^29.5.1",
                 "form-data": "^4.0.0",
                 "jest": "^29.5.0",
@@ -14047,13 +14042,6 @@
                 "webpack": "^5.87.0",
                 "webpack-cli": "^5.1.4",
                 "webpack-node-externals": "^3.0.0"
-            },
-            "dependencies": {
-                "@backtrace-labs/sdk-core": {
-                    "version": "0.0.4",
-                    "resolved": "https://registry.npmjs.org/@backtrace-labs/sdk-core/-/sdk-core-0.0.4.tgz",
-                    "integrity": "sha512-kQUy/6dhAD/zN3OQmQsoLe5BnPjm7qRunZfklYiZ7ENdDDOTeRu3w1eyoAe7kO3/kCzdk0o6KeEf7PHSeUr2kA=="
-                }
             }
         },
         "@backtrace-labs/react": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -49,7 +49,7 @@
         "webpack-cli": "^5.1.4"
     },
     "dependencies": {
-        "@backtrace-labs/sdk-core": "^0.0.4",
+        "@backtrace-labs/sdk-core": "^0.0.5",
         "ua-parser-js": "^1.0.35"
     }
 }

--- a/packages/browser/src/redux/BacktraceReduxMiddleware.ts
+++ b/packages/browser/src/redux/BacktraceReduxMiddleware.ts
@@ -1,5 +1,6 @@
 import type { Middleware, Action } from 'redux';
 import { BacktraceClient } from '../BacktraceClient';
+import { jsonEscaper } from '@backtrace-labs/sdk-core';
 
 /**
  *
@@ -20,12 +21,14 @@ export const createBacktraceReduxMiddleware = (
             const interceptedAction = interceptAction(action);
             // If the user returns undefined for an action, we skip the breadcrumb
             if (interceptedAction) {
-                client.breadcrumbs?.info(`REDUX Action: ${JSON.stringify(interceptedAction)}`);
+                client.breadcrumbs?.info(`REDUX Action: ${JSON.stringify(interceptedAction, jsonEscaper())}`);
             }
             return response;
         } catch (err) {
             const message = err instanceof Error ? err.message : err?.toString() ?? 'unknown';
-            client.breadcrumbs?.warn(`A problem occurred during action ${action.type}. Reason: ${message}`);
+            client.breadcrumbs?.warn(
+                `A problem occurred during action ${action?.type ?? 'unknown'}. Reason: ${message}`,
+            );
             throw err;
         }
     };

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -49,7 +49,7 @@
         "webpack-node-externals": "^3.0.0"
     },
     "dependencies": {
-        "@backtrace-labs/sdk-core": "^0.0.4",
+        "@backtrace-labs/sdk-core": "^0.0.5",
         "form-data": "^4.0.0",
         "native-reg": "^1.1.1"
     }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -48,7 +48,7 @@
     },
     "dependencies": {
         "@backtrace-labs/browser": "^0.0.4",
-        "@backtrace-labs/sdk-core": "^0.0.4"
+        "@backtrace-labs/sdk-core": "^0.0.5"
     },
     "peerDependencies": {
         "react": ">=16.8.0"

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace-labs/sdk-core",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "description": "Backtrace-JavaScript SDK core library",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",


### PR DESCRIPTION
This fixes the bug where we don't handle circular references or bigints properly