### PR TITLE
scripts: add scripts for making releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
             ],
             "devDependencies": {
                 "@types/node": "^14.18.51",
+                "@types/semver": "^7.5.3",
                 "@typescript-eslint/eslint-plugin": "^5.59.7",
                 "@typescript-eslint/parser": "^5.59.7",
                 "eslint": "^8.41.0",
@@ -32,6 +33,7 @@
                 "eslint-plugin-local-rules": "^1.3.2",
                 "prettier": "^2.8.8",
                 "rimraf": "^5.0.1",
+                "semver": "^7.5.4",
                 "ts-node": "^10.9.1",
                 "typescript": "^5.0.4"
             }
@@ -15558,7 +15560,7 @@
         },
         "packages/browser": {
             "name": "@backtrace/browser",
-            "version": "0.0.5",
+            "version": "0.1.0",
             "license": "MIT",
             "dependencies": {
                 "@backtrace/sdk-core": "^0.1.0",
@@ -15591,7 +15593,7 @@
         },
         "packages/nestjs": {
             "name": "@backtrace/nestjs",
-            "version": "0.0.1",
+            "version": "0.1.0",
             "license": "MIT",
             "dependencies": {
                 "@backtrace/node": "^0.1.0"
@@ -15621,7 +15623,7 @@
         },
         "packages/node": {
             "name": "@backtrace/node",
-            "version": "0.0.6",
+            "version": "0.1.0",
             "license": "MIT",
             "dependencies": {
                 "@backtrace/sdk-core": "^0.1.0",
@@ -18314,6 +18316,297 @@
             "license": "MIT",
             "dependencies": {
                 "@types/react": "*"
+            }
+        },
+        "packages/react-native/node_modules/@types/scheduler": {
+            "version": "0.16.3",
+            "dev": true,
+            "license": "MIT"
+        },
+        "packages/react-native/node_modules/@types/yargs-parser": {
+            "version": "21.0.0",
+            "dev": true,
+            "license": "MIT"
+        },
+        "packages/react-native/node_modules/@typescript-eslint/eslint-plugin": {
+            "version": "5.62.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/regexpp": "^4.4.0",
+                "@typescript-eslint/scope-manager": "5.62.0",
+                "@typescript-eslint/type-utils": "5.62.0",
+                "@typescript-eslint/utils": "5.62.0",
+                "debug": "^4.3.4",
+                "graphemer": "^1.4.0",
+                "ignore": "^5.2.0",
+                "natural-compare-lite": "^1.4.0",
+                "semver": "^7.3.7",
+                "tsutils": "^3.21.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/parser": "^5.0.0",
+                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/react-native/node_modules/@typescript-eslint/eslint-plugin/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "packages/react-native/node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
+            "version": "7.5.4",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "packages/react-native/node_modules/@typescript-eslint/eslint-plugin/node_modules/yallist": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "ISC"
+        },
+        "packages/react-native/node_modules/@typescript-eslint/parser": {
+            "version": "5.62.0",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "@typescript-eslint/scope-manager": "5.62.0",
+                "@typescript-eslint/types": "5.62.0",
+                "@typescript-eslint/typescript-estree": "5.62.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/react-native/node_modules/@typescript-eslint/scope-manager": {
+            "version": "5.62.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "5.62.0",
+                "@typescript-eslint/visitor-keys": "5.62.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "packages/react-native/node_modules/@typescript-eslint/type-utils": {
+            "version": "5.62.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/typescript-estree": "5.62.0",
+                "@typescript-eslint/utils": "5.62.0",
+                "debug": "^4.3.4",
+                "tsutils": "^3.21.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "*"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/react-native/node_modules/@typescript-eslint/types": {
+            "version": "5.62.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "packages/react-native/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "5.62.0",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "@typescript-eslint/types": "5.62.0",
+                "@typescript-eslint/visitor-keys": "5.62.0",
+                "debug": "^4.3.4",
+                "globby": "^11.1.0",
+                "is-glob": "^4.0.3",
+                "semver": "^7.3.7",
+                "tsutils": "^3.21.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/react-native/node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "packages/react-native/node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+            "version": "7.5.4",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "packages/react-native/node_modules/@typescript-eslint/typescript-estree/node_modules/yallist": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "ISC"
+        },
+        "packages/react-native/node_modules/@typescript-eslint/utils": {
+            "version": "5.62.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.2.0",
+                "@types/json-schema": "^7.0.9",
+                "@types/semver": "^7.3.12",
+                "@typescript-eslint/scope-manager": "5.62.0",
+                "@typescript-eslint/types": "5.62.0",
+                "@typescript-eslint/typescript-estree": "5.62.0",
+                "eslint-scope": "^5.1.1",
+                "semver": "^7.3.7"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "packages/react-native/node_modules/@typescript-eslint/utils/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "packages/react-native/node_modules/@typescript-eslint/utils/node_modules/semver": {
+            "version": "7.5.4",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "packages/react-native/node_modules/@typescript-eslint/utils/node_modules/yallist": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "ISC"
+        },
+        "packages/react-native/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "5.62.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "5.62.0",
+                "eslint-visitor-keys": "^3.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "packages/react-native/node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "packages/react-native/node_modules/abort-controller": {
@@ -21940,7 +22233,7 @@
         },
         "tools/sourcemap-tools": {
             "name": "@backtrace/sourcemap-tools",
-            "version": "0.1.0",
+            "version": "0.2.0",
             "license": "MIT",
             "dependencies": {
                 "tar-stream": "^3.1.6"
@@ -21962,7 +22255,7 @@
         },
         "tools/vite-plugin": {
             "name": "@backtrace/vite-plugin",
-            "version": "0.0.2",
+            "version": "0.1.0",
             "license": "MIT",
             "dependencies": {
                 "@backtrace/rollup-plugin": "^0.1.0"
@@ -24302,6 +24595,163 @@
                     "dev": true,
                     "requires": {
                         "@types/react": "*"
+                    }
+                },
+                "@types/scheduler": {
+                    "version": "0.16.3",
+                    "dev": true
+                },
+                "@types/yargs-parser": {
+                    "version": "21.0.0",
+                    "dev": true
+                },
+                "@typescript-eslint/eslint-plugin": {
+                    "version": "5.62.0",
+                    "dev": true,
+                    "requires": {
+                        "@eslint-community/regexpp": "^4.4.0",
+                        "@typescript-eslint/scope-manager": "5.62.0",
+                        "@typescript-eslint/type-utils": "5.62.0",
+                        "@typescript-eslint/utils": "5.62.0",
+                        "debug": "^4.3.4",
+                        "graphemer": "^1.4.0",
+                        "ignore": "^5.2.0",
+                        "natural-compare-lite": "^1.4.0",
+                        "semver": "^7.3.7",
+                        "tsutils": "^3.21.0"
+                    },
+                    "dependencies": {
+                        "lru-cache": {
+                            "version": "6.0.0",
+                            "dev": true,
+                            "requires": {
+                                "yallist": "^4.0.0"
+                            }
+                        },
+                        "semver": {
+                            "version": "7.5.4",
+                            "dev": true,
+                            "requires": {
+                                "lru-cache": "^6.0.0"
+                            }
+                        },
+                        "yallist": {
+                            "version": "4.0.0",
+                            "dev": true
+                        }
+                    }
+                },
+                "@typescript-eslint/parser": {
+                    "version": "5.62.0",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/scope-manager": "5.62.0",
+                        "@typescript-eslint/types": "5.62.0",
+                        "@typescript-eslint/typescript-estree": "5.62.0",
+                        "debug": "^4.3.4"
+                    }
+                },
+                "@typescript-eslint/scope-manager": {
+                    "version": "5.62.0",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "5.62.0",
+                        "@typescript-eslint/visitor-keys": "5.62.0"
+                    }
+                },
+                "@typescript-eslint/type-utils": {
+                    "version": "5.62.0",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/typescript-estree": "5.62.0",
+                        "@typescript-eslint/utils": "5.62.0",
+                        "debug": "^4.3.4",
+                        "tsutils": "^3.21.0"
+                    }
+                },
+                "@typescript-eslint/types": {
+                    "version": "5.62.0",
+                    "dev": true
+                },
+                "@typescript-eslint/typescript-estree": {
+                    "version": "5.62.0",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "5.62.0",
+                        "@typescript-eslint/visitor-keys": "5.62.0",
+                        "debug": "^4.3.4",
+                        "globby": "^11.1.0",
+                        "is-glob": "^4.0.3",
+                        "semver": "^7.3.7",
+                        "tsutils": "^3.21.0"
+                    },
+                    "dependencies": {
+                        "lru-cache": {
+                            "version": "6.0.0",
+                            "dev": true,
+                            "requires": {
+                                "yallist": "^4.0.0"
+                            }
+                        },
+                        "semver": {
+                            "version": "7.5.4",
+                            "dev": true,
+                            "requires": {
+                                "lru-cache": "^6.0.0"
+                            }
+                        },
+                        "yallist": {
+                            "version": "4.0.0",
+                            "dev": true
+                        }
+                    }
+                },
+                "@typescript-eslint/utils": {
+                    "version": "5.62.0",
+                    "dev": true,
+                    "requires": {
+                        "@eslint-community/eslint-utils": "^4.2.0",
+                        "@types/json-schema": "^7.0.9",
+                        "@types/semver": "^7.3.12",
+                        "@typescript-eslint/scope-manager": "5.62.0",
+                        "@typescript-eslint/types": "5.62.0",
+                        "@typescript-eslint/typescript-estree": "5.62.0",
+                        "eslint-scope": "^5.1.1",
+                        "semver": "^7.3.7"
+                    },
+                    "dependencies": {
+                        "lru-cache": {
+                            "version": "6.0.0",
+                            "dev": true,
+                            "requires": {
+                                "yallist": "^4.0.0"
+                            }
+                        },
+                        "semver": {
+                            "version": "7.5.4",
+                            "dev": true,
+                            "requires": {
+                                "lru-cache": "^6.0.0"
+                            }
+                        },
+                        "yallist": {
+                            "version": "4.0.0",
+                            "dev": true
+                        }
+                    }
+                },
+                "@typescript-eslint/visitor-keys": {
+                    "version": "5.62.0",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "5.62.0",
+                        "eslint-visitor-keys": "^3.3.0"
+                    },
+                    "dependencies": {
+                        "eslint-visitor-keys": {
+                            "version": "3.4.3",
+                            "dev": true
+                        }
                     }
                 },
                 "abort-controller": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "homepage": "https://github.com/backtrace-labs/backtrace-javascript#readme",
     "devDependencies": {
         "@types/node": "^14.18.51",
+        "@types/semver": "^7.5.3",
         "@typescript-eslint/eslint-plugin": "^5.59.7",
         "@typescript-eslint/parser": "^5.59.7",
         "eslint": "^8.41.0",
@@ -56,6 +57,7 @@
         "eslint-plugin-local-rules": "^1.3.2",
         "prettier": "^2.8.8",
         "rimraf": "^5.0.1",
+        "semver": "^7.5.4",
         "ts-node": "^10.9.1",
         "typescript": "^5.0.4"
     }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,117 @@
+# Scripts
+
+This doc covers helper scripts that are available in this repo.
+
+# `syncVersions.ts`
+
+Synchronizes dependency versions. Useful for making sure that e.g. node is using the correct sdk-core version.
+
+## Usage
+
+```
+syncVersions.ts [...package.json paths]
+```
+
+### Examples
+
+-   Sync versions of all packages
+
+    ```
+    syncVersions.ts
+    ```
+
+-   Sync versions of specific packages
+    ```
+    syncVersions.ts ./path/to/package.json ./path/to/different/package.json
+    ```
+
+# `gitRelease.ts`
+
+Creates a git release for a package by doing the following:
+
+1. Update `package.json` with the new version,
+1. Run `npm install` to generate a valid `package-lock.json` file,
+1. Stage `package.json` and `package-lock.json`,
+1. Create branch `<package name>/<new version>` and checkout to it,
+1. Commit with message `<package name>: version <new version>`,
+1. Push to `<package name>/<new version>`.
+
+If something goes wrong on any of the steps, the script will try to rollback the changes.
+
+## Usage
+
+```
+gitRelease.ts [opts] <package.json path> <release|version> [identifier]
+```
+
+### Options:
+
+-   `release` - can be one of `major`, `premajor`, `minor`, `preminor`, `patch`, `prepatch`, `prerelease`
+-   `version` - semantic version
+-   `identifier` - identifier for preleases, e.g. `alpha` or `beta`
+
+-   `--dry-run` - does not do anything, just prints the output
+-   `--no-add` - exits before staging any files
+-   `--no-checkout` - exits before creating and checkouting to the branch
+-   `--no-commit` - exits before creating a commit
+-   `--no-push` - exits before pushing
+
+### Examples:
+
+-   Make a minor release
+
+    ```
+    gitRelease.ts ./path/to/package.json minor
+    ```
+
+-   Make a beta prerelase without pushing
+
+    ```
+    gitRelease.ts ./path/to/package.json prerelase beta --no-push
+    ```
+
+-   Check what happens with making a release with version 1.2.3
+    ```
+    gitRelease.ts ./path/to/package.json 1.2.3 --dry-run
+    ```
+
+# `release.ts`
+
+Creates a tagged release and publishes it to npm:
+
+1. Create tag `<package name>/<version>`,
+2. Push tag to remote,
+3. Run `npm publish`.
+
+The version is read from the `package.json` file. If something goes wrong on any of the steps, the script will try to
+rollback the changes.
+
+## Usage
+
+```
+release.ts [opts] <package.json path> [commit hash]
+```
+
+### Options
+
+-   `commit hash` - if specified, tag will be added on this hash instead of `HEAD`. **Warning: checkout is not performed
+    currently**
+
+-   `--dry-run` - does not do anything, just prints the output
+-   `--no-tag` - does not add and push a tag
+-   `--no-push-tag` - does not push the tag
+-   `--no-publish` - does not publish to npm
+
+### Examples
+
+-   Make a release of package
+
+    ```
+    release.ts ./path/to/package.json
+    ```
+
+-   Make a release of package without publishing to npm and add tag on hash `b19f45885a21ba7235c32aae62c4c73199f40ca6`
+
+    ```
+    release.ts ./path/to/package.json b19f45885a21ba7235c32aae62c4c73199f40ca6 --no-publish
+    ```

--- a/scripts/common/commands.ts
+++ b/scripts/common/commands.ts
@@ -1,0 +1,38 @@
+import { SpawnSyncReturns, spawnSync } from 'child_process';
+
+export interface SpawnCommandOptions {
+    readonly command: string;
+    readonly args?: string[];
+    readonly cwd?: string;
+    response?(res: SpawnSyncReturns<string>): string;
+    validate?(res: SpawnSyncReturns<string>): boolean;
+}
+
+export function spawnCommandSync(opts: SpawnCommandOptions) {
+    const output = spawnSync(opts.command, opts.args ?? [], {
+        encoding: 'utf-8',
+        cwd: opts.cwd,
+    });
+
+    if ((opts.validate && !opts.validate(output)) || output.status) {
+        throw new Error(`Failed to execute ${opts.command}: ${output.stderr || output.stdout}`);
+    }
+
+    return opts.response ? opts.response(output) : output.stdout;
+}
+
+export function printCommand(opts: SpawnCommandOptions) {
+    console.log('+', opts.command, ...(opts.args ?? []));
+    return opts;
+}
+
+export function executor(dryRun?: boolean) {
+    return (opts: SpawnCommandOptions) => {
+        printCommand(opts);
+        if (dryRun) {
+            return '<dry-run>';
+        }
+
+        return spawnCommandSync(opts);
+    };
+}

--- a/scripts/common/git.ts
+++ b/scripts/common/git.ts
@@ -89,3 +89,36 @@ export function gitPush(branch?: string, remote?: string) {
         ],
     };
 }
+
+export function gitAddTag(name: string, commitHash?: string) {
+    const args = ['tag', name];
+    if (commitHash) {
+        args.push(commitHash);
+    }
+
+    return {
+        command: 'git',
+        args,
+    };
+}
+
+export function gitRemoveTag(name: string) {
+    return {
+        command: 'git',
+        args: ['tag', '-d', name],
+    };
+}
+
+export function gitPushTag(name: string, remote?: string) {
+    return {
+        command: 'git',
+        args: ['push', remote ?? spawnCommandSync(gitGetRemote()), `refs/tags/${name}`],
+    };
+}
+
+export function gitRemoveTagRemote(name: string, remote?: string) {
+    return {
+        command: 'git',
+        args: ['push', '--delete', remote ?? spawnCommandSync(gitGetRemote()), `refs/tags/${name}`],
+    };
+}

--- a/scripts/common/git.ts
+++ b/scripts/common/git.ts
@@ -1,0 +1,91 @@
+import { SpawnCommandOptions, spawnCommandSync } from './commands';
+
+export function gitGetCurrentBranch(): SpawnCommandOptions {
+    return {
+        command: 'git',
+        args: ['branch', '--show-current'],
+        response: (res) => res.stdout.trim(),
+    };
+}
+
+export function gitGetRemote(): SpawnCommandOptions {
+    return {
+        command: 'git',
+        args: ['remote', 'show'],
+        response(output) {
+            const remotes = output.stdout.trim().split('\n');
+            if (remotes.find((r) => r === 'origin')) {
+                return 'origin';
+            }
+            return remotes[0];
+        },
+    };
+}
+
+export function gitAdd(...paths: string[]): SpawnCommandOptions {
+    return {
+        command: 'git',
+        args: ['add', '--', ...paths],
+    };
+}
+
+export function gitReset(...paths: string[]): SpawnCommandOptions {
+    return {
+        command: 'git',
+        args: ['reset', '--', ...paths],
+    };
+}
+
+export function gitCommit(message: string): SpawnCommandOptions {
+    return {
+        command: 'git',
+        args: ['commit', '-m', message],
+    };
+}
+
+export function gitResetToCommit(hash: string): SpawnCommandOptions {
+    return {
+        command: 'git',
+        args: ['reset', '--soft', hash],
+    };
+}
+
+export function gitCheckoutToBranch(branch: string) {
+    return {
+        command: 'git',
+        args: ['checkout', branch],
+    };
+}
+
+export function gitCreateBranch(branch: string) {
+    return {
+        command: 'git',
+        args: ['branch', branch],
+    };
+}
+
+export function gitDeleteBranch(branch: string) {
+    return {
+        command: 'git',
+        args: ['branch', '-D', branch],
+    };
+}
+
+export function gitRestoreFile(file: string) {
+    return {
+        command: 'git',
+        args: ['checkout', 'HEAD', '--', file],
+    };
+}
+
+export function gitPush(branch?: string, remote?: string) {
+    return {
+        command: 'git',
+        args: [
+            'push',
+            '-u',
+            remote ?? spawnCommandSync(gitGetRemote()),
+            branch ?? spawnCommandSync(gitGetCurrentBranch()),
+        ],
+    };
+}

--- a/scripts/common/output.ts
+++ b/scripts/common/output.ts
@@ -1,0 +1,3 @@
+export function log(message: string) {
+    process.stderr.write(message + '\n');
+}

--- a/scripts/common/packageJson.ts
+++ b/scripts/common/packageJson.ts
@@ -53,3 +53,11 @@ export function npmInstall(): SpawnCommandOptions {
         cwd: rootDir,
     };
 }
+
+export function npmPublish(packageJsonPath: string) {
+    return {
+        command: 'npm',
+        args: ['publish'],
+        cwd: path.dirname(packageJsonPath),
+    };
+}

--- a/scripts/common/packageJson.ts
+++ b/scripts/common/packageJson.ts
@@ -1,0 +1,55 @@
+import fs from 'fs';
+import path from 'path';
+import { SpawnCommandOptions } from './commands';
+
+const rootDir = path.join(__dirname, '../..');
+
+export interface PackageJson {
+    readonly name: string;
+    readonly version: string;
+    readonly workspaces?: string[];
+    readonly dependencies?: Record<string, string>;
+    readonly devDependencies?: Record<string, string>;
+    readonly peerDependencies?: Record<string, string>;
+}
+
+export type DependencyType = keyof Pick<PackageJson, 'dependencies' | 'devDependencies' | 'peerDependencies'>;
+
+export interface Dependency {
+    readonly name: string;
+    readonly version: string;
+    readonly type: DependencyType;
+}
+
+export async function loadPackageJson(packageJsonPath: string): Promise<PackageJson> {
+    const error = new Error(`${packageJsonPath} does not seem to be a valid package.json file`);
+
+    let packageJson: Partial<PackageJson>;
+    try {
+        packageJson = JSON.parse(await fs.promises.readFile(packageJsonPath, 'utf-8')) as Partial<PackageJson>;
+    } catch {
+        throw error;
+    }
+
+    if (!packageJson.name || !packageJson.version) {
+        throw error;
+    }
+
+    return packageJson as PackageJson;
+}
+
+export async function savePackageJson(packageJsonPath: string, packageJson: PackageJson) {
+    return await fs.promises.writeFile(packageJsonPath, JSON.stringify(packageJson, null, '    ') + '\n');
+}
+
+export function getWorkspacePackageJsonPaths(packageJson: PackageJson) {
+    return packageJson.workspaces?.map((workspaceDir) => path.join(rootDir, workspaceDir, 'package.json')) ?? [];
+}
+
+export function npmInstall(): SpawnCommandOptions {
+    return {
+        command: 'npm',
+        args: ['install'],
+        cwd: rootDir,
+    };
+}

--- a/scripts/common/packageJson.ts
+++ b/scripts/common/packageJson.ts
@@ -22,17 +22,23 @@ export interface Dependency {
 }
 
 export async function loadPackageJson(packageJsonPath: string): Promise<PackageJson> {
-    const error = new Error(`${packageJsonPath} does not seem to be a valid package.json file`);
+    function throwLoadError(error: unknown): never {
+        throw new Error(
+            `${packageJsonPath} does not seem to be a valid package.json file: ${
+                error instanceof Error ? error.message : String(error)
+            }`,
+        );
+    }
 
     let packageJson: Partial<PackageJson>;
     try {
         packageJson = JSON.parse(await fs.promises.readFile(packageJsonPath, 'utf-8')) as Partial<PackageJson>;
-    } catch {
-        throw error;
+    } catch (err) {
+        throwLoadError(err);
     }
 
     if (!packageJson.name || !packageJson.version) {
-        throw error;
+        throwLoadError('no name or version key found');
     }
 
     return packageJson as PackageJson;

--- a/scripts/common/transaction.ts
+++ b/scripts/common/transaction.ts
@@ -1,0 +1,43 @@
+import { log } from './output';
+
+export type TrasnactionFn = [
+    description: string,
+    fn: (context: unknown) => Promise<unknown> | unknown,
+    undo?: (context: unknown) => Promise<unknown> | unknown,
+];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const noop: TrasnactionFn = [
+    'noop',
+    () => {
+        // Do nothing
+    },
+];
+
+export function transaction(...fns: TrasnactionFn[]) {
+    return async (context?: unknown) => {
+        const undos: ((context: unknown) => Promise<unknown> | unknown)[] = [];
+
+        for (const [description, fn, undo] of fns) {
+            try {
+                context = await fn(context);
+                if (undo) {
+                    undos.push(undo);
+                }
+            } catch (err) {
+                log(`ERROR! Failed to run "${description}". Rollbacking...`);
+                try {
+                    for (const undoFn of undos.reverse()) {
+                        await undoFn(context);
+                    }
+                } catch (undoErr) {
+                    log('Failed to rollback changes!');
+                    log(`Rollback error: ${undoErr instanceof Error ? undoErr.stack : undoErr}`);
+                    throw err;
+                }
+
+                throw err;
+            }
+        }
+    };
+}

--- a/scripts/gitRelease.ts
+++ b/scripts/gitRelease.ts
@@ -64,10 +64,6 @@ async function main() {
 
     const argv = process.argv.slice(2);
     const [packageJsonPath, versionOrRelease, identifier] = argv.filter((v) => !options.includes(v as never));
-    const optionValues = options.reduce((val, k) => {
-        val[k] = argv.includes(k);
-        return val;
-    }, {} as Record<(typeof options)[number], boolean>);
 
     if (!packageJsonPath) {
         throw new Error('first argument must be a package.json path');
@@ -76,6 +72,11 @@ async function main() {
     if (!versionOrRelease) {
         throw new Error('second argument must be a version or release type');
     }
+
+    const optionValues = options.reduce((val, k) => {
+        val[k] = argv.includes(k);
+        return val;
+    }, {} as Record<(typeof options)[number], boolean>);
 
     const dryRun = optionValues['--dry-run'];
     if (dryRun) {

--- a/scripts/gitRelease.ts
+++ b/scripts/gitRelease.ts
@@ -1,0 +1,151 @@
+#!/usr/bin/env -S node -r ts-node/register
+
+/**
+ * 1. Increment version
+ * 2. Checkout to release/<new version>
+ * 3. npm i
+ * 4. commit package.json of package and package-lock.json
+ * 5. push to release/<new version>
+ */
+
+import path from 'path';
+import semver, { ReleaseType, SemVer } from 'semver';
+import { executor } from './common/commands';
+import {
+    gitAdd,
+    gitCheckoutToBranch,
+    gitCommit,
+    gitCreateBranch,
+    gitDeleteBranch,
+    gitGetCurrentBranch,
+    gitPush,
+    gitReset,
+    gitResetToCommit,
+    gitRestoreFile,
+} from './common/git';
+import { log } from './common/output';
+import { PackageJson, loadPackageJson, npmInstall, savePackageJson } from './common/packageJson';
+import { TrasnactionFn, noop, transaction } from './common/transaction';
+
+const rootDir = path.join(__dirname, '..');
+
+function updateVersion(
+    packageJson: PackageJson,
+    versionOrRelease: ReleaseType | string,
+    identifier?: string,
+    rawIdentifierBase?: string,
+): PackageJson {
+    let version = packageJson.version;
+    try {
+        const identifierBase: semver.inc.IdentifierBase | false | undefined =
+            rawIdentifierBase === '0' || rawIdentifierBase === '1'
+                ? rawIdentifierBase
+                : rawIdentifierBase === 'false'
+                ? false
+                : undefined;
+
+        const result = semver.inc(version, versionOrRelease as ReleaseType, identifier, identifierBase);
+        if (result == null) {
+            throw new Error('failed to increment version');
+        }
+        version = result;
+    } catch {
+        version = new SemVer(versionOrRelease).raw;
+    }
+
+    return {
+        ...packageJson,
+        version: version,
+    };
+}
+
+async function main() {
+    const options = ['--dry-run', '--no-push', '--no-commit', '--no-checkout', '--no-add'] as const;
+
+    const argv = process.argv.slice(2);
+    const [packageJsonPath, versionOrRelease, identifier] = argv.filter((v) => !options.includes(v as never));
+    const optionValues = options.reduce((val, k) => {
+        val[k] = argv.includes(k);
+        return val;
+    }, {} as Record<(typeof options)[number], boolean>);
+
+    if (!packageJsonPath) {
+        throw new Error('first argument must be a package.json path');
+    }
+
+    if (!versionOrRelease) {
+        throw new Error('second argument must be a version or release type');
+    }
+
+    const dryRun = optionValues['--dry-run'];
+    if (dryRun) {
+        log('dry run enabled');
+    }
+
+    const execute = executor(dryRun);
+
+    const packageLockPath = path.relative(process.cwd(), path.join(rootDir, 'package-lock.json'));
+    const packageJson = await loadPackageJson(packageJsonPath);
+    const packageName = packageJson.name.replace('@backtrace-labs/', '');
+    const updatedPackageJson = updateVersion(packageJson, versionOrRelease, identifier);
+    const currentBranch = execute(gitGetCurrentBranch());
+    const branchName = `${packageName}/${updatedPackageJson.version}`;
+
+    log(`updating version from ${packageJson.version} to ${updatedPackageJson.version}`);
+
+    const exit: TrasnactionFn = [
+        'exit',
+        () => {
+            console.log(packageJsonPath);
+            process.exit(0);
+        },
+    ];
+
+    const run = transaction(
+        dryRun
+            ? noop
+            : [
+                  'save package json',
+                  () => savePackageJson(packageJsonPath, updatedPackageJson),
+                  () => savePackageJson(packageJsonPath, packageJson),
+              ],
+        ['npm install', () => execute(npmInstall()), () => execute(gitRestoreFile(packageLockPath))],
+        optionValues['--no-add']
+            ? exit
+            : [
+                  'add package.json to git',
+                  () => execute(gitAdd(packageJsonPath)),
+                  () => execute(gitReset(packageJsonPath)),
+              ],
+        optionValues['--no-add']
+            ? exit
+            : [
+                  'add package-lock.json to git',
+                  () => execute(gitAdd(packageLockPath)),
+                  () => execute(gitReset(packageLockPath)),
+              ],
+        optionValues['--no-checkout']
+            ? exit
+            : ['create branch', () => execute(gitCreateBranch(branchName)), () => execute(gitDeleteBranch(branchName))],
+        [
+            'checkout to branch',
+            () => execute(gitCheckoutToBranch(branchName)),
+            () => execute(gitCheckoutToBranch(currentBranch)),
+        ],
+        optionValues['--no-commit']
+            ? exit
+            : [
+                  'commit changes',
+                  () => execute(gitCommit(`${packageName}: version ${updatedPackageJson.version}`)),
+                  () => execute(gitResetToCommit('HEAD~1')),
+              ],
+        optionValues['--no-push'] ? exit : ['push to remote', () => log(execute(gitPush(branchName)))],
+        exit,
+    );
+
+    run();
+}
+
+if (require.main === module) {
+    main();
+}

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env -S node -r ts-node/register
+
+/**
+ * 1. Create tag
+ * 2. Push tag
+ * 3. Publish package
+ */
+
+import { executor } from './common/commands';
+import { gitAddTag, gitPushTag, gitRemoveTag, gitRemoveTagRemote } from './common/git';
+import { log } from './common/output';
+import { loadPackageJson, npmPublish } from './common/packageJson';
+import { TrasnactionFn, noop, transaction } from './common/transaction';
+
+async function main() {
+    const options = ['--dry-run', '--no-tag', '--no-push-tag', '--no-publish'] as const;
+
+    const argv = process.argv.slice(2);
+    const [packageJsonPath, commitHash] = argv.filter((v) => !options.includes(v as never));
+    const optionValues = options.reduce((val, k) => {
+        val[k] = argv.includes(k);
+        return val;
+    }, {} as Record<(typeof options)[number], boolean>);
+
+    if (!packageJsonPath) {
+        throw new Error('first argument must be a package.json path');
+    }
+
+    const dryRun = optionValues['--dry-run'];
+    if (dryRun) {
+        log('dry run enabled');
+    }
+
+    const execute = executor(dryRun);
+
+    const packageJson = await loadPackageJson(packageJsonPath);
+    const packageName = packageJson.name.replace('@backtrace-labs/', '');
+    const tagName = `${packageName}/${packageJson.version}`;
+
+    log(`releasing version ${packageJson.version}`);
+
+    const exit: TrasnactionFn = [
+        'exit',
+        () => {
+            console.log(packageJsonPath);
+            process.exit(0);
+        },
+    ];
+
+    const run = transaction(
+        optionValues['--no-tag']
+            ? noop
+            : ['add tag', () => execute(gitAddTag(tagName, commitHash)), () => execute(gitRemoveTag(tagName))],
+        optionValues['--no-tag'] || optionValues['--no-push-tag']
+            ? noop
+            : ['push tag', () => execute(gitPushTag(tagName)), () => execute(gitRemoveTagRemote(tagName))],
+        optionValues['--no-publish'] ? noop : ['npm publish', () => execute(npmPublish(packageJsonPath))],
+        exit,
+    );
+
+    run();
+}
+
+if (require.main === module) {
+    main();
+}

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -17,14 +17,15 @@ async function main() {
 
     const argv = process.argv.slice(2);
     const [packageJsonPath, commitHash] = argv.filter((v) => !options.includes(v as never));
-    const optionValues = options.reduce((val, k) => {
-        val[k] = argv.includes(k);
-        return val;
-    }, {} as Record<(typeof options)[number], boolean>);
 
     if (!packageJsonPath) {
         throw new Error('first argument must be a package.json path');
     }
+
+    const optionValues = options.reduce((val, k) => {
+        val[k] = argv.includes(k);
+        return val;
+    }, {} as Record<(typeof options)[number], boolean>);
 
     const dryRun = optionValues['--dry-run'];
     if (dryRun) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,10 @@
         {
             "path": "./tools/webpack-plugin/tsconfig.build.json"
         }
-    ]
+    ],
+    "ts-node": {
+        "compilerOptions": {
+            "target": "ES2019"
+        }
+    }
 }


### PR DESCRIPTION
This PR adds two scripts:
* gitRelease.ts - for a package, increments version, commits the version update to `<package>/<version>`
* release.ts - for a package, releases current version and creates a tag on HEAD or provided commit hash

Scripts have a rudimentary transaction capability - if something fails on the way, the script will try to undo all stuff it did.

sdk-core/0.0.7 was released using these scripts.