### PR TITLE
cli: support tuple paths

### DIFF
--- a/tools/cli/src/helpers/common.ts
+++ b/tools/cli/src/helpers/common.ts
@@ -57,7 +57,7 @@ export function readSourceMap<T extends Asset>(asset: T): ResultPromise<AssetWit
 }
 
 export function readSourceAndSourceMap(sourceProcessor: SourceProcessor) {
-    return async function _readSourceAndSourceMapx({
+    return async function _readSourceAndSourceMap({
         source,
         sourceMap,
     }: SourceAndSourceMapPaths): ResultPromise<SourceAndSourceMap, string> {

--- a/tools/cli/src/helpers/common.ts
+++ b/tools/cli/src/helpers/common.ts
@@ -73,8 +73,8 @@ export function readSourceAndSourceMap(sourceProcessor: SourceProcessor) {
             : await pipe(
                   loadedSource,
                   ({ content }) => sourceProcessor.getSourceMapPathFromSource(content, source.path),
-                  R.map((result) => result ?? pathIfExists(`${source.path}.map`)),
-                  R.map((path) => (path ? Ok(toAsset(path)) : Err('could not find source map for source'))),
+                  (result) => result ?? pathIfExists(`${source.path}.map`),
+                  (path) => (path ? Ok(toAsset(path)) : Err('could not find source map for source')),
                   R.map(readSourceMap),
               );
 

--- a/tools/cli/src/helpers/errorBehavior.ts
+++ b/tools/cli/src/helpers/errorBehavior.ts
@@ -36,7 +36,7 @@ export function handleError(behavior: ErrorBehavior = 'exit') {
 
             switch (behavior) {
                 case 'exit':
-                    return Err(result.data);
+                    return result;
                 case 'skip':
                     return Ok<BehaviorSkippedElement<E>>({ reason: result });
                 default:

--- a/tools/cli/src/helpers/find.ts
+++ b/tools/cli/src/helpers/find.ts
@@ -15,6 +15,7 @@ import {
 } from '@backtrace/sourcemap-tools';
 import fs from 'fs';
 import { glob } from 'glob';
+import os from 'os';
 import path from 'path';
 
 export interface FindResult {
@@ -159,10 +160,14 @@ export async function findTuples(paths: string[]): Promise<Result<FindFileTuple[
         };
     }
 
+    function isWindows() {
+        return os.platform() === 'win32';
+    }
+
     function processPath(path: string): ResultPromise<FindFileTuple[], string> {
         return pipe(
             path,
-            splitByLongest(':'),
+            splitByLongest(isWindows() ? '::' : ':'),
             verifyTupleLength(path),
             R.map(verifyTuple(path)),
             R.map(async ([path1, path2]) => ({ result: await find([path1]), path2 })),

--- a/tools/cli/src/helpers/logs.ts
+++ b/tools/cli/src/helpers/logs.ts
@@ -1,5 +1,6 @@
-import { Asset, log, LogLevel, ProcessAssetResult, SourceAndSourceMap } from '@backtrace/sourcemap-tools';
+import { Asset, log, LogLevel, ProcessAssetResult } from '@backtrace/sourcemap-tools';
 import { CliLogger } from '../logger';
+import { SourceAndSourceMapPaths } from '../models/Asset';
 
 export function logAsset(logger: CliLogger, level: LogLevel) {
     const logFn = log(logger, level);
@@ -19,5 +20,5 @@ export function logAsset(logger: CliLogger, level: LogLevel) {
 export const logAssets =
     (logger: CliLogger, level: LogLevel) =>
     (message: string) =>
-    <T extends SourceAndSourceMap>(assets: T) =>
+    <T extends SourceAndSourceMapPaths>(assets: T) =>
         log(logger, level)<T>(`${assets.source.name}: ${message}`)(assets);

--- a/tools/cli/src/models/Asset.ts
+++ b/tools/cli/src/models/Asset.ts
@@ -1,0 +1,6 @@
+import { Asset } from '@backtrace/sourcemap-tools';
+
+export interface SourceAndSourceMapPaths {
+    readonly source: Asset;
+    readonly sourceMap?: Asset;
+}

--- a/tools/cli/src/sourcemaps/add-sources.ts
+++ b/tools/cli/src/sourcemaps/add-sources.ts
@@ -168,20 +168,24 @@ export async function addSourcesToSourcemaps({ opts, logger, getHelpMessage }: C
     return pipe(
         searchPaths,
         findTuples,
-        map(file2Or1FromTuple),
-        logDebug((r) => `found ${r.length} files`),
-        map(logTrace((result) => `found file: ${result.path}`)),
-        isIncluded ? filterAsync(isIncluded) : pass,
-        isExcluded ? filterAsync(flow(isExcluded, not)) : pass,
-        filter((t) => t.direct || matchSourceMapExtension(t.path)),
-        map((t) => t.path),
-        logDebug((r) => `found ${r.length} files for adding sources`),
-        map(logTrace((path) => `file to add sources to: ${path}`)),
-        map(toAsset),
-        opts['pass-with-no-files'] ? Ok : failIfEmpty('no sourcemaps found'),
-        R.map(flow(mapAsync(addSourcesCommand), R.flatMap)),
-        R.map(filterBehaviorSkippedElements),
-        R.map(map(output(logger))),
+        R.map(
+            flow(
+                map(file2Or1FromTuple),
+                logDebug((r) => `found ${r.length} files`),
+                map(logTrace((result) => `found file: ${result.path}`)),
+                isIncluded ? filterAsync(isIncluded) : pass,
+                isExcluded ? filterAsync(flow(isExcluded, not)) : pass,
+                filter((t) => t.direct || matchSourceMapExtension(t.path)),
+                map((t) => t.path),
+                logDebug((r) => `found ${r.length} files for adding sources`),
+                map(logTrace((path) => `file to add sources to: ${path}`)),
+                map(toAsset),
+                opts['pass-with-no-files'] ? Ok : failIfEmpty('no sourcemaps found'),
+                R.map(flow(mapAsync(addSourcesCommand), R.flatMap)),
+                R.map(filterBehaviorSkippedElements),
+                R.map(map(output(logger))),
+            ),
+        ),
     );
 }
 

--- a/tools/cli/src/sourcemaps/add-sources.ts
+++ b/tools/cli/src/sourcemaps/add-sources.ts
@@ -26,7 +26,7 @@ import { GlobalOptions } from '..';
 import { Command, CommandContext } from '../commands/Command';
 import { readSourceMapFromPathOrFromSource, toAsset, writeAsset } from '../helpers/common';
 import { ErrorBehaviors, filterBehaviorSkippedElements, getErrorBehavior, handleError } from '../helpers/errorBehavior';
-import { buildIncludeExclude, find } from '../helpers/find';
+import { buildIncludeExclude, file2Or1FromTuple, findTuples } from '../helpers/find';
 import { logAsset } from '../helpers/logs';
 import { normalizePaths, relativePaths } from '../helpers/normalizePaths';
 import { CliLogger } from '../logger';
@@ -167,7 +167,8 @@ export async function addSourcesToSourcemaps({ opts, logger, getHelpMessage }: C
 
     return pipe(
         searchPaths,
-        find,
+        findTuples,
+        map(file2Or1FromTuple),
         logDebug((r) => `found ${r.length} files`),
         map(logTrace((result) => `found file: ${result.path}`)),
         isIncluded ? filterAsync(isIncluded) : pass,

--- a/tools/cli/src/sourcemaps/process.ts
+++ b/tools/cli/src/sourcemaps/process.ts
@@ -166,18 +166,22 @@ export async function processSources({ opts, logger, getHelpMessage }: CommandCo
     return pipe(
         searchPaths,
         findTuples,
-        logDebug((r) => `found ${r.length} files`),
-        map(logTrace((result) => `found file: ${result.file1.path}`)),
-        isIncluded ? filterAsync((x) => isIncluded(x.file1)) : pass,
-        isExcluded ? filterAsync(flow((x) => isExcluded(x.file1), not)) : pass,
-        filter((t) => t.file1.direct || matchSourceExtension(t.file1.path)),
-        logDebug((r) => `found ${r.length} files for processing`),
-        map(logTrace((path) => `file for processing: ${path.file1.path}`)),
-        map(toSourceAndSourceMapPaths),
-        opts['pass-with-no-files'] ? Ok : failIfEmpty('no source files found'),
-        R.map(flow(mapAsync(processAssetCommand), R.flatMap)),
-        R.map(filterBehaviorSkippedElements),
-        R.map(map(output(logger))),
+        R.map(
+            flow(
+                logDebug((r) => `found ${r.length} files`),
+                map(logTrace((result) => `found file: ${result.file1.path}`)),
+                isIncluded ? filterAsync((x) => isIncluded(x.file1)) : pass,
+                isExcluded ? filterAsync(flow((x) => isExcluded(x.file1), not)) : pass,
+                filter((t) => t.file1.direct || matchSourceExtension(t.file1.path)),
+                logDebug((r) => `found ${r.length} files for processing`),
+                map(logTrace((path) => `file for processing: ${path.file1.path}`)),
+                map(toSourceAndSourceMapPaths),
+                opts['pass-with-no-files'] ? Ok : failIfEmpty('no source files found'),
+                R.map(flow(mapAsync(processAssetCommand), R.flatMap)),
+                R.map(filterBehaviorSkippedElements),
+                R.map(map(output(logger))),
+            ),
+        ),
     );
 }
 

--- a/tools/cli/src/sourcemaps/upload.ts
+++ b/tools/cli/src/sourcemaps/upload.ts
@@ -36,7 +36,7 @@ import { GlobalOptions } from '..';
 import { Command, CommandContext } from '../commands/Command';
 import { isAssetProcessed, readSourceMapFromPathOrFromSource, toAsset, uniqueBy, validateUrl } from '../helpers/common';
 import { ErrorBehaviors, filterBehaviorSkippedElements, getErrorBehavior, handleError } from '../helpers/errorBehavior';
-import { buildIncludeExclude, find } from '../helpers/find';
+import { buildIncludeExclude, file2Or1FromTuple, findTuples } from '../helpers/find';
 import { logAsset } from '../helpers/logs';
 import { normalizePaths, relativePaths } from '../helpers/normalizePaths';
 import { CliLogger } from '../logger';
@@ -259,7 +259,8 @@ export async function uploadSourcemaps({ opts, logger, getHelpMessage }: Command
 
     return pipe(
         searchPaths,
-        find,
+        findTuples,
+        map(file2Or1FromTuple),
         logDebug((r) => `found ${r.length} files`),
         map(logTrace((result) => `found file: ${result.path}`)),
         isIncluded ? filterAsync(isIncluded) : pass,

--- a/tools/cli/tests/_files/not-linked-different-name-sourcemaps/entry1.js
+++ b/tools/cli/tests/_files/not-linked-different-name-sourcemaps/entry1.js
@@ -1,0 +1,6 @@
+function doSomething() {
+    console.log('Done something');
+}
+
+console.log('Hello World Entry 1!');
+doSomething();

--- a/tools/cli/tests/_files/not-linked-different-name-sourcemaps/entry2.js
+++ b/tools/cli/tests/_files/not-linked-different-name-sourcemaps/entry2.js
@@ -1,0 +1,6 @@
+function doSomething() {
+    console.log('Done something');
+}
+
+console.log('Hello World Entry 2!');
+doSomething();

--- a/tools/cli/tests/_files/not-linked-different-name-sourcemaps/sourcemap1.js.map
+++ b/tools/cli/tests/_files/not-linked-different-name-sourcemaps/sourcemap1.js.map
@@ -1,0 +1,11 @@
+{
+    "version": 3,
+    "file": "entry1.js",
+    "mappings": "",
+    "sources": [
+        "../sources/dependency.ts",
+        "../sources/entry1.ts"
+    ],
+    "names": [],
+    "sourceRoot": ""
+}

--- a/tools/cli/tests/_files/not-linked-different-name-sourcemaps/sourcemap2.js.map
+++ b/tools/cli/tests/_files/not-linked-different-name-sourcemaps/sourcemap2.js.map
@@ -1,0 +1,11 @@
+{
+    "version": 3,
+    "file": "entry2.js",
+    "mappings": "",
+    "sources": [
+        "../sources/dependency.ts",
+        "../sources/entry2.ts"
+    ],
+    "names": [],
+    "sourceRoot": ""
+}

--- a/tools/cli/tests/_files/processed-not-linked-different-name-sourcemaps/entry1.js
+++ b/tools/cli/tests/_files/processed-not-linked-different-name-sourcemaps/entry1.js
@@ -1,0 +1,8 @@
+;!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e._btDebugIds=e._btDebugIds||{},e._btDebugIds[n]="4fe9a5c9-ab48-b240-9469-04aa2db251b6")}catch(e){}}();
+function doSomething() {
+    console.log('Done something');
+}
+
+console.log('Hello World Entry 1!');
+doSomething();
+//# debugId=4fe9a5c9-ab48-b240-9469-04aa2db251b6

--- a/tools/cli/tests/_files/processed-not-linked-different-name-sourcemaps/entry2.js
+++ b/tools/cli/tests/_files/processed-not-linked-different-name-sourcemaps/entry2.js
@@ -1,0 +1,8 @@
+;!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:{},n=(new Error).stack;n&&(e._btDebugIds=e._btDebugIds||{},e._btDebugIds[n]="d538bdaa-8149-8111-25f0-b5c0f472366a")}catch(e){}}();
+function doSomething() {
+    console.log('Done something');
+}
+
+console.log('Hello World Entry 2!');
+doSomething();
+//# debugId=d538bdaa-8149-8111-25f0-b5c0f472366a

--- a/tools/cli/tests/_files/processed-not-linked-different-name-sourcemaps/sourcemap1.js.map
+++ b/tools/cli/tests/_files/processed-not-linked-different-name-sourcemaps/sourcemap1.js.map
@@ -1,0 +1,16 @@
+{
+    "version": 3,
+    "file": "entry1.js",
+    "mappings": ";",
+    "sources": [
+        "../sources/dependency.ts",
+        "../sources/entry1.ts"
+    ],
+    "names": [],
+    "sourceRoot": "",
+    "debugId": "4fe9a5c9-ab48-b240-9469-04aa2db251b6",
+    "sourcesContent": [
+        "export function doSomething() {\n    console.log('Done something');\n}\n",
+        "import { doSomething } from './dependency';\n\nconsole.log('Hello World Entry 1!');\ndoSomething();\n"
+    ]
+}

--- a/tools/cli/tests/_files/processed-not-linked-different-name-sourcemaps/sourcemap2.js.map
+++ b/tools/cli/tests/_files/processed-not-linked-different-name-sourcemaps/sourcemap2.js.map
@@ -1,0 +1,16 @@
+{
+    "version": 3,
+    "file": "entry2.js",
+    "mappings": ";",
+    "sources": [
+        "../sources/dependency.ts",
+        "../sources/entry2.ts"
+    ],
+    "names": [],
+    "sourceRoot": "",
+    "debugId": "d538bdaa-8149-8111-25f0-b5c0f472366a",
+    "sourcesContent": [
+        "export function doSomething() {\n    console.log('Done something');\n}\n",
+        "import { doSomething } from './dependency';\n\nconsole.log('Hello World Entry 2!');\ndoSomething();\n"
+    ]
+}

--- a/tools/cli/tests/_helpers/testFiles.ts
+++ b/tools/cli/tests/_helpers/testFiles.ts
@@ -7,8 +7,10 @@ import path from 'path';
 export type TestFiles =
     | 'no-sourcemaps'
     | 'not-linked-sourcemaps'
+    | 'not-linked-different-name-sourcemaps'
     | 'directory-linked-sourcemaps'
     | 'processed-not-linked-sourcemaps'
+    | 'processed-not-linked-different-name-sourcemaps'
     | 'processed-directory-linked-sourcemaps'
     | 'original'
     | 'processed'

--- a/tools/cli/tests/sourcemaps/add-sources.spec.ts
+++ b/tools/cli/tests/sourcemaps/add-sources.spec.ts
@@ -474,4 +474,72 @@ describe('add-sources', () => {
             }),
         );
     });
+
+    describe('tuple paths', () => {
+        it(
+            'should not fail',
+            withWorkingCopy('not-linked-different-name-sourcemaps', async (workingDir) => {
+                const result = await addSourcesToSourcemaps({
+                    logger: new CliLogger({ level: 'output', silent: true }),
+                    getHelpMessage,
+                    opts: {
+                        path: [
+                            `${workingDir}/entry1.js:${workingDir}/sourcemap1.js.map`,
+                            `${workingDir}/entry2.js:${workingDir}/sourcemap2.js.map`,
+                        ],
+                    },
+                });
+
+                assert(result.isOk(), result.data as string);
+            }),
+        );
+
+        it(
+            'should call SourceProcessor with sourcemap paths',
+            withWorkingCopy('not-linked-different-name-sourcemaps', async (workingDir) => {
+                const spy = jest.spyOn(SourceProcessor.prototype, 'addSourcesToSourceMap');
+
+                const result = await addSourcesToSourcemaps({
+                    logger: new CliLogger({ level: 'output', silent: true }),
+                    getHelpMessage,
+                    opts: {
+                        path: [
+                            `${workingDir}/entry1.js:${workingDir}/sourcemap1.js.map`,
+                            `${workingDir}/entry2.js:${workingDir}/sourcemap2.js.map`,
+                        ],
+                    },
+                });
+
+                assert(result.isOk(), result.data as string);
+                const files = await glob(`${workingDir}/*.js.map`);
+
+                for (const file of files) {
+                    expect(spy).toBeCalledWith(expect.anything(), file);
+                }
+            }),
+        );
+
+        it(
+            'should modify sourcesmaps in place',
+            withWorkingCopy('not-linked-different-name-sourcemaps', async (workingDir) => {
+                const preHashes = await hashEachFile(await glob(`${workingDir}/*.js.map`));
+
+                const result = await addSourcesToSourcemaps({
+                    logger: new CliLogger({ level: 'output', silent: true }),
+                    getHelpMessage,
+                    opts: {
+                        path: [
+                            `${workingDir}/entry1.js:${workingDir}/sourcemap1.js.map`,
+                            `${workingDir}/entry2.js:${workingDir}/sourcemap2.js.map`,
+                        ],
+                    },
+                });
+
+                assert(result.isOk(), result.data as string);
+                const postHashes = await hashEachFile(await glob(`${workingDir}/*.js.map`));
+
+                expectHashesToChange(preHashes, postHashes);
+            }),
+        );
+    });
 });

--- a/tools/cli/tests/sourcemaps/run.spec.ts
+++ b/tools/cli/tests/sourcemaps/run.spec.ts
@@ -531,4 +531,43 @@ describe('run', () => {
             }),
         );
     });
+
+    describe('tuple paths', () => {
+        it(
+            'should return processed sources and sourcemap paths',
+            withWorkingCopy('not-linked-different-name-sourcemaps', async (workingDir) => {
+                const entry1Path = `${workingDir}/entry1.js`;
+                const entry2Path = `${workingDir}/entry2.js`;
+                const sourcemap1Path = `${workingDir}/sourcemap1.js.map`;
+                const sourcemap2Path = `${workingDir}/sourcemap2.js.map`;
+
+                const config = await mockOptions(workingDir, {
+                    run: {
+                        'add-sources': true,
+                        process: true,
+                        upload: true,
+                    },
+                    upload: {
+                        url: 'https://test',
+                    },
+                });
+
+                const result = await runSourcemapCommands({
+                    logger: new CliLogger({ level: 'output', silent: true }),
+                    getHelpMessage,
+                    opts: {
+                        path: [`${entry1Path}:${sourcemap1Path}`, `${entry2Path}:${sourcemap2Path}`],
+                        config,
+                    },
+                });
+
+                assert(result.isOk(), result.data as string);
+
+                const expected = [entry1Path, entry2Path, sourcemap1Path, sourcemap2Path];
+                expect(result.data.flatMap((d) => [d.source.path, d.sourceMap.path])).toEqual(
+                    expect.arrayContaining(expected),
+                );
+            }),
+        );
+    });
 });

--- a/tools/sourcemap-tools/src/helpers/common.ts
+++ b/tools/sourcemap-tools/src/helpers/common.ts
@@ -89,8 +89,11 @@ export function map<T, B>(fn: (t: T) => B) {
 }
 
 export function flatMap<T, B>(fn: (t: T) => B[]) {
-    return function map(t: T[]) {
-        return t.flatMap(fn);
+    return function flatMap(t: T[]) {
+        return t.reduce((res, v) => {
+            res.push(...fn(v));
+            return res;
+        }, [] as B[]);
     };
 }
 

--- a/tools/sourcemap-tools/src/helpers/common.ts
+++ b/tools/sourcemap-tools/src/helpers/common.ts
@@ -29,7 +29,7 @@ export async function statFile(path: string) {
     try {
         return Ok(await fs.promises.stat(path));
     } catch (err) {
-        return Err(`failed to write file: ${err}`);
+        return Err(`failed to stat file: ${err}`);
     }
 }
 
@@ -85,6 +85,12 @@ export function failIfEmpty<E>(error: E) {
 export function map<T, B>(fn: (t: T) => B) {
     return function map(t: T[]) {
         return t.map(fn);
+    };
+}
+
+export function flatMap<T, B>(fn: (t: T) => B[]) {
+    return function map(t: T[]) {
+        return t.flatMap(fn);
     };
 }
 


### PR DESCRIPTION
This PR adds support of tuple paths for paths, so you can assign specific sourcemaps to sources.

For example:
```
$ backtrace-js process ./lib/index.js:./lib/sourcemap.js.map ./lib/file2.js:./lib/sourcemap2.js.map
```