### PR TITLE
react-native: Add support for unhandled exception handler on Android

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11946,14 +11946,16 @@
             }
         },
         "node_modules/ts-loader": {
-            "version": "9.4.4",
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.0.tgz",
+            "integrity": "sha512-LLlB/pkB4q9mW2yLdFMnK3dEHbrBjeZTYguaaIfusyojBgAGf5kF+O6KcWqiGzWqHk0LBsoolrp4VftEURhybg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "chalk": "^4.1.0",
                 "enhanced-resolve": "^5.0.0",
                 "micromatch": "^4.0.0",
-                "semver": "^7.3.4"
+                "semver": "^7.3.4",
+                "source-map": "^0.7.4"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -14049,13 +14051,17 @@
             },
             "devDependencies": {
                 "@react-native-community/eslint-config": "^3.0.2",
+                "@types/jest": "^29.5.5",
                 "@types/react": "~17.0.21",
                 "@types/react-native": "0.70.0",
+                "jest": "^29.7.0",
                 "pod-install": "^0.1.0",
                 "prettier": "^2.0.5",
                 "react": "18.2.0",
                 "react-native": "^0.72.4",
                 "react-native-builder-bob": "^0.21.3",
+                "ts-jest": "^29.1.1",
+                "ts-loader": "^9.5.0",
                 "typescript": "^5.0.2"
             },
             "engines": {
@@ -25800,16 +25806,20 @@
         "@backtrace-labs/react-native": {
             "version": "file:packages/react-native",
             "requires": {
-                "@backtrace-labs/react": "0.0.5",
+                "@backtrace-labs/react": "^0.0.5",
                 "@backtrace-labs/sdk-core": "^0.0.7",
                 "@react-native-community/eslint-config": "^3.0.2",
+                "@types/jest": "^29.5.5",
                 "@types/react": "~17.0.21",
                 "@types/react-native": "0.70.0",
+                "jest": "^29.7.0",
                 "pod-install": "^0.1.0",
                 "prettier": "^2.0.5",
                 "react": "18.2.0",
                 "react-native": "^0.72.4",
                 "react-native-builder-bob": "^0.21.3",
+                "ts-jest": "^29.1.1",
+                "ts-loader": "^9.5.0",
                 "typescript": "^5.0.2"
             },
             "dependencies": {
@@ -40387,13 +40397,16 @@
             }
         },
         "ts-loader": {
-            "version": "9.4.4",
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.0.tgz",
+            "integrity": "sha512-LLlB/pkB4q9mW2yLdFMnK3dEHbrBjeZTYguaaIfusyojBgAGf5kF+O6KcWqiGzWqHk0LBsoolrp4VftEURhybg==",
             "dev": true,
             "requires": {
                 "chalk": "^4.1.0",
                 "enhanced-resolve": "^5.0.0",
                 "micromatch": "^4.0.0",
-                "semver": "^7.3.4"
+                "semver": "^7.3.4",
+                "source-map": "^0.7.4"
             }
         },
         "ts-loader-webpack-4": {

--- a/packages/react-native/jest.config.js
+++ b/packages/react-native/jest.config.js
@@ -1,0 +1,6 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+    preset: 'react-native',
+    testEnvironment: 'node',
+    setupFiles: ['./jest.setup.js'],
+};

--- a/packages/react-native/jest.setup.js
+++ b/packages/react-native/jest.setup.js
@@ -1,0 +1,2 @@
+global.BACKTRACE_AGENT_NAME = 'test';
+global.BACKTRACE_AGENT_VERSION = 'test';

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -30,7 +30,8 @@
         "build": "bob build",
         "clean": "rimraf \"lib\"",
         "format:check": "eslint \"**/*.{js,ts,tsx}\"",
-        "prepublishOnly": "bob build"
+        "prepublishOnly": "bob build",
+        "test": "NODE_ENV=test jest"
     },
     "keywords": [
         "Error",
@@ -55,13 +56,6 @@
     "engines": {
         "node": ">= 16.0.0"
     },
-    "jest": {
-        "preset": "react-native",
-        "modulePathIgnorePatterns": [
-            "<rootDir>/example/node_modules",
-            "<rootDir>/lib/"
-        ]
-    },
     "react-native-builder-bob": {
         "source": "src",
         "output": "lib",
@@ -82,13 +76,17 @@
     },
     "devDependencies": {
         "@react-native-community/eslint-config": "^3.0.2",
+        "@types/jest": "^29.5.5",
         "@types/react": "~17.0.21",
         "@types/react-native": "0.70.0",
+        "jest": "^29.7.0",
         "pod-install": "^0.1.0",
         "prettier": "^2.0.5",
         "react": "18.2.0",
         "react-native": "^0.72.4",
         "react-native-builder-bob": "^0.21.3",
+        "ts-jest": "^29.1.1",
+        "ts-loader": "^9.5.0",
         "typescript": "^5.0.2"
     },
     "dependencies": {

--- a/packages/react-native/src/converters/AndroidStackTraceConverter.ts
+++ b/packages/react-native/src/converters/AndroidStackTraceConverter.ts
@@ -1,0 +1,40 @@
+import { type BacktraceStackFrame } from '@backtrace-labs/sdk-core';
+
+export class AndroidStackTraceConverter {
+    public readonly NativeLibraryName = 'Native';
+
+    public convert(androidStackTrace: string): BacktraceStackFrame[] {
+        const result: BacktraceStackFrame[] = [];
+        if (!androidStackTrace) {
+            return result;
+        }
+
+        const frames = androidStackTrace.trim().split('\n');
+        for (const frame of frames) {
+            const parameterStartIndex = frame.indexOf('(');
+            const sourceCodeInformation = frame.substring(parameterStartIndex + 1, frame.length - 1);
+            const sourceCodeInfo = sourceCodeInformation.split(':');
+            let library = sourceCodeInfo[0] as string;
+            if (frame.startsWith('java.lang') && sourceCodeInformation === 'Unknown Source') {
+                library = sourceCodeInformation;
+            }
+            if (library === 'Native Method') {
+                library = this.NativeLibraryName;
+            }
+
+            const resultFrame: BacktraceStackFrame = {
+                funcName: frame.substring(0, parameterStartIndex),
+                library,
+            };
+
+            const lineNumber = sourceCodeInfo[1];
+            if (lineNumber) {
+                resultFrame.line = parseInt(lineNumber);
+            }
+
+            result.push(resultFrame);
+        }
+
+        return result;
+    }
+}

--- a/packages/react-native/src/handlers/android/AndroidUnhandledException.ts
+++ b/packages/react-native/src/handlers/android/AndroidUnhandledException.ts
@@ -1,0 +1,5 @@
+export class AndroidUnhandledException extends Error {
+    constructor(public readonly name: string, public readonly message: string, public readonly stack: string) {
+        super(message);
+    }
+}

--- a/packages/react-native/tests/androidStackTraceConverterTests.spec.ts
+++ b/packages/react-native/tests/androidStackTraceConverterTests.spec.ts
@@ -1,0 +1,71 @@
+import { type BacktraceStackFrame } from '@backtrace-labs/sdk-core';
+import { fail } from 'assert';
+import { AndroidStackTraceConverter } from '../src/converters/AndroidStackTraceConverter';
+
+describe('Android Stack trace converter tests', () => {
+    it('Should parse correctly android stack trace', () => {
+        const testFrames: Array<BacktraceStackFrame & { frame: string }> = [
+            {
+                frame: 'com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:383)',
+                library: 'JavaMethodWrapper.java',
+                funcName: 'com.facebook.react.bridge.JavaMethodWrapper.invoke',
+                line: 383,
+            },
+            {
+                frame: 'com.facebook.jni.NativeRunnable.run(Native Method)',
+                library: 'Native',
+                funcName: 'com.facebook.jni.NativeRunnable.run',
+            },
+            {
+                frame: 'android.os.Handler.handleCallback(Handler.java:942)',
+                library: 'Handler.java',
+                funcName: 'android.os.Handler.handleCallback',
+                line: 942,
+            },
+            {
+                frame: 'com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27)',
+                library: 'MessageQueueThreadHandler.java',
+                funcName: 'com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage',
+                line: 27,
+            },
+            {
+                frame: 'java.lang.Thread.run(Thread.java:1012)',
+                library: 'Thread.java',
+                funcName: 'java.lang.Thread.run',
+                line: 1012,
+            },
+        ];
+        const androidStackTrace = testFrames.map((n) => n.frame).join('\n');
+
+        const androidStackTraceConverter = new AndroidStackTraceConverter();
+        const stackFrames = androidStackTraceConverter.convert(androidStackTrace);
+
+        for (let index = 0; index < testFrames.length; index++) {
+            expect(testFrames[index]).toMatchObject(stackFrames[index] as object);
+        }
+    });
+
+    it('Should convert native method into native library', () => {
+        const nativeMethodFrame = 'com.facebook.jni.NativeRunnable.run(Native Method)';
+        const androidStackTraceConverter = new AndroidStackTraceConverter();
+        const [stackFrame] = androidStackTraceConverter.convert(nativeMethodFrame);
+        if (!stackFrame) {
+            fail('Stack frame is not defined');
+        }
+        expect(stackFrame.library).toEqual(androidStackTraceConverter.NativeLibraryName);
+    });
+
+    it('Should trim stack trace', () => {
+        const nativeMethodFrame = ' \n\ncom.facebook.jni.NativeRunnable.run(Native Method) \n';
+        const androidStackTraceConverter = new AndroidStackTraceConverter();
+        const stackFrames = androidStackTraceConverter.convert(nativeMethodFrame);
+        expect(stackFrames.length).toBe(1);
+    });
+
+    it('Should generate an empty stack trace if stack trace is undefined', () => {
+        const androidStackTraceConverter = new AndroidStackTraceConverter();
+        const stackFrames = androidStackTraceConverter.convert(undefined as unknown as string);
+        expect(stackFrames).toBeDefined();
+        expect(stackFrames.length).toBe(0);
+    });
+});

--- a/packages/react-native/tsconfig.json
+++ b/packages/react-native/tsconfig.json
@@ -25,5 +25,6 @@
         "target": "esnext",
         "verbatimModuleSyntax": true
     },
-    "references": []
+    "references": [],
+    "exclude": ["node_modules", "tests", "lib"]
 }


### PR DESCRIPTION
# Why

This diff adds support for unhandled exceptions generated on Android.

refs BT-523