### PR TITLE
react-native: set transfer encoding to chunked

### DIFF
--- a/packages/react-native/src/ReactNativeRequestHandler.ts
+++ b/packages/react-native/src/ReactNativeRequestHandler.ts
@@ -32,8 +32,8 @@ export class ReactNativeRequestHandler implements BacktraceRequestHandler {
         attachments: BacktraceAttachment<Blob | string>[],
         abortSignal?: AbortSignal,
     ): Promise<BacktraceReportSubmissionResult<T>> {
-        const formData = this.createFormData(dataJson, attachments);
-        return this.post(submissionUrl, formData, abortSignal);
+        const payload = this.createSubmissionPayload(dataJson, attachments);
+        return this.post(submissionUrl, payload, abortSignal);
     }
 
     public async post<T>(
@@ -86,13 +86,15 @@ export class ReactNativeRequestHandler implements BacktraceRequestHandler {
         }
     }
 
-    private createFormData(json: string, attachments: BacktraceAttachment<Blob | string>[]) {
+    private createSubmissionPayload(
+        json: string,
+        attachments: BacktraceAttachment<Blob | string>[],
+    ): FormData | string {
+        if (!attachments || attachments.length === 0) {
+            return json;
+        }
         const formData = new FormData();
         formData.append(this.UPLOAD_FILE_NAME, json);
-
-        if (!attachments || attachments.length === 0) {
-            return formData;
-        }
         for (const attachment of attachments) {
             const data = attachment.get();
             if (!data) {

--- a/packages/react-native/src/ReactNativeRequestHandler.ts
+++ b/packages/react-native/src/ReactNativeRequestHandler.ts
@@ -13,6 +13,9 @@ export class ReactNativeRequestHandler implements BacktraceRequestHandler {
     private readonly JSON_HEADERS = {
         'Content-type': 'application/json',
     };
+    private readonly MULTIPART_HEADERS = {
+        'Transfer-Encoding': 'chunked',
+    };
 
     constructor(
         private readonly _options: {
@@ -45,7 +48,7 @@ export class ReactNativeRequestHandler implements BacktraceRequestHandler {
             const response = await fetch(submissionUrl, {
                 method: 'POST',
                 body: payload,
-                headers: typeof payload === 'string' ? this.JSON_HEADERS : {},
+                headers: typeof payload === 'string' ? this.JSON_HEADERS : this.MULTIPART_HEADERS,
                 signal: anySignal(abortSignal, controller.signal),
             });
 


### PR DESCRIPTION
# Why

This diff adds a new header to the multipart upload request. Those headers are necessary to fix a problem with a truncated stream sent by react-native to the server. 

refs BT-1979