### PR TITLE
browser: add middleware modes to redux middleware, move JSON action to attributes

### DIFF
--- a/packages/browser/src/redux/BacktraceReduxMiddleware.ts
+++ b/packages/browser/src/redux/BacktraceReduxMiddleware.ts
@@ -2,27 +2,100 @@ import { jsonEscaper } from '@backtrace/sdk-core';
 import type { Action, Middleware } from 'redux';
 import { BacktraceClient } from '../BacktraceClient';
 
+export interface BacktraceReduxMiddlewareOptions {
+    /**
+     * A function that can be used to skip an action or filter out information from a dispatched action, such as PII,
+     * that shouldn't be sent to Backtrace. Return undefined to skip an action, otherwise whatever
+     * (potentially modified) action returned will be sent to Backtrace.
+     */
+    readonly interceptAction?: (action: Action) => Action | undefined;
+
+    /**
+     * Middleware mode. Can be one of:
+     * * `all` - include everything by default,
+     * * `omit-values` - add the breadcrumb, but omit the values,
+     * * `off` - disable the middleware.
+     */
+    readonly mode?: 'all' | 'omit-values' | 'off';
+}
+
+function getBreadcrumbPayload(mode: BacktraceReduxMiddlewareOptions['mode'], action: Action) {
+    switch (mode) {
+        case 'all':
+            return action;
+        case 'omit-values':
+            return { type: action.type };
+        default:
+            return undefined;
+    }
+}
+
 /**
  *
  * @param client BacktraceClient used to send breadcrumbs
- * @param interceptAction A function that can be used to skip an action or filter out information from a dispatched action, such as PII, that shouldn't be sent to Backtrace. Return undefined to skip an action, otherwise whatever (potentially modified) action returned will be sent to Backtrace.
+ * @param interceptAction A function that can be used to skip an action or filter out information from a dispatched action, such as PII,
+ * that shouldn't be sent to Backtrace. Return undefined to skip an action, otherwise whatever
+ * (potentially modified) action returned will be sent to Backtrace.
  */
-export const createBacktraceReduxMiddleware = (
+export function createBacktraceReduxMiddleware(
     client: BacktraceClient,
-    interceptAction: (action: Action) => Action | undefined = (action) => action,
-) => {
+    interceptAction?: (action: Action) => Action | undefined,
+): Middleware;
+/**
+ *
+ * @param client BacktraceClient used to send breadcrumbs
+ * @param options Middleware options.
+ */
+export function createBacktraceReduxMiddleware(
+    client: BacktraceClient,
+    options?: BacktraceReduxMiddlewareOptions,
+): Middleware;
+/**
+ *
+ * @param client BacktraceClient used to send breadcrumbs
+ * @param options Middleware options or intercept action function.
+ */
+export function createBacktraceReduxMiddleware(
+    client: BacktraceClient,
+    interceptActionOrOptions?: BacktraceReduxMiddlewareOptions | ((action: Action) => Action | undefined),
+): Middleware;
+export function createBacktraceReduxMiddleware(
+    client: BacktraceClient,
+    interceptActionOrOptions: BacktraceReduxMiddlewareOptions | ((action: Action) => Action | undefined) = (action) =>
+        action,
+): Middleware {
     if (!client) {
         throw new Error('Must pass a BacktraceClient to the BacktraceReduxMiddleware.');
     }
+
+    const options: BacktraceReduxMiddlewareOptions =
+        typeof interceptActionOrOptions === 'object'
+            ? interceptActionOrOptions
+            : {
+                  interceptAction: interceptActionOrOptions,
+              };
+
+    const interceptAction = options.interceptAction ?? ((action) => action);
+    const mode = options.mode ?? 'all';
+
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const middleware: Middleware = (store) => (next) => (action: Action) => {
+    const middleware: Middleware = () => (next) => (action: Action) => {
         try {
             const response = next(action);
-            const interceptedAction = interceptAction(action);
-            // If the user returns undefined for an action, we skip the breadcrumb
-            if (interceptedAction) {
-                client.breadcrumbs?.info(`REDUX Action: ${JSON.stringify(interceptedAction, jsonEscaper())}`);
+            if (mode === 'off') {
+                return response;
             }
+
+            const interceptedAction = interceptAction(action);
+
+            // If the user returns undefined for an action, we skip the breadcrumb
+            const payload = interceptedAction ? getBreadcrumbPayload(mode, interceptedAction) : undefined;
+            if (payload) {
+                client.breadcrumbs?.info(`REDUX Action: ${payload.type}`, {
+                    action: JSON.stringify(payload, jsonEscaper()),
+                });
+            }
+
             return response;
         } catch (err) {
             const message = err instanceof Error ? err.message : err?.toString() ?? 'unknown';
@@ -32,5 +105,6 @@ export const createBacktraceReduxMiddleware = (
             throw err;
         }
     };
+
     return middleware;
-};
+}

--- a/packages/browser/src/redux/BacktraceReduxMiddleware.ts
+++ b/packages/browser/src/redux/BacktraceReduxMiddleware.ts
@@ -15,6 +15,8 @@ export interface BacktraceReduxMiddlewareOptions {
      * * `all` - include everything by default,
      * * `omit-values` - add the breadcrumb, but omit the values,
      * * `off` - disable the middleware.
+     *
+     * @default 'omit-values'
      */
     readonly mode?: 'all' | 'omit-values' | 'off';
 }
@@ -74,7 +76,7 @@ export function createBacktraceReduxMiddleware(
               };
 
     const interceptAction = options.interceptAction ?? ((action) => action);
-    const mode = options.mode ?? 'all';
+    const mode = options.mode ?? 'omit-values';
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const middleware: Middleware = () => (next) => (action: Action) => {

--- a/packages/browser/tests/redux/backtraceReduxMiddlewareTests.spec.ts
+++ b/packages/browser/tests/redux/backtraceReduxMiddlewareTests.spec.ts
@@ -59,7 +59,17 @@ const createLoggingMiddleware = (whatToLog: string) => {
 const hiLoggingMiddleware = createLoggingMiddleware('hi');
 const holaLoggingMiddleware = createLoggingMiddleware('hola');
 
-const getExpectedBreadcrumb = (action: Action) => [`REDUX Action: ${action.type}`, { action: JSON.stringify(action) }];
+const getExpectedBreadcrumb = (action: Action, mode?: BacktraceReduxMiddlewareOptions['mode']) => {
+    switch (mode) {
+        case undefined:
+        case 'all':
+            return [`REDUX Action: ${action.type}`, { action: JSON.stringify(action) }];
+        case 'omit-values':
+            return [`REDUX Action: ${action.type}`, undefined];
+        default:
+            return [];
+    }
+};
 
 const { addToTestArray, toggleTestBool, throwErrorForTest } = testSlice.actions;
 
@@ -191,7 +201,7 @@ describe('createBacktraceReduxMiddleware', () => {
                 const interceptedAction = { type: 'expected-type', payload: { abc: '123' } };
                 const store = getStore({ interceptAction: () => interceptedAction });
                 const breadcrumbsSpy = getBreadcrumbsSpy('info');
-                const expected = getExpectedBreadcrumb(interceptedAction);
+                const expected = getExpectedBreadcrumb(interceptedAction, 'all');
                 store.dispatch(addToTestArray('Message to add'));
                 expect(breadcrumbsSpy).toHaveBeenCalledWith(...expected);
             });
@@ -200,7 +210,7 @@ describe('createBacktraceReduxMiddleware', () => {
                 const interceptedAction = { type: 'expected-type', payload: { abc: '123' } };
                 const store = getStore({ interceptAction: () => interceptedAction, mode: 'all' });
                 const breadcrumbsSpy = getBreadcrumbsSpy('info');
-                const expected = getExpectedBreadcrumb(interceptedAction);
+                const expected = getExpectedBreadcrumb(interceptedAction, 'all');
                 store.dispatch(addToTestArray('Message to add'));
                 expect(breadcrumbsSpy).toHaveBeenCalledWith(...expected);
             });
@@ -209,7 +219,7 @@ describe('createBacktraceReduxMiddleware', () => {
                 const interceptedAction = { type: 'expected-type', payload: { abc: '123' } };
                 const store = getStore({ interceptAction: () => interceptedAction, mode: 'omit-values' });
                 const breadcrumbsSpy = getBreadcrumbsSpy('info');
-                const expected = getExpectedBreadcrumb({ type: interceptedAction.type });
+                const expected = getExpectedBreadcrumb({ type: interceptedAction.type }, 'omit-values');
                 store.dispatch(addToTestArray('Message to add'));
                 expect(breadcrumbsSpy).toHaveBeenCalledWith(...expected);
             });

--- a/packages/browser/tests/redux/backtraceReduxMiddlewareTests.spec.ts
+++ b/packages/browser/tests/redux/backtraceReduxMiddlewareTests.spec.ts
@@ -61,9 +61,9 @@ const holaLoggingMiddleware = createLoggingMiddleware('hola');
 
 const getExpectedBreadcrumb = (action: Action, mode?: BacktraceReduxMiddlewareOptions['mode']) => {
     switch (mode) {
-        case undefined:
         case 'all':
             return [`REDUX Action: ${action.type}`, { action: JSON.stringify(action) }];
+        case undefined:
         case 'omit-values':
             return [`REDUX Action: ${action.type}`, undefined];
         default:
@@ -197,11 +197,11 @@ describe('createBacktraceReduxMiddleware', () => {
         });
 
         describe('modes', () => {
-            it('Should add whole action as JSON to breadcrumb attributes by default', () => {
+            it('Should add only action type as JSON to breadcrumb attributes by default', () => {
                 const interceptedAction = { type: 'expected-type', payload: { abc: '123' } };
                 const store = getStore({ interceptAction: () => interceptedAction });
                 const breadcrumbsSpy = getBreadcrumbsSpy('info');
-                const expected = getExpectedBreadcrumb(interceptedAction, 'all');
+                const expected = getExpectedBreadcrumb(interceptedAction, 'omit-values');
                 store.dispatch(addToTestArray('Message to add'));
                 expect(breadcrumbsSpy).toHaveBeenCalledWith(...expected);
             });

--- a/packages/browser/tests/redux/backtraceReduxMiddlewareTests.spec.ts
+++ b/packages/browser/tests/redux/backtraceReduxMiddlewareTests.spec.ts
@@ -219,7 +219,7 @@ describe('createBacktraceReduxMiddleware', () => {
                 const interceptedAction = { type: 'expected-type', payload: { abc: '123' } };
                 const store = getStore({ interceptAction: () => interceptedAction, mode: 'omit-values' });
                 const breadcrumbsSpy = getBreadcrumbsSpy('info');
-                const expected = getExpectedBreadcrumb({ type: interceptedAction.type }, 'omit-values');
+                const expected = getExpectedBreadcrumb(interceptedAction, 'omit-values');
                 store.dispatch(addToTestArray('Message to add'));
                 expect(breadcrumbsSpy).toHaveBeenCalledWith(...expected);
             });


### PR DESCRIPTION
Adds following modes to the Redux middleware:
* `all` - include everything by default,
* `omit-values` - add the breadcrumb, but omit the values,
* `off` - disable the middleware.

When `omit-values` is specified, only `type` is added to attributes.