### PR TITLE
react-native: ensure breadcrumb message is always a string type

### DIFF
--- a/packages/sdk-core/tests/breadcrumbs/breadcrumbsCreationTests.spec.ts
+++ b/packages/sdk-core/tests/breadcrumbs/breadcrumbsCreationTests.spec.ts
@@ -73,6 +73,19 @@ describe('Breadcrumbs creation tests', () => {
         expect(breadcrumb.message).toEqual(expectedBreadcrumbValueOutput);
     });
 
+    it('Should correctly handle null breadcrumb value', () => {
+        const input = null;
+        const expectedBreadcrumbValueOutput = '';
+
+        const storage = new InMemoryBreadcrumbsStorage(100);
+        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage });
+        breadcrumbsManager.initialize();
+        breadcrumbsManager.info(input as unknown as string);
+        const [breadcrumb] = JSON.parse(storage.get() as string);
+
+        expect(breadcrumb.message).toEqual(expectedBreadcrumbValueOutput);
+    });
+
     it('Should set expected breadcrumb level', () => {
         const message = 'test';
         const level = BreadcrumbLogLevel.Warning;

--- a/packages/sdk-core/tests/breadcrumbs/breadcrumbsCreationTests.spec.ts
+++ b/packages/sdk-core/tests/breadcrumbs/breadcrumbsCreationTests.spec.ts
@@ -47,6 +47,32 @@ describe('Breadcrumbs creation tests', () => {
         expect(breadcrumb.message).toEqual(message);
     });
 
+    it('Should convert number to string and treat it as a breadcrumb message', () => {
+        const input = 1;
+        const expectedBreadcrumbValueOutput = input.toString();
+
+        const storage = new InMemoryBreadcrumbsStorage(100);
+        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage });
+        breadcrumbsManager.initialize();
+        breadcrumbsManager.info(input as unknown as string);
+        const [breadcrumb] = JSON.parse(storage.get() as string);
+
+        expect(breadcrumb.message).toEqual(expectedBreadcrumbValueOutput);
+    });
+
+    it('Should convert object to JSON and treat it as a breadcrumb message', () => {
+        const input = { foo: 1, bar: true, baz: undefined };
+        const expectedBreadcrumbValueOutput = JSON.stringify(input);
+
+        const storage = new InMemoryBreadcrumbsStorage(100);
+        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage });
+        breadcrumbsManager.initialize();
+        breadcrumbsManager.info(input as unknown as string);
+        const [breadcrumb] = JSON.parse(storage.get() as string);
+
+        expect(breadcrumb.message).toEqual(expectedBreadcrumbValueOutput);
+    });
+
     it('Should set expected breadcrumb level', () => {
         const message = 'test';
         const level = BreadcrumbLogLevel.Warning;


### PR DESCRIPTION
# Why

We're in the javascript world. We should expect unexpected. In any logger integration, even if we expect to receive a string, logger can pass unstructured data. We expect string, but we should be prepared for the case when we receive unexpected input, that breaks things. This change makes sure the message passed by the logger or user is always valid or will be always converted into the format we want to have

refs: BT-1968