### PR TITLE
cli: add-sources error behavior

### DIFF
--- a/tools/cli/src/helpers/errorBehavior.ts
+++ b/tools/cli/src/helpers/errorBehavior.ts
@@ -1,4 +1,4 @@
-import { Err, Ok, Result, ResultErr } from '@backtrace/sourcemap-tools';
+import { Err, LogLevel, Ok, Result, ResultErr } from '@backtrace/sourcemap-tools';
 
 export const ErrorBehaviors = {
     exit: 'exit',
@@ -51,4 +51,18 @@ export function filterBehaviorSkippedElements<T>(asset: Array<T | BehaviorSkippe
     return asset.filter(
         (a) => !(typeof a === 'object' && !!a && 'reason' in a && a.reason instanceof ResultErr),
     ) as T[];
+}
+
+export function isFatal(behavior: ErrorBehavior) {
+    return behavior === 'exit';
+}
+
+export function shouldLog(behavior: ErrorBehavior): behavior is LogLevel {
+    switch (behavior) {
+        case 'exit':
+        case 'skip':
+            return false;
+        default:
+            return true;
+    }
 }

--- a/tools/cli/src/sourcemaps/add-sources.ts
+++ b/tools/cli/src/sourcemaps/add-sources.ts
@@ -27,7 +27,7 @@ import { Command, CommandContext } from '../commands/Command';
 import { readSourceMapFromPathOrFromSource, toAsset, writeAsset } from '../helpers/common';
 import { ErrorBehaviors, filterBehaviorSkippedElements, getErrorBehavior, handleError } from '../helpers/errorBehavior';
 import { buildIncludeExclude, file2Or1FromTuple, findTuples } from '../helpers/find';
-import { logAsset } from '../helpers/logs';
+import { createAssetLogger } from '../helpers/logs';
 import { normalizePaths, relativePaths } from '../helpers/normalizePaths';
 import { CliLogger } from '../logger';
 import { findConfig, loadOptionsForCommand } from '../options/loadOptions';
@@ -123,8 +123,9 @@ export async function addSourcesToSourcemaps({ opts, logger, getHelpMessage }: C
 
     const logDebug = log(logger, 'debug');
     const logTrace = log(logger, 'trace');
-    const logDebugAsset = logAsset(logger, 'debug');
-    const logTraceAsset = logAsset(logger, 'trace');
+    const logAsset = createAssetLogger(logger);
+    const logDebugAsset = logAsset('debug');
+    const logTraceAsset = logAsset('trace');
 
     const assetErrorBehaviorResult = getErrorBehavior(opts['asset-error-behavior'] ?? 'exit');
     if (assetErrorBehaviorResult.isErr()) {

--- a/tools/cli/src/sourcemaps/process.ts
+++ b/tools/cli/src/sourcemaps/process.ts
@@ -26,7 +26,7 @@ import { Command, CommandContext } from '../commands/Command';
 import { readSourceAndSourceMap, toSourceAndSourceMapPaths, writeSourceAndSourceMap } from '../helpers/common';
 import { ErrorBehaviors, filterBehaviorSkippedElements, getErrorBehavior, handleError } from '../helpers/errorBehavior';
 import { buildIncludeExclude, findTuples } from '../helpers/find';
-import { logAsset, logAssets } from '../helpers/logs';
+import { createAssetLogger, logAssets } from '../helpers/logs';
 import { normalizePaths, relativePaths } from '../helpers/normalizePaths';
 import { CliLogger } from '../logger';
 import { SourceAndSourceMapPaths } from '../models/Asset';
@@ -135,7 +135,7 @@ export async function processSources({ opts, logger, getHelpMessage }: CommandCo
     const handleFailedAsset = handleError(assetErrorBehavior);
 
     const logAssetBehaviorError = (asset: Asset) => (err: string, level: LogLevel) =>
-        logAsset(logger, level)(err)(asset);
+        createAssetLogger(logger, level)(err)(asset);
 
     const processAssetCommand = (asset: SourceAndSourceMapPaths) =>
         pipe(

--- a/tools/cli/src/sourcemaps/run.ts
+++ b/tools/cli/src/sourcemaps/run.ts
@@ -37,7 +37,7 @@ import {
 } from '../helpers/common';
 import { ErrorBehaviors, filterBehaviorSkippedElements, getErrorBehavior, handleError } from '../helpers/errorBehavior';
 import { buildIncludeExclude, findTuples } from '../helpers/find';
-import { logAsset, logAssets } from '../helpers/logs';
+import { createAssetLogger, logAssets } from '../helpers/logs';
 import { normalizePaths, relativePaths } from '../helpers/normalizePaths';
 import { SourceAndSourceMapPaths } from '../models/Asset';
 import { findConfig, joinOptions, loadOptions } from '../options/loadOptions';
@@ -225,8 +225,8 @@ export async function runSourcemapCommands({ opts, logger, getHelpMessage }: Com
     const logInfo = log(logger, 'info');
     const logDebug = log(logger, 'debug');
     const logTrace = log(logger, 'trace');
-    const logDebugAsset = logAsset(logger, 'trace');
-    const logTraceAsset = logAsset(logger, 'trace');
+    const logDebugAsset = createAssetLogger(logger, 'trace');
+    const logTraceAsset = createAssetLogger(logger, 'trace');
     const logDebugAssets = logAssets(logger, 'debug');
     const logTraceAssets = logAssets(logger, 'trace');
 
@@ -241,7 +241,7 @@ export async function runSourcemapCommands({ opts, logger, getHelpMessage }: Com
     const handleFailedAsset = handleError(assetErrorBehavior);
 
     const logAssetBehaviorError = (asset: Asset) => (err: string, level: LogLevel) =>
-        logAsset(logger, level)(err)(asset);
+        createAssetLogger(logger, level)(err)(asset);
 
     const readAssetCommand = (asset: SourceAndSourceMapPaths) =>
         pipe(

--- a/tools/cli/src/sourcemaps/upload.ts
+++ b/tools/cli/src/sourcemaps/upload.ts
@@ -37,7 +37,7 @@ import { Command, CommandContext } from '../commands/Command';
 import { isAssetProcessed, readSourceMapFromPathOrFromSource, toAsset, uniqueBy, validateUrl } from '../helpers/common';
 import { ErrorBehaviors, filterBehaviorSkippedElements, getErrorBehavior, handleError } from '../helpers/errorBehavior';
 import { buildIncludeExclude, file2Or1FromTuple, findTuples } from '../helpers/find';
-import { logAsset } from '../helpers/logs';
+import { createAssetLogger } from '../helpers/logs';
 import { normalizePaths, relativePaths } from '../helpers/normalizePaths';
 import { CliLogger } from '../logger';
 import { findConfig, loadOptionsForCommand } from '../options/loadOptions';
@@ -196,8 +196,8 @@ export async function uploadSourcemaps({ opts, logger, getHelpMessage }: Command
 
     const logDebug = log(logger, 'debug');
     const logTrace = log(logger, 'trace');
-    const logDebugAsset = logAsset(logger, 'debug');
-    const logTraceAsset = logAsset(logger, 'trace');
+    const logDebugAsset = createAssetLogger(logger, 'debug');
+    const logTraceAsset = createAssetLogger(logger, 'trace');
 
     const assetErrorBehaviorResult = getErrorBehavior(opts['asset-error-behavior'] ?? 'exit');
     if (assetErrorBehaviorResult.isErr()) {
@@ -210,7 +210,7 @@ export async function uploadSourcemaps({ opts, logger, getHelpMessage }: Command
     const handleFailedAsset = handleError(assetErrorBehavior);
 
     const logAssetBehaviorError = (asset: Asset) => (err: string, level: LogLevel) =>
-        logAsset(logger, level)(err)(asset);
+        createAssetLogger(logger, level)(err)(asset);
 
     const isAssetProcessedCommand = (asset: AssetWithContent<RawSourceMap>) =>
         pipe(

--- a/tools/cli/tests/sourcemaps/add-sources.spec.ts
+++ b/tools/cli/tests/sourcemaps/add-sources.spec.ts
@@ -7,6 +7,10 @@ import { expectAllKeysToChange, filterKeys, getHelpMessage } from '../_helpers/c
 import { expectHashesToChange, hashEachFile, hashFiles, withWorkingCopy } from '../_helpers/testFiles';
 
 describe('add-sources', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
     describe('returning value', () => {
         it(
             'should return processed sourcemaps',
@@ -79,7 +83,7 @@ describe('add-sources', () => {
                 const files = await glob(`${workingDir}/*.js.map`);
 
                 for (const file of files) {
-                    expect(spy).toBeCalledWith(expect.anything(), file);
+                    expect(spy).toBeCalledWith(expect.anything(), file, expect.any(Boolean));
                 }
             }),
         );
@@ -167,7 +171,7 @@ describe('add-sources', () => {
                 const files = await glob(`${workingDir}/*.js.map`);
 
                 for (const file of files) {
-                    expect(spy).toBeCalledWith(expect.anything(), file);
+                    expect(spy).toBeCalledWith(expect.anything(), file, expect.any(Boolean));
                 }
             }),
         );
@@ -226,7 +230,7 @@ describe('add-sources', () => {
                 const files = await glob(`${workingDir}/*.js.map`);
 
                 for (const file of files) {
-                    expect(spy).toBeCalledWith(expect.anything(), file);
+                    expect(spy).toBeCalledWith(expect.anything(), file, expect.any(Boolean));
                 }
             }),
         );
@@ -266,6 +270,7 @@ describe('add-sources', () => {
                     getHelpMessage,
                     opts: {
                         path: workingDir,
+                        'source-error-behavior': 'exit',
                     },
                 });
 
@@ -286,6 +291,7 @@ describe('add-sources', () => {
                     getHelpMessage,
                     opts: {
                         path: [workingDir],
+                        'source-error-behavior': 'exit',
                     },
                 });
 
@@ -309,6 +315,7 @@ describe('add-sources', () => {
                     getHelpMessage,
                     opts: {
                         path: [workingDir],
+                        'source-error-behavior': 'exit',
                     },
                 });
 
@@ -329,6 +336,22 @@ describe('add-sources', () => {
                     opts: {
                         path: workingDir,
                         'asset-error-behavior': 'skip',
+                    },
+                });
+
+                assert(result.isOk(), result.data as string);
+            }),
+        );
+
+        it(
+            'should not fail with source-error-behavior=skip',
+            withWorkingCopy('invalid', async (workingDir) => {
+                const result = await addSourcesToSourcemaps({
+                    logger: new CliLogger({ level: 'output', silent: true }),
+                    getHelpMessage,
+                    opts: {
+                        path: workingDir,
+                        'source-error-behavior': 'skip',
                     },
                 });
 
@@ -390,7 +413,7 @@ describe('add-sources', () => {
                 const files = await glob(`${workingDir}/*.js.map`);
 
                 for (const file of files) {
-                    expect(spy).toBeCalledWith(expect.anything(), file);
+                    expect(spy).toBeCalledWith(expect.anything(), file, expect.any(Boolean));
                 }
             }),
         );
@@ -449,7 +472,7 @@ describe('add-sources', () => {
                 const files = await glob(`${workingDir}/*.js.map`);
 
                 for (const file of files) {
-                    expect(spy).toBeCalledWith(expect.anything(), file);
+                    expect(spy).toBeCalledWith(expect.anything(), file, expect.any(Boolean));
                 }
             }),
         );
@@ -514,7 +537,7 @@ describe('add-sources', () => {
                 const files = await glob(`${workingDir}/*.js.map`);
 
                 for (const file of files) {
-                    expect(spy).toBeCalledWith(expect.anything(), file);
+                    expect(spy).toBeCalledWith(expect.anything(), file, expect.any(Boolean));
                 }
             }),
         );

--- a/tools/cli/tests/sourcemaps/run.spec.ts
+++ b/tools/cli/tests/sourcemaps/run.spec.ts
@@ -257,7 +257,14 @@ describe('run', () => {
                 type InnerAddSources = ReturnType<typeof addSourcesCmd.addSourceToSourceMap>;
                 const innerAddSources = jest
                     .fn<ReturnType<InnerAddSources>, Parameters<InnerAddSources>>()
-                    .mockImplementation((asset) => Promise.resolve(Ok(asset)));
+                    .mockImplementation((asset) =>
+                        Promise.resolve(
+                            Ok({
+                                ...asset,
+                                result: { sourceMap: {} as never, succeeded: [], skipped: [], failed: [] },
+                            }),
+                        ),
+                    );
 
                 const addSourcesSpy = jest
                     .spyOn(addSourcesCmd, 'addSourceToSourceMap')

--- a/tools/sourcemap-tools/tests/SourceProcessor.spec.ts
+++ b/tools/sourcemap-tools/tests/SourceProcessor.spec.ts
@@ -303,13 +303,26 @@ function foo(){console.log("Hello World!")}foo();`;
             const sourceMapContent = await fs.promises.readFile(sourceMapPath, 'utf-8');
 
             const sourceProcessor = new SourceProcessor(new DebugIdGenerator());
-            const result = await sourceProcessor.addSourcesToSourceMap(sourceMapContent, sourceMapPath);
+            const result = await sourceProcessor.addSourcesToSourceMap(sourceMapContent, sourceMapPath, false);
             assert(result.isOk());
 
-            expect(result.data.sourcesContent).toEqual([sourceContent]);
+            expect(result.data.sourceMap.sourcesContent).toEqual([sourceContent]);
         });
 
-        it('should overwrite sources in source map', async () => {
+        it('should not overwrite sources in source map when force is false', async () => {
+            const sourceMapPath = path.join(__dirname, './testFiles/source.js.map');
+
+            const sourceMapContent = JSON.parse(await fs.promises.readFile(sourceMapPath, 'utf-8')) as RawSourceMap;
+            sourceMapContent.sourcesContent = ['abc'];
+
+            const sourceProcessor = new SourceProcessor(new DebugIdGenerator());
+            const result = await sourceProcessor.addSourcesToSourceMap(sourceMapContent, sourceMapPath, false);
+            assert(result.isOk());
+
+            expect(result.data.sourceMap.sourcesContent).toEqual(['abc']);
+        });
+
+        it('should overwrite sources in source map when force is true', async () => {
             const originalSourcePath = path.join(__dirname, './testFiles/source.ts');
             const sourceMapPath = path.join(__dirname, './testFiles/source.js.map');
 
@@ -318,10 +331,10 @@ function foo(){console.log("Hello World!")}foo();`;
             sourceMapContent.sourcesContent = ['abc'];
 
             const sourceProcessor = new SourceProcessor(new DebugIdGenerator());
-            const result = await sourceProcessor.addSourcesToSourceMap(sourceMapContent, sourceMapPath);
+            const result = await sourceProcessor.addSourcesToSourceMap(sourceMapContent, sourceMapPath, true);
             assert(result.isOk());
 
-            expect(result.data.sourcesContent).toEqual([sourceContent]);
+            expect(result.data.sourceMap.sourcesContent).toEqual([sourceContent]);
         });
     });
 


### PR DESCRIPTION
This PR adds some changes to add-sources:
* by default, it will now warn about sources that failed to add if the source is not there, and skip it if the source is already in the sourcemap,
  * you can control what happens with failed sources using `--source-error-behavior`
* if `--force` is passed, all sources are treated as if they were not there

Jira task: BT-2080