### PR TITLE
sync versions script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
                 "eslint-plugin-local-rules": "^1.3.2",
                 "prettier": "^2.8.8",
                 "rimraf": "^5.0.1",
+                "ts-node": "^10.9.1",
                 "typescript": "^5.0.4"
             }
         },
@@ -745,6 +746,28 @@
             "version": "0.2.3",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@cspotcode/source-map-support": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/trace-mapping": "0.3.9"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.0.3",
+                "@jridgewell/sourcemap-codec": "^1.4.10"
+            }
         },
         "node_modules/@discoveryjs/json-ext": {
             "version": "0.5.7",
@@ -1682,6 +1705,30 @@
             "engines": {
                 "node": ">= 10"
             }
+        },
+        "node_modules/@tsconfig/node10": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+            "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+            "dev": true
+        },
+        "node_modules/@tsconfig/node12": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+            "dev": true
+        },
+        "node_modules/@tsconfig/node14": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+            "dev": true
+        },
+        "node_modules/@tsconfig/node16": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+            "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+            "dev": true
         },
         "node_modules/@types/aria-query": {
             "version": "5.0.1",
@@ -2663,6 +2710,12 @@
             "version": "1.2.0",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+            "dev": true
         },
         "node_modules/argparse": {
             "version": "2.0.1",
@@ -4181,6 +4234,12 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+            "dev": true
+        },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
             "license": "MIT",
@@ -4572,6 +4631,15 @@
             "dependencies": {
                 "asap": "^2.0.0",
                 "wrappy": "1"
+            }
+        },
+        "node_modules/diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.3.1"
             }
         },
         "node_modules/diff-sequences": {
@@ -11974,6 +12042,49 @@
                 "node": ">=6"
             }
         },
+        "node_modules/ts-node": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+            "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+            "dev": true,
+            "dependencies": {
+                "@cspotcode/source-map-support": "^0.8.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "v8-compile-cache-lib": "^3.0.1",
+                "yn": "3.1.1"
+            },
+            "bin": {
+                "ts-node": "dist/bin.js",
+                "ts-node-cwd": "dist/bin-cwd.js",
+                "ts-node-esm": "dist/bin-esm.js",
+                "ts-node-script": "dist/bin-script.js",
+                "ts-node-transpile-only": "dist/bin-transpile.js",
+                "ts-script": "dist/bin-script-deprecated.js"
+            },
+            "peerDependencies": {
+                "@swc/core": ">=1.2.50",
+                "@swc/wasm": ">=1.2.50",
+                "@types/node": "*",
+                "typescript": ">=2.7"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "@swc/wasm": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/tsconfig-paths": {
             "version": "3.14.2",
             "dev": true,
@@ -12399,6 +12510,12 @@
             "engines": {
                 "node": ">= 0.4.0"
             }
+        },
+        "node_modules/v8-compile-cache-lib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+            "dev": true
         },
         "node_modules/v8-to-istanbul": {
             "version": "9.1.0",
@@ -13803,6 +13920,15 @@
             "dependencies": {
                 "buffer-crc32": "~0.2.3",
                 "fd-slicer": "~1.1.0"
+            }
+        },
+        "node_modules/yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/yocto-queue": {
@@ -15922,14 +16048,6 @@
             },
             "engines": {
                 "node": ">=6.9.0"
-            }
-        },
-        "packages/react-native/node_modules/@backtrace-labs/browser": {
-            "version": "0.0.4",
-            "license": "MIT",
-            "dependencies": {
-                "@backtrace-labs/sdk-core": "^0.0.4",
-                "ua-parser-js": "^1.0.35"
             }
         },
         "packages/react-native/node_modules/@eslint-community/eslint-utils": {
@@ -21101,6 +21219,7 @@
         },
         "packages/react-native/node_modules/js-tokens": {
             "version": "4.0.0",
+            "dev": true,
             "license": "MIT"
         },
         "packages/react-native/node_modules/js-yaml": {
@@ -21620,6 +21739,7 @@
         },
         "packages/react-native/node_modules/loose-envify": {
             "version": "1.4.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
@@ -23352,6 +23472,7 @@
         },
         "packages/react-native/node_modules/react": {
             "version": "18.2.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0"
@@ -24602,27 +24723,6 @@
                 "node": ">=14.17"
             }
         },
-        "packages/react-native/node_modules/ua-parser-js": {
-            "version": "1.0.36",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/ua-parser-js"
-                },
-                {
-                    "type": "paypal",
-                    "url": "https://paypal.me/faisalman"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/faisalman"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": "*"
-            }
-        },
         "packages/react-native/node_modules/uglify-es": {
             "version": "3.3.9",
             "dev": true,
@@ -25059,7 +25159,7 @@
         },
         "packages/sdk-core": {
             "name": "@backtrace-labs/sdk-core",
-            "version": "0.0.5",
+            "version": "0.0.6",
             "license": "MIT",
             "devDependencies": {
                 "@types/jest": "^29.5.1",
@@ -26884,13 +26984,6 @@
                         "@babel/helper-string-parser": "^7.22.5",
                         "@babel/helper-validator-identifier": "^7.22.19",
                         "to-fast-properties": "^2.0.0"
-                    }
-                },
-                "@backtrace-labs/browser": {
-                    "version": "0.0.4",
-                    "requires": {
-                        "@backtrace-labs/sdk-core": "^0.0.4",
-                        "ua-parser-js": "^1.0.35"
                     }
                 },
                 "@eslint-community/eslint-utils": {
@@ -30180,7 +30273,8 @@
                     }
                 },
                 "js-tokens": {
-                    "version": "4.0.0"
+                    "version": "4.0.0",
+                    "dev": true
                 },
                 "js-yaml": {
                     "version": "4.1.0",
@@ -30525,6 +30619,7 @@
                 },
                 "loose-envify": {
                     "version": "1.4.0",
+                    "dev": true,
                     "requires": {
                         "js-tokens": "^3.0.0 || ^4.0.0"
                     }
@@ -31641,6 +31736,7 @@
                 },
                 "react": {
                     "version": "18.2.0",
+                    "dev": true,
                     "requires": {
                         "loose-envify": "^1.1.0"
                     }
@@ -32468,9 +32564,6 @@
                     "version": "5.2.2",
                     "dev": true
                 },
-                "ua-parser-js": {
-                    "version": "1.0.36"
-                },
                 "uglify-es": {
                     "version": "3.3.9",
                     "dev": true,
@@ -32809,6 +32902,27 @@
         "@bcoe/v8-coverage": {
             "version": "0.2.3",
             "dev": true
+        },
+        "@cspotcode/source-map-support": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/trace-mapping": "0.3.9"
+            },
+            "dependencies": {
+                "@jridgewell/trace-mapping": {
+                    "version": "0.3.9",
+                    "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+                    "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jridgewell/resolve-uri": "^3.0.3",
+                        "@jridgewell/sourcemap-codec": "^1.4.10"
+                    }
+                }
+            }
         },
         "@discoveryjs/json-ext": {
             "version": "0.5.7",
@@ -33384,6 +33498,30 @@
         },
         "@tootallnate/once": {
             "version": "2.0.0",
+            "dev": true
+        },
+        "@tsconfig/node10": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+            "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+            "dev": true
+        },
+        "@tsconfig/node12": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+            "dev": true
+        },
+        "@tsconfig/node14": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+            "dev": true
+        },
+        "@tsconfig/node16": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+            "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
             "dev": true
         },
         "@types/aria-query": {
@@ -34093,6 +34231,12 @@
         },
         "aproba": {
             "version": "1.2.0",
+            "dev": true
+        },
+        "arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
             "dev": true
         },
         "argparse": {
@@ -35113,6 +35257,12 @@
                 "prompts": "^2.0.1"
             }
         },
+        "create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+            "dev": true
+        },
         "cross-spawn": {
             "version": "7.0.3",
             "requires": {
@@ -35392,6 +35542,12 @@
                 "asap": "^2.0.0",
                 "wrappy": "1"
             }
+        },
+        "diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "dev": true
         },
         "diff-sequences": {
             "version": "29.6.3",
@@ -40298,6 +40454,27 @@
                 }
             }
         },
+        "ts-node": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+            "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+            "dev": true,
+            "requires": {
+                "@cspotcode/source-map-support": "^0.8.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "v8-compile-cache-lib": "^3.0.1",
+                "yn": "3.1.1"
+            }
+        },
         "tsconfig-paths": {
             "version": "3.14.2",
             "dev": true,
@@ -40564,6 +40741,12 @@
         },
         "utils-merge": {
             "version": "1.0.1",
+            "dev": true
+        },
+        "v8-compile-cache-lib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
             "dev": true
         },
         "v8-to-istanbul": {
@@ -41522,6 +41705,12 @@
                 "buffer-crc32": "~0.2.3",
                 "fd-slicer": "~1.1.0"
             }
+        },
+        "yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+            "dev": true
         },
         "yocto-queue": {
             "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "lint": "eslint . --ext .ts",
         "rebuild": "npm run clean && npm run build",
         "watch": "tsc -b ./tsconfig.packages.json -w",
-        "test": "npm run test --ws --if-present"
+        "test": "npm run test --ws --if-present",
+        "syncVersions": "ts-node ./scripts/syncVersions.ts"
     },
     "workspaces": [
         "packages/sdk-core",
@@ -54,6 +55,7 @@
         "eslint-plugin-local-rules": "^1.3.2",
         "prettier": "^2.8.8",
         "rimraf": "^5.0.1",
+        "ts-node": "^10.9.1",
         "typescript": "^5.0.4"
     }
 }

--- a/scripts/syncVersions.ts
+++ b/scripts/syncVersions.ts
@@ -47,36 +47,36 @@ function getWorkspacePackageJsonPaths(packageJson: PackageJson) {
     return packageJson.workspaces?.map((workspaceDir) => path.join(rootDir, workspaceDir, 'package.json')) ?? [];
 }
 
+function updateDependency(packageJson: PackageJson, type: Dependencies, name: string, newVersion: string) {
+    const deps = packageJson[type];
+    if (!deps) {
+        return false;
+    }
+
+    const currentVersion = deps[name];
+    if (!currentVersion) {
+        return false;
+    }
+
+    if (currentVersion !== newVersion) {
+        deps[name] = newVersion;
+        console.log(`[${packageJson.name}] - updated ${name} from ${currentVersion} to ${newVersion} in ${type}`);
+
+        return true;
+    }
+
+    return false;
+}
+
 function updateVersions(packageJson: PackageJson, currentVersions: Record<string, string>) {
     let updated = false;
 
     for (const [name, version] of Object.entries(currentVersions)) {
         const newVersion = `^${version}`;
 
-        function updateDependency(type: Dependencies) {
-            const deps = packageJson[type];
-            if (!deps) {
-                return;
-            }
-
-            const currentVersion = deps[name];
-            if (!currentVersion) {
-                return;
-            }
-
-            if (currentVersion !== newVersion) {
-                deps[name] = newVersion;
-                console.log(
-                    `[${packageJson.name}] - updated ${name} from ${currentVersion} to ${newVersion} in ${type}`,
-                );
-
-                return true;
-            }
-        }
-
-        updated = updateDependency('dependencies') || updated;
-        updated = updateDependency('devDependencies') || updated;
-        updated = updateDependency('peerDependencies') || updated;
+        updated = updateDependency(packageJson, 'dependencies', name, newVersion) || updated;
+        updated = updateDependency(packageJson, 'devDependencies', name, newVersion) || updated;
+        updated = updateDependency(packageJson, 'peerDependencies', name, newVersion) || updated;
     }
 
     if (!updated) {

--- a/scripts/syncVersions.ts
+++ b/scripts/syncVersions.ts
@@ -1,0 +1,107 @@
+#!/usr/bin/env -S node -r ts-node/register
+
+/**
+ * This scripts makes sure that all packages use the newest versions of dependencies.
+ * Without arguments, it reads all workspaces from root package.json and checks all workspaces.
+ * Pass paths to package.json files as arguments to parse only those.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const rootDir = path.join(__dirname, '..');
+
+interface PackageJson {
+    readonly name: string;
+    readonly version: string;
+    readonly workspaces?: string[];
+    readonly dependencies?: Record<string, string>;
+    readonly devDependencies?: Record<string, string>;
+    readonly peerDependencies?: Record<string, string>;
+}
+
+type Dependencies = keyof Pick<PackageJson, 'dependencies' | 'devDependencies' | 'peerDependencies'>;
+
+async function loadPackageJson(packageJsonPath: string): Promise<PackageJson> {
+    const error = new Error(`${packageJsonPath} does not seem to be a valid package.json file`);
+
+    let packageJson: Partial<PackageJson>;
+    try {
+        packageJson = JSON.parse(await fs.promises.readFile(packageJsonPath, 'utf-8')) as Partial<PackageJson>;
+    } catch {
+        throw error;
+    }
+
+    if (!packageJson.name || !packageJson.version) {
+        throw error;
+    }
+
+    return packageJson as PackageJson;
+}
+
+async function savePackageJson(packageJsonPath: string, packageJson: PackageJson) {
+    return await fs.promises.writeFile(packageJsonPath, JSON.stringify(packageJson, null, '    ') + '\n');
+}
+
+function getWorkspacePackageJsonPaths(packageJson: PackageJson) {
+    return packageJson.workspaces?.map((workspaceDir) => path.join(rootDir, workspaceDir, 'package.json')) ?? [];
+}
+
+function updateVersions(packageJson: PackageJson, currentVersions: Record<string, string>) {
+    let updated = false;
+
+    for (const [name, version] of Object.entries(currentVersions)) {
+        const newVersion = `^${version}`;
+
+        function updateDependency(type: Dependencies) {
+            const deps = packageJson[type];
+            if (!deps) {
+                return;
+            }
+
+            const currentVersion = deps[name];
+            if (!currentVersion) {
+                return;
+            }
+
+            if (currentVersion !== newVersion) {
+                deps[name] = newVersion;
+                console.log(
+                    `[${packageJson.name}] - updated ${name} from ${currentVersion} to ${newVersion} in ${type}`,
+                );
+
+                return true;
+            }
+        }
+
+        updated = updateDependency('dependencies') || updated;
+        updated = updateDependency('devDependencies') || updated;
+        updated = updateDependency('peerDependencies') || updated;
+    }
+
+    if (!updated) {
+        console.log(`[${packageJson.name}] - no changes`);
+    }
+
+    return packageJson;
+}
+
+(async () => {
+    const rootPackageJson = await loadPackageJson(path.join(rootDir, 'package.json'));
+    const workspacePackageJsonPaths = getWorkspacePackageJsonPaths(rootPackageJson);
+    const workspacePackageJsons = await Promise.all(workspacePackageJsonPaths.map(loadPackageJson));
+
+    const args = process.argv.slice(2);
+    const packageJsonPathsToSync = args.length ? args : workspacePackageJsonPaths;
+
+    const currentVersions = workspacePackageJsons.reduce((obj, pj) => {
+        obj[pj.name] = pj.version;
+        return obj;
+    }, {} as Record<string, string>);
+
+    for (const packageJsonPath of packageJsonPathsToSync) {
+        const packageJson = await loadPackageJson(packageJsonPath);
+        const updatedPackageJson = updateVersions(packageJson, currentVersions);
+        await savePackageJson(packageJsonPath, updatedPackageJson);
+    }
+})();


### PR DESCRIPTION
This script helps to synchronize all versions of workspace packages in all workspaces.

For example, if `sdk-core` version changes, instead of going to every package and updating the version manually, one has to only run `npm run syncVersions` and it will take care of everything.

Example:
1. update sdk-core from 0.0.5 to 0.0.6
2. run `npm run syncVersions`
Output:
```
> @backtrace-labs/javascript@0.0.1 syncVersions
> ts-node ./scripts/syncVersions.ts

[@backtrace-labs/sdk-core] - no changes
[@backtrace-labs/browser] - updated @backtrace-labs/sdk-core from ^0.0.5 to ^0.0.6 in dependencies
[@backtrace-labs/react] - updated @backtrace-labs/sdk-core from ^0.0.5 to ^0.0.6 in dependencies
[@backtrace-labs/node] - updated @backtrace-labs/sdk-core from ^0.0.5 to ^0.0.6 in dependencies
[@backtrace-labs/nestjs] - no changes
[@backtrace-labs/react-native] - updated @backtrace-labs/sdk-core from ^0.0.5 to ^0.0.6 in dependencies
[@backtrace-labs/sourcemap-tools] - no changes
[@backtrace-labs/javascript-cli] - no changes
[@backtrace-labs/rollup-plugin] - no changes
[@backtrace-labs/webpack-plugin] - no changes
[@backtrace-labs/vite-plugin] - no changes
```

Also, if you want to sync versions of specific packages, you can pass paths to package.jsons:
```
> npm run syncVersions -- packages/node/package.json packages/browser/package.json 

> @backtrace-labs/javascript@0.0.1 syncVersions
> ts-node ./scripts/syncVersions.ts packages/node/package.json packages/browser/package.json

[@backtrace-labs/node] - updated @backtrace-labs/sdk-core from ^0.0.5 to ^0.0.6 in dependencies
[@backtrace-labs/browser] - updated @backtrace-labs/sdk-core from ^0.0.5 to ^0.0.6 in dependencies
```