### PR TITLE
Remove react dependency on react-native project

### DIFF
--- a/examples/sdk/reactNative/index.js
+++ b/examples/sdk/reactNative/index.js
@@ -15,12 +15,14 @@ BacktraceClient.initialize({
             prop2: 123,
         },
     },
-    database: {
-        enable: true,
-        captureNativeCrashes: true,
-        createDatabaseDirectory: true,
-        path: `${BacktraceClient.applicationDataPath}/backtrace`,
-    },
+    database: __DEV__
+        ? undefined
+        : {
+              enable: true,
+              captureNativeCrashes: true,
+              createDatabaseDirectory: true,
+              path: `${BacktraceClient.applicationDataPath}/backtrace`,
+          },
 });
 
 AppRegistry.registerComponent(appName, () => App);

--- a/package-lock.json
+++ b/package-lock.json
@@ -15497,8 +15497,7 @@
             "version": "0.1.0",
             "license": "MIT",
             "dependencies": {
-                "@backtrace/node": "^0.1.0",
-                "@backtrace/sdk-core": "^0.1.0"
+                "@backtrace/node": "^0.1.3"
             },
             "peerDependencies": {
                 "electron": "12 - 26"
@@ -15674,10 +15673,9 @@
         },
         "packages/react-native": {
             "name": "@backtrace/react-native",
-            "version": "0.0.1",
+            "version": "0.1.0",
             "license": "MIT",
             "dependencies": {
-                "@backtrace/react": "^0.1.0",
                 "@backtrace/sdk-core": "^0.1.0"
             },
             "devDependencies": {
@@ -22886,8 +22884,7 @@
         "@backtrace/electron": {
             "version": "file:packages/electron",
             "requires": {
-                "@backtrace/node": "^0.1.0",
-                "@backtrace/sdk-core": "^0.1.0"
+                "@backtrace/node": "^0.1.3"
             }
         },
         "@backtrace/javascript-cli": {
@@ -23007,7 +23004,6 @@
         "@backtrace/react-native": {
             "version": "file:packages/react-native",
             "requires": {
-                "@backtrace/react": "^0.1.0",
                 "@backtrace/sdk-core": "^0.1.0",
                 "@react-native-community/eslint-config": "^3.0.2",
                 "@types/jest": "^29.5.5",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -90,7 +90,6 @@
         "typescript": "^5.0.2"
     },
     "dependencies": {
-        "@backtrace/react": "^0.1.0",
         "@backtrace/sdk-core": "^0.1.0"
     }
 }

--- a/packages/react-native/src/BacktraceClient.ts
+++ b/packages/react-native/src/BacktraceClient.ts
@@ -1,4 +1,3 @@
-import { BacktraceBrowserRequestHandler, ReactStackTraceConverter } from '@backtrace/react';
 import {
     BacktraceCoreClient,
     BreadcrumbsManager,
@@ -18,6 +17,8 @@ import { version } from './common/platformHelper';
 import { CrashReporter } from './crashReporter/CrashReporter';
 import { generateUnhandledExceptionHandler } from './handlers';
 import { type ExceptionHandler } from './handlers/ExceptionHandler';
+import { ReactNativeRequestHandler } from './ReactNativeRequestHandler';
+import { ReactStackTraceConverter } from './ReactStackTraceConverter';
 import { type FileSystem } from './storage/FileSystem';
 
 export class BacktraceClient extends BacktraceCoreClient<BacktraceConfiguration> {
@@ -40,7 +41,7 @@ export class BacktraceClient extends BacktraceCoreClient<BacktraceConfiguration>
                 langName: 'react-native',
                 langVersion: version(),
             },
-            requestHandler: new BacktraceBrowserRequestHandler(clientSetup.options),
+            requestHandler: new ReactNativeRequestHandler(clientSetup.options),
             debugIdMapProvider: new VariableDebugIdMapProvider(global as DebugIdContainer),
             stackTraceConverter: new ReactStackTraceConverter(new V8StackTraceConverter('address at')),
             sessionProvider: new SingleSessionProvider(),

--- a/packages/react-native/src/ErrorBoundary.tsx
+++ b/packages/react-native/src/ErrorBoundary.tsx
@@ -34,14 +34,14 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
         return { error };
     }
 
-    public async componentDidCatch(error: Error, info: ErrorInfo) {
+    public componentDidCatch(error: Error, info: ErrorInfo) {
         const { name } = this.props;
         const report = new BacktraceReport(error, {
             'errorboundary.name': name ?? 'main',
             'error.type': 'Unhandled exception',
         });
         report.addStackTrace(this.COMPONENT_THREAD_NAME, info.componentStack);
-        await this._client.send(report);
+        this._client.send(report);
     }
 
     render() {

--- a/packages/react-native/src/ReactNativeRequestHandler.ts
+++ b/packages/react-native/src/ReactNativeRequestHandler.ts
@@ -1,0 +1,103 @@
+import {
+    anySignal,
+    BacktraceAttachment,
+    BacktraceReportSubmissionResult,
+    BacktraceRequestHandler,
+    ConnectionError,
+    DEFAULT_TIMEOUT,
+} from '@backtrace/sdk-core';
+
+export class ReactNativeRequestHandler implements BacktraceRequestHandler {
+    private readonly UPLOAD_FILE_NAME = 'upload_file';
+    private readonly _timeout: number;
+    private readonly JSON_HEADERS = {
+        'Content-type': 'application/json',
+    };
+
+    constructor(
+        private readonly _options: {
+            url: string;
+            token?: string;
+            timeout?: number;
+        },
+    ) {
+        this._timeout = this._options.timeout ?? DEFAULT_TIMEOUT;
+    }
+    public async postError<T>(
+        submissionUrl: string,
+        dataJson: string,
+        attachments: BacktraceAttachment<Blob | string>[],
+        abortSignal?: AbortSignal,
+    ): Promise<BacktraceReportSubmissionResult<T>> {
+        const formData = this.createFormData(dataJson, attachments);
+        return this.post(submissionUrl, formData, abortSignal);
+    }
+
+    public async post<T>(
+        submissionUrl: string,
+        payload: string | FormData,
+        abortSignal?: AbortSignal,
+    ): Promise<BacktraceReportSubmissionResult<T>> {
+        const controller = new AbortController();
+        const id = setTimeout(() => controller.abort(), this._timeout);
+
+        try {
+            const response = await fetch(submissionUrl, {
+                method: 'POST',
+                body: payload,
+                headers: typeof payload === 'string' ? this.JSON_HEADERS : {},
+                signal: anySignal(abortSignal, controller.signal),
+            });
+
+            clearInterval(id);
+
+            switch (response.status) {
+                case 200: {
+                    const result: T = await response.json();
+                    return BacktraceReportSubmissionResult.Ok(result);
+                }
+                case 401:
+                case 403: {
+                    return BacktraceReportSubmissionResult.OnInvalidToken();
+                }
+                case 429: {
+                    return BacktraceReportSubmissionResult.OnLimitReached();
+                }
+                default: {
+                    return BacktraceReportSubmissionResult.OnInternalServerError(response.statusText);
+                }
+            }
+        } catch (err) {
+            if (!(err instanceof Error)) {
+                return BacktraceReportSubmissionResult.OnUnknownError(err as string);
+            }
+
+            if (err.name === 'AbortError') {
+                return BacktraceReportSubmissionResult.OnNetworkingError('Timeout');
+            }
+            if (ConnectionError.isConnectionError(err)) {
+                return BacktraceReportSubmissionResult.OnNetworkingError(err.message);
+            }
+
+            return BacktraceReportSubmissionResult.OnUnknownError(err.message);
+        }
+    }
+
+    private createFormData(json: string, attachments: BacktraceAttachment<Blob | string>[]) {
+        const formData = new FormData();
+        formData.append(this.UPLOAD_FILE_NAME, json);
+
+        if (!attachments || attachments.length === 0) {
+            return formData;
+        }
+        for (const attachment of attachments) {
+            const data = attachment.get();
+            if (!data) {
+                continue;
+            }
+            formData.append(`attachment_${attachment.name}`, data);
+        }
+
+        return formData;
+    }
+}

--- a/packages/react-native/src/ReactStackTraceConverter.ts
+++ b/packages/react-native/src/ReactStackTraceConverter.ts
@@ -1,0 +1,51 @@
+import { BacktraceStackFrame, BacktraceStackTraceConverter, JavaScriptEngine } from '@backtrace/sdk-core';
+
+export class ReactStackTraceConverter implements BacktraceStackTraceConverter {
+    constructor(private readonly stackTraceConverter: BacktraceStackTraceConverter) {}
+
+    get engine(): JavaScriptEngine {
+        return this.stackTraceConverter.engine;
+    }
+
+    public convert(stackTrace: string, message = ''): BacktraceStackFrame[] {
+        // React 16 component stacks are not JS error stacks, and need to be parsed separately
+        if (this.isReact16ComponentStack(stackTrace)) {
+            return this.parseReact16ComponentStack(stackTrace);
+        }
+        return this.stackTraceConverter.convert(stackTrace, message);
+    }
+
+    /**
+     * React 16 component stacks need to be parsed separately. React 17+ component stacks can be parsed like Error stacks
+     */
+    private isReact16ComponentStack(stack: string): boolean {
+        if (!stack) {
+            return false;
+        }
+        const frames = stack.split('\n').filter((line) => !!line);
+        for (const frame of frames) {
+            if (!frame.includes('in ')) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private parseReact16ComponentStack(stack: string): BacktraceStackFrame[] {
+        const btFrames: BacktraceStackFrame[] = [];
+        if (!stack) {
+            return btFrames;
+        }
+        const frames = stack.split('\n');
+        for (const frame of frames) {
+            if (!frame.trim()) continue;
+            const component = frame.split('in ')[1]?.trim();
+            const btFrame: BacktraceStackFrame = {
+                funcName: component ?? 'unknown',
+                library: 'unknown',
+            };
+            btFrames.push(btFrame);
+        }
+        return btFrames;
+    }
+}


### PR DESCRIPTION
# Why

Adding web dependencies to the react-native package generates multiple warnings during the compiling time on any native platform. In addition to that, react/browser code are included in the generated bundle. We can definitely avoid adding them and reduce the package size significantly by dropping this dependency

This diff removes react dependency from the react-native package