### PR TITLE
Correct reference to @backtrace/node

### DIFF
--- a/packages/nestjs/README.md
+++ b/packages/nestjs/README.md
@@ -3,7 +3,7 @@
 [Backtrace](https://backtrace.io) captures and reports handled and unhandled exceptions in your production software so
 you can manage application quality through the complete product lifecycle.
 
-The [@backtrace/node](#) SDK connects your JavaScript application to Backtrace. The basic integration is quick and easy,
+The [@backtrace/nestjs](#) SDK connects your JavaScript application to Backtrace. The basic integration is quick and easy,
 after which you can explore the rich set of Backtrace features.
 
 ## Table of Contents


### PR DESCRIPTION
Correct reference to @backtrace/node, which should be @backtrace/nestjs