### PR TITLE
Dont create formdata without attachments

### DIFF
--- a/packages/browser/src/BacktraceBrowserRequestHandler.ts
+++ b/packages/browser/src/BacktraceBrowserRequestHandler.ts
@@ -1,10 +1,10 @@
 import {
+    anySignal,
     BacktraceAttachment,
     BacktraceReportSubmissionResult,
     BacktraceRequestHandler,
     ConnectionError,
     DEFAULT_TIMEOUT,
-    anySignal,
 } from '@backtrace/sdk-core';
 
 export class BacktraceBrowserRequestHandler implements BacktraceRequestHandler {
@@ -29,8 +29,8 @@ export class BacktraceBrowserRequestHandler implements BacktraceRequestHandler {
         attachments: BacktraceAttachment<Blob | string>[],
         abortSignal?: AbortSignal,
     ): Promise<BacktraceReportSubmissionResult<T>> {
-        const formData = this.createFormData(dataJson, attachments);
-        return this.post(submissionUrl, formData, abortSignal);
+        const payload = attachments.length === 0 ? dataJson : this.createFormData(dataJson, attachments);
+        return this.post(submissionUrl, payload, abortSignal);
     }
 
     public async post<T>(

--- a/packages/node/src/BacktraceNodeRequestHandler.ts
+++ b/packages/node/src/BacktraceNodeRequestHandler.ts
@@ -35,7 +35,7 @@ export class BacktraceNodeRequestHandler implements BacktraceRequestHandler {
         attachments: BacktraceAttachment<Buffer | Readable | string | Uint8Array>[],
         abortSignal?: AbortSignal,
     ): Promise<BacktraceReportSubmissionResult<BacktraceSubmissionResponse>> {
-        const formData = this.createFormData(dataJson, attachments);
+        const formData = attachments.length === 0 ? dataJson : this.createFormData(dataJson, attachments);
         return this.send<BacktraceSubmissionResponse>(submissionUrl, formData, abortSignal);
     }
 


### PR DESCRIPTION
# Why

This diff allows us to skip form data creation if there is no attachments to upload