### PR TITLE
Hermes react stack trace

### DIFF
--- a/packages/react-native/src/BacktraceClient.ts
+++ b/packages/react-native/src/BacktraceClient.ts
@@ -42,7 +42,7 @@ export class BacktraceClient extends BacktraceCoreClient<BacktraceConfiguration>
             },
             requestHandler: new BacktraceBrowserRequestHandler(clientSetup.options),
             debugIdMapProvider: new VariableDebugIdMapProvider(global as DebugIdContainer),
-            stackTraceConverter: new ReactStackTraceConverter(new V8StackTraceConverter()),
+            stackTraceConverter: new ReactStackTraceConverter(new V8StackTraceConverter('address-at')),
             sessionProvider: new SingleSessionProvider(),
             ...clientSetup,
         });

--- a/packages/react-native/src/BacktraceClient.ts
+++ b/packages/react-native/src/BacktraceClient.ts
@@ -42,7 +42,7 @@ export class BacktraceClient extends BacktraceCoreClient<BacktraceConfiguration>
             },
             requestHandler: new BacktraceBrowserRequestHandler(clientSetup.options),
             debugIdMapProvider: new VariableDebugIdMapProvider(global as DebugIdContainer),
-            stackTraceConverter: new ReactStackTraceConverter(new V8StackTraceConverter('address-at')),
+            stackTraceConverter: new ReactStackTraceConverter(new V8StackTraceConverter('address at')),
             sessionProvider: new SingleSessionProvider(),
             ...clientSetup,
         });

--- a/packages/sdk-core/src/modules/converter/V8StackTraceConverter.ts
+++ b/packages/sdk-core/src/modules/converter/V8StackTraceConverter.ts
@@ -64,6 +64,9 @@ export class V8StackTraceConverter implements BacktraceStackTraceConverter {
         if (sourceCodeInformation.startsWith('eval')) {
             return this.extractEvalInformation(sourceCodeInformation);
         }
+        if (sourceCodeInformation.startsWith('address at ')) {
+            sourceCodeInformation = sourceCodeInformation.substring('address at '.length);
+        }
         const sourceCodeParts = sourceCodeInformation.split(':');
         const column = parseInt(sourceCodeParts[sourceCodeParts.length - 1]);
         const lineNumber = parseInt(sourceCodeParts[sourceCodeParts.length - 2]);

--- a/packages/sdk-core/src/modules/converter/V8StackTraceConverter.ts
+++ b/packages/sdk-core/src/modules/converter/V8StackTraceConverter.ts
@@ -8,6 +8,8 @@ export class V8StackTraceConverter implements BacktraceStackTraceConverter {
         return 'v8';
     }
 
+    constructor(public readonly addressSeparator: string = '') {}
+
     convert(stackTrace: string, message: string): BacktraceStackFrame[] {
         const result: BacktraceStackFrame[] = [];
         let stackFrames = stackTrace.split('\n');
@@ -64,8 +66,8 @@ export class V8StackTraceConverter implements BacktraceStackTraceConverter {
         if (sourceCodeInformation.startsWith('eval')) {
             return this.extractEvalInformation(sourceCodeInformation);
         }
-        if (sourceCodeInformation.startsWith('address at ')) {
-            sourceCodeInformation = sourceCodeInformation.substring('address at '.length);
+        if (this.addressSeparator && sourceCodeInformation.startsWith(this.addressSeparator)) {
+            sourceCodeInformation = sourceCodeInformation.substring(this.addressSeparator.length).trimStart();
         }
         const sourceCodeParts = sourceCodeInformation.split(':');
         const column = parseInt(sourceCodeParts[sourceCodeParts.length - 1]);

--- a/packages/sdk-core/tests/converters/stackTraceConverterTests.spec.ts
+++ b/packages/sdk-core/tests/converters/stackTraceConverterTests.spec.ts
@@ -3,7 +3,7 @@ import { v8StackTraceTests } from './v8stackTraceTestCases';
 
 describe('Stack trace converter tests', () => {
     describe('v8', () => {
-        const converter = new V8StackTraceConverter();
+        const converter = new V8StackTraceConverter('address at');
 
         describe('Stack trace generator', () => {
             for (const stackTraceTest of v8StackTraceTests) {

--- a/packages/sdk-core/tests/converters/v8stackTraceTestCases.ts
+++ b/packages/sdk-core/tests/converters/v8stackTraceTestCases.ts
@@ -142,4 +142,27 @@ export const v8StackTraceTests: Array<{
             },
         ],
     },
+    {
+        name: 'Address at test',
+        test: {
+            message: 'Foo bar',
+            stackTrace: `Error: Foo bar
+                    at foo (address at main.js.bundle:1:2)
+                    at bar (address at main.js.bundle:3:4)`,
+        },
+        expectation: [
+            {
+                funcName: 'foo',
+                library: 'main.js.bundle',
+                column: 2,
+                line: 1,
+            },
+            {
+                funcName: 'bar',
+                library: 'main.js.bundle',
+                column: 4,
+                line: 3,
+            },
+        ],
+    },
 ];


### PR DESCRIPTION
# Why


This diff adds better support for Hermes-specific stack trace - it's like v8 but before source code information there might be "address at" instead of "at" like in typical v8 stack trace.