### PR TITLE
cli: test and upload improvements

### DIFF
--- a/tools/cli/src/sourcemaps/run.ts
+++ b/tools/cli/src/sourcemaps/run.ts
@@ -22,6 +22,7 @@ import {
     not,
     pass,
     pipe,
+    stripSourcesContent,
 } from '@backtrace-labs/sourcemap-tools';
 import path from 'path';
 import { GlobalOptions } from '..';
@@ -285,13 +286,8 @@ export async function runSourcemapCommands({ opts, logger, getHelpMessage }: Com
         ? await uploadOrSaveAssets(
               uploadUrl,
               uploadOptions.output,
-              (url) =>
-                  uploadAssets(
-                      url,
-                      { ignoreSsl: uploadOptions.insecure ?? false },
-                      uploadOptions['include-sources'] ?? false,
-                  ),
-              (path) => flow(saveAssets(path, uploadOptions['include-sources'] ?? false), Ok),
+              (url) => uploadAssets(url, { ignoreSsl: uploadOptions.insecure ?? false }),
+              (path) => flow(saveAssets(path), Ok),
           )
         : Ok(undefined);
 
@@ -330,6 +326,7 @@ export async function runSourcemapCommands({ opts, logger, getHelpMessage }: Com
                       ? Ok
                       : failIfEmpty('no processed sourcemaps found, make sure to run process'),
                   R.map(uniqueBy((asset) => asset.content.debugId)),
+                  R.map(opts['include-sources'] ? pass : map(stripSourcesContent)),
                   R.map((assets) =>
                       uploadOptions['dry-run']
                           ? Ok({ rxid: '<dry-run>' })

--- a/tools/cli/src/sourcemaps/upload.ts
+++ b/tools/cli/src/sourcemaps/upload.ts
@@ -351,11 +351,14 @@ function pipeAssets(assets: AssetWithContent<RawSourceMapWithDebugId>[]) {
     return function pipeAssets(writable: Writable) {
         const archive = new ZipArchive();
 
+        const waitForFinish = new Promise((resolve, reject) => writable.on('finish', resolve).on('error', reject));
+
         return pipe(
             writable,
-            pipeStream(archive),
+            pipeStream(archive.stream),
             () => assets.map(appendToArchive(archive)),
             () => archive.finalize(),
+            () => waitForFinish,
         );
     };
 }

--- a/tools/sourcemap-tools/src/ZipArchive.ts
+++ b/tools/sourcemap-tools/src/ZipArchive.ts
@@ -13,6 +13,10 @@ export class ZipArchive {
         this._pack.pipe(this._gz);
     }
 
+    public get stream() {
+        return this._gz;
+    }
+
     public append(name: string, sourceMap: string) {
         this._pack.entry({ name }, sourceMap);
         return this;
@@ -22,17 +26,8 @@ export class ZipArchive {
         this._pack.finalize();
 
         return new Promise<ZipArchive>((resolve, reject) => {
-            this._gz.on('close', () => resolve(this));
+            this._gz.on('finish', () => resolve(this));
             this._gz.on('error', reject);
         });
-    }
-
-    public on(event: string, listener: (...args: unknown[]) => void): this {
-        this._pack.on(event, listener);
-        return this;
-    }
-
-    public pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean }): T {
-        return this._gz.pipe(destination, options);
     }
 }

--- a/tools/sourcemap-tools/src/commands/loadSourceMaps.ts
+++ b/tools/sourcemap-tools/src/commands/loadSourceMaps.ts
@@ -13,7 +13,7 @@ export function loadSourceMap(asset: Asset) {
     );
 }
 
-export function stripSourcesContent(asset: AssetWithContent<RawSourceMap>): AssetWithContent<RawSourceMap> {
+export function stripSourcesContent<T extends AssetWithContent<RawSourceMap>>(asset: T): T {
     return {
         ...asset,
         content: {

--- a/tools/sourcemap-tools/src/commands/uploadArchive.ts
+++ b/tools/sourcemap-tools/src/commands/uploadArchive.ts
@@ -3,6 +3,6 @@ import { ZipArchive } from '../ZipArchive';
 
 export function uploadArchive(symbolUploader: SymbolUploader) {
     return function uploadArchive(archive: ZipArchive) {
-        return symbolUploader.uploadSymbol(archive);
+        return symbolUploader.uploadSymbol(archive.stream);
     };
 }

--- a/tools/sourcemap-tools/tests/ZipArchive.spec.ts
+++ b/tools/sourcemap-tools/tests/ZipArchive.spec.ts
@@ -20,7 +20,7 @@ describe('ZipArchive', () => {
     it('should create a zip archive', async () => {
         const archive = new ZipArchive();
         const outputStream = fs.createWriteStream(outputFile);
-        archive.pipe(outputStream);
+        archive.stream.pipe(outputStream);
 
         const entries = [
             ['entry1', 'entry1Data'],


### PR DESCRIPTION
This PR hopefully fixes the random test failures.

After adding this change, running `npm run test --upload` 40 times succeeded every time.
Before the change, I was getting at least one failure per 20 runs.