### PR TITLE
react-native: managed breadcrumb support

### DIFF
--- a/packages/react-native/src/breadcrumbs/events/AppStateBreadcrumbSubscriber.ts
+++ b/packages/react-native/src/breadcrumbs/events/AppStateBreadcrumbSubscriber.ts
@@ -1,0 +1,63 @@
+import {
+    BreadcrumbLogLevel,
+    BreadcrumbType,
+    type BacktraceBreadcrumbs,
+    type BreadcrumbsEventSubscriber,
+} from '@backtrace/sdk-core';
+import { AppState, Platform, type NativeEventSubscription } from 'react-native';
+
+export class AppStateBreadcrumbSubscriber implements BreadcrumbsEventSubscriber {
+    private _nativeEventSubscriptions: NativeEventSubscription[] = [];
+    public start(backtraceBreadcrumbs: BacktraceBreadcrumbs): void {
+        if ((backtraceBreadcrumbs.breadcrumbsType & BreadcrumbType.System) === BreadcrumbType.System) {
+            this._nativeEventSubscriptions.push(
+                AppState.addEventListener('memoryWarning', (state) => {
+                    backtraceBreadcrumbs.addBreadcrumb(
+                        `Detected memory pressure change. Current state: ${state}`,
+                        BreadcrumbLogLevel.Warning,
+                        BreadcrumbType.System,
+                        { state },
+                    );
+                }),
+            );
+        }
+
+        if ((backtraceBreadcrumbs.breadcrumbsType & BreadcrumbType.User) === BreadcrumbType.User) {
+            this._nativeEventSubscriptions.push(
+                AppState.addEventListener('change', (state) => {
+                    backtraceBreadcrumbs.addBreadcrumb(
+                        `Application state change to ${state}`,
+                        BreadcrumbLogLevel.Info,
+                        BreadcrumbType.User,
+                    );
+                }),
+            );
+
+            if (Platform.OS === 'android') {
+                this._nativeEventSubscriptions.push(
+                    AppState.addEventListener('blur', () => {
+                        backtraceBreadcrumbs.addBreadcrumb(
+                            `Application on blur`,
+                            BreadcrumbLogLevel.Info,
+                            BreadcrumbType.User,
+                        );
+                    }),
+                );
+                this._nativeEventSubscriptions.push(
+                    AppState.addEventListener('focus', () => {
+                        backtraceBreadcrumbs.addBreadcrumb(
+                            `Application focus`,
+                            BreadcrumbLogLevel.Info,
+                            BreadcrumbType.User,
+                        );
+                    }),
+                );
+            }
+        }
+    }
+    public dispose(): void {
+        for (const eventSubscription of this._nativeEventSubscriptions) {
+            eventSubscription.remove();
+        }
+    }
+}

--- a/packages/react-native/src/breadcrumbs/events/DimensionChangeBreadcrumbSubscriber.ts
+++ b/packages/react-native/src/breadcrumbs/events/DimensionChangeBreadcrumbSubscriber.ts
@@ -1,0 +1,43 @@
+import {
+    BreadcrumbLogLevel,
+    BreadcrumbType,
+    type BacktraceBreadcrumbs,
+    type BreadcrumbsEventSubscriber,
+} from '@backtrace/sdk-core';
+import { Dimensions, type NativeEventSubscription } from 'react-native';
+
+export class DimensionChangeBreadcrumbSubscriber implements BreadcrumbsEventSubscriber {
+    private _nativeEventSubscriptions: NativeEventSubscription[] = [];
+    public start(backtraceBreadcrumbs: BacktraceBreadcrumbs): void {
+        if ((backtraceBreadcrumbs.breadcrumbsType & BreadcrumbType.User) !== BreadcrumbType.User) {
+            return;
+        }
+
+        this._nativeEventSubscriptions.push(
+            Dimensions.addEventListener('change', (appState) => {
+                const { window, screen } = appState;
+                backtraceBreadcrumbs.addBreadcrumb(
+                    `Dimension changed. Window (${Math.floor(window.height)} x ${Math.floor(window.width)}),
+                         Screen (${Math.floor(screen.height)} x ${Math.floor(screen.width)})`,
+                    BreadcrumbLogLevel.Verbose,
+                    BreadcrumbType.User,
+                    {
+                        ['window.fontScale']: window.fontScale,
+                        ['window.scale']: window.scale,
+                        ['window.width']: window.width,
+                        ['window.height']: window.height,
+                        ['screen.fontScale']: screen.fontScale,
+                        ['screen.scale']: screen.scale,
+                        ['screen.width']: screen.width,
+                        ['screen.height']: screen.height,
+                    },
+                );
+            }),
+        );
+    }
+    public dispose(): void {
+        for (const eventSubscription of this._nativeEventSubscriptions) {
+            eventSubscription.remove();
+        }
+    }
+}

--- a/packages/react-native/src/breadcrumbs/events/WebRequestEventSubscriber.ts
+++ b/packages/react-native/src/breadcrumbs/events/WebRequestEventSubscriber.ts
@@ -1,0 +1,96 @@
+import {
+    BreadcrumbLogLevel,
+    BreadcrumbType,
+    type BacktraceBreadcrumbs,
+    type BreadcrumbsEventSubscriber,
+} from '@backtrace/sdk-core';
+
+export class WebRequestEventSubscriber implements BreadcrumbsEventSubscriber {
+    private _xmlHttpRequestOriginalOpenMethod?: typeof XMLHttpRequest.prototype.open;
+    private _fetchOriginalMethod?: typeof window.fetch;
+
+    public start(backtraceBreadcrumbs: BacktraceBreadcrumbs): void {
+        if ((backtraceBreadcrumbs.breadcrumbsType & BreadcrumbType.Http) !== BreadcrumbType.Http) {
+            return;
+        }
+        const xmlHttpRequestOriginalOpenMethod = XMLHttpRequest.prototype.open;
+
+        XMLHttpRequest.prototype.open = function (
+            method: string,
+            url: string,
+            async?: boolean,
+            username?: string | null,
+            password?: string | null,
+        ) {
+            const readyStateChangeCallback = this.onreadystatechange;
+            this.onreadystatechange = (event: Event) => {
+                if (this.readyState === XMLHttpRequest.DONE) {
+                    backtraceBreadcrumbs.addBreadcrumb(
+                        `Sent an HTTP ${method} request to ${url}. Response status code: ${this.status}`,
+                        BreadcrumbLogLevel.Debug,
+                        BreadcrumbType.Http,
+                        {
+                            method,
+                            url: url.toString(),
+                            statusCode: this.status,
+                        },
+                    );
+                }
+
+                readyStateChangeCallback?.apply(this, [event]);
+            };
+
+            xmlHttpRequestOriginalOpenMethod.call(this, method, url, async || true, username, password);
+        };
+
+        this._xmlHttpRequestOriginalOpenMethod = xmlHttpRequestOriginalOpenMethod;
+
+        const fetchOriginalMethod = window.fetch;
+
+        window.fetch = async function (resource, config) {
+            const method = config?.method ?? 'GET';
+            const attributes = {
+                url: resource.toString(),
+                method: method,
+                referrer: config?.referrer,
+            };
+
+            try {
+                const result = await fetchOriginalMethod(resource, config);
+                backtraceBreadcrumbs.addBreadcrumb(
+                    `Sent an HTTP ${method} request to ${resource}. Response status code: ${result.status}`,
+                    BreadcrumbLogLevel.Debug,
+                    BreadcrumbType.Http,
+                    {
+                        ...attributes,
+                        statusCode: result.status,
+                    },
+                );
+
+                return result;
+            } catch (e) {
+                backtraceBreadcrumbs.addBreadcrumb(
+                    `HTTP ${method} failure on request to ${resource}. Reason: ${
+                        e instanceof Error ? e.message : e?.toString() ?? 'unknown'
+                    }`,
+                    BreadcrumbLogLevel.Warning,
+                    BreadcrumbType.Http,
+                    attributes,
+                );
+                throw e;
+            }
+        };
+
+        this._fetchOriginalMethod = fetchOriginalMethod;
+    }
+
+    public dispose(): void {
+        if (this._fetchOriginalMethod) {
+            window.fetch = this._fetchOriginalMethod;
+        }
+
+        if (this._xmlHttpRequestOriginalOpenMethod) {
+            XMLHttpRequest.prototype.open = this._xmlHttpRequestOriginalOpenMethod;
+        }
+    }
+}

--- a/packages/react-native/src/builder/BacktraceClientBuilder.ts
+++ b/packages/react-native/src/builder/BacktraceClientBuilder.ts
@@ -50,7 +50,6 @@ export class BacktraceClientBuilder extends BacktraceCoreClientBuilder<Backtrace
         this.useBreadcrumbSubscriber(new AppStateBreadcrumbSubscriber());
         this.useBreadcrumbSubscriber(new DimensionChangeBreadcrumbSubscriber());
         this.useBreadcrumbSubscriber(new WebRequestEventSubscriber());
-        // this.useBreadcrumbSubscriber(new NativeBreadcrumbSubsriber());
     }
 
     public useFileSystem(fileSystem: ReactNativeFileSystem): this {

--- a/packages/react-native/src/builder/BacktraceClientBuilder.ts
+++ b/packages/react-native/src/builder/BacktraceClientBuilder.ts
@@ -3,6 +3,9 @@ import { Platform } from 'react-native';
 import { NativeAttributeProvider } from '../attributes/NativeAttributeProvider';
 import { ReactNativeAttributeProvider } from '../attributes/ReactNativeAttributeProvider';
 import { BacktraceClient } from '../BacktraceClient';
+import { AppStateBreadcrumbSubscriber } from '../breadcrumbs/events/AppStateBreadcrumbSubscriber';
+import { DimensionChangeBreadcrumbSubscriber } from '../breadcrumbs/events/DimensionChangeBreadcrumbSubscriber';
+import { WebRequestEventSubscriber } from '../breadcrumbs/events/WebRequestEventSubscriber';
 import { DebuggerHelper } from '../common/DebuggerHelper';
 import { ReactNativeFileSystem } from '../storage';
 import type { BacktraceClientSetup } from './BacktraceClientSetup';
@@ -14,6 +17,10 @@ export class BacktraceClientBuilder extends BacktraceCoreClientBuilder<Backtrace
         const debuggerAvailable = DebuggerHelper.isConnected();
         this.addAttributeProvider(new ReactNativeAttributeProvider());
         if (debuggerAvailable) {
+            return;
+        }
+
+        if (Platform.OS !== 'android' && Platform.OS !== 'ios') {
             return;
         }
 
@@ -38,9 +45,12 @@ export class BacktraceClientBuilder extends BacktraceCoreClientBuilder<Backtrace
         for (const provider of attributeProviders) {
             this.addAttributeProvider(provider);
         }
-        if ((Platform.OS === 'android' || Platform.OS === 'ios') && !DebuggerHelper.isConnected()) {
-            this.useFileSystem(new ReactNativeFileSystem());
-        }
+
+        this.useFileSystem(new ReactNativeFileSystem());
+        this.useBreadcrumbSubscriber(new AppStateBreadcrumbSubscriber());
+        this.useBreadcrumbSubscriber(new DimensionChangeBreadcrumbSubscriber());
+        this.useBreadcrumbSubscriber(new WebRequestEventSubscriber());
+        // this.useBreadcrumbSubscriber(new NativeBreadcrumbSubsriber());
     }
 
     public useFileSystem(fileSystem: ReactNativeFileSystem): this {


### PR DESCRIPTION
# Why

This diff adds managed breadcrumbs support to the react-native library. Basic breadcrumbs are populated.

Side note:
- we want to avoid using react library inside react-native - builder includes our react/browser/sdk-core library in the bundler output. We want to reduce the size of the library since it matters a lot on mobile