### PR TITLE
BT-718 - Reduce breadcrumb size

### DIFF
--- a/packages/sdk-core/src/builder/BacktraceCoreClientBuilder.ts
+++ b/packages/sdk-core/src/builder/BacktraceCoreClientBuilder.ts
@@ -1,7 +1,7 @@
 import { BacktraceReportSubmission } from '../model/http/BacktraceReportSubmission';
 import { BacktraceRequestHandler } from '../model/http/BacktraceRequestHandler';
 import { BacktraceAttributeProvider } from '../modules/attribute/BacktraceAttributeProvider';
-import { BreadcrumbsEventSubscriber, BreadcrumbsStorage } from '../modules/breadcrumbs';
+import { BreadcrumbsEventSubscriber, BreadcrumbsStorage, BreadcrumbsStorageFactory } from '../modules/breadcrumbs';
 import { BacktraceStackTraceConverter } from '../modules/converter';
 import { BacktraceSessionProvider } from '../modules/metrics/BacktraceSessionProvider';
 import { MetricsQueue } from '../modules/metrics/MetricsQueue';
@@ -38,12 +38,22 @@ export abstract class BacktraceCoreClientBuilder<S extends Partial<CoreClientSet
         return this;
     }
 
-    public useBreadcrumbsStorage(storage: BreadcrumbsStorage): this {
+    public useBreadcrumbsStorage(storageFactory: BreadcrumbsStorageFactory): this;
+    /**
+     * @deprecated Use `useBreadcrumbsStorage` with `BreadcrumbsStorageFactory`.
+     */
+    public useBreadcrumbsStorage(storage: BreadcrumbsStorage): this;
+    public useBreadcrumbsStorage(storage: BreadcrumbsStorage | BreadcrumbsStorageFactory): this {
         if (!this.clientSetup.breadcrumbsSetup) {
             this.clientSetup.breadcrumbsSetup = {};
         }
 
-        this.clientSetup.breadcrumbsSetup.storage = storage;
+        if (typeof storage === 'function') {
+            this.clientSetup.breadcrumbsSetup.storage = storage;
+        } else {
+            this.clientSetup.breadcrumbsSetup.storage = () => storage;
+        }
+
         return this;
     }
 

--- a/packages/sdk-core/src/common/jsonEscaper.ts
+++ b/packages/sdk-core/src/common/jsonEscaper.ts
@@ -5,12 +5,10 @@ export function jsonEscaper() {
     // in TypeScript add "this: any" param to avoid compliation errors - as follows
     //    return function (this: any, field: any, value: any) {
     return function (this: unknown, key: string, value: unknown) {
-        if (!key) {
-            return value;
-        }
         if (value === null) {
             return value;
         }
+
         const valueType = typeof value;
 
         if (valueType === 'bigint') {
@@ -28,7 +26,7 @@ export function jsonEscaper() {
             keys.pop();
         }
         if (ancestors.includes(value)) {
-            return `[Circular].${keys.join('.')}.${key}`;
+            return `[Circular].${keys.filter((k) => !!k).join('.')}.${key}`;
         }
         keys.push(key);
         ancestors.push(value);

--- a/packages/sdk-core/src/common/jsonSize.ts
+++ b/packages/sdk-core/src/common/jsonSize.ts
@@ -15,7 +15,7 @@ const booleanSize = (value: boolean) => (value ? 4 : 5);
 const undefinedSize = 0;
 const nullSize = 'null'.length;
 
-const arraySize = (array: unknown[], replacer?: (this: unknown, key: string, value: unknown) => unknown): number => {
+function arraySize(array: unknown[], replacer?: (this: unknown, key: string, value: unknown) => unknown): number {
     const bracketLength = 2;
     const commaLength = array.length - 1;
     let elementsLength = 0;
@@ -33,7 +33,7 @@ const arraySize = (array: unknown[], replacer?: (this: unknown, key: string, val
     }
 
     return bracketLength + commaLength + elementsLength;
-};
+}
 
 const objectSize = (obj: object, replacer?: (this: unknown, key: string, value: unknown) => unknown): number => {
     let jsonObject: object;
@@ -126,6 +126,15 @@ function _jsonSize(
     return 0;
 }
 
-export function jsonSize(value: unknown, replacer?: (this: unknown, key: string, value: unknown) => unknown) {
+/**
+ * Calculates size of the object as it would be serialized into JSON.
+ *
+ * _Should_ return the same value as `JSON.stringify(value, replacer).length`.
+ * This may not be 100% accurate, but should work for our requirements.
+ * @param value Value to compute length for.
+ * @param replacer A function that transforms the results as in `JSON.stringify`.
+ * @returns Final string length.
+ */
+export function jsonSize(value: unknown, replacer?: (this: unknown, key: string, value: unknown) => unknown): number {
     return _jsonSize(undefined, '', value, replacer);
 }

--- a/packages/sdk-core/src/common/jsonSize.ts
+++ b/packages/sdk-core/src/common/jsonSize.ts
@@ -1,0 +1,131 @@
+function stringifiedSize<T>(value: T): number {
+    return JSON.stringify(value).length;
+}
+
+function toStringSize<T extends { toString(): string }>(value: T): number {
+    return value.toString().length;
+}
+
+const stringSize = (value: string) => stringifiedSize(value);
+const numberSize = toStringSize<number>;
+const bigintSize = toStringSize<bigint>;
+const symbolSize = 0;
+const functionSize = 0;
+const booleanSize = (value: boolean) => (value ? 4 : 5);
+const undefinedSize = 0;
+const nullSize = 'null'.length;
+
+const arraySize = (array: unknown[], replacer?: (this: unknown, key: string, value: unknown) => unknown): number => {
+    const bracketLength = 2;
+    const commaLength = array.length - 1;
+    let elementsLength = 0;
+    for (let i = 0; i < array.length; i++) {
+        const element = array[i];
+        switch (typeof element) {
+            case 'function':
+            case 'symbol':
+            case 'undefined':
+                elementsLength += nullSize;
+                break;
+            default:
+                elementsLength += _jsonSize(array, i.toString(), element, replacer);
+        }
+    }
+
+    return bracketLength + commaLength + elementsLength;
+};
+
+const objectSize = (obj: object, replacer?: (this: unknown, key: string, value: unknown) => unknown): number => {
+    let jsonObject: object;
+    if ('toJSON' in obj && typeof obj.toJSON === 'function') {
+        jsonObject = obj.toJSON() as object;
+    } else {
+        jsonObject = obj;
+    }
+
+    const entries = Object.entries(jsonObject);
+    const bracketLength = 2;
+
+    let entryCount = 0;
+    let entriesLength = 0;
+
+    for (const [k, v] of entries) {
+        const valueSize = _jsonSize(obj, k, v, replacer);
+        if (valueSize === 0) {
+            continue;
+        }
+
+        entryCount++;
+        entriesLength += keySize(k) + valueSize + 1;
+    }
+
+    const commaLength = Math.max(0, entryCount - 1);
+
+    return bracketLength + commaLength + entriesLength;
+};
+
+function keySize(key: unknown): number {
+    const QUOTE_SIZE = 2;
+
+    if (key === null) {
+        return nullSize + QUOTE_SIZE;
+    } else if (key === undefined) {
+        return '"undefined"'.length;
+    }
+
+    switch (typeof key) {
+        case 'string':
+            return stringSize(key);
+        case 'number':
+            return numberSize(key) + QUOTE_SIZE;
+        case 'boolean':
+            return booleanSize(key) + QUOTE_SIZE;
+        case 'symbol':
+            return 0; // key not used in JSON
+        default:
+            return stringSize(key.toString());
+    }
+}
+
+function _jsonSize(
+    parent: unknown,
+    key: string,
+    value: unknown,
+    replacer?: (this: unknown, key: string, value: unknown) => unknown,
+): number {
+    value = replacer ? replacer.call(parent, key, value) : value;
+    if (value === null) {
+        return nullSize;
+    } else if (value === undefined) {
+        return undefinedSize;
+    }
+
+    if (Array.isArray(value)) {
+        return arraySize(value, replacer);
+    }
+
+    switch (typeof value) {
+        case 'bigint':
+            return bigintSize(value);
+        case 'boolean':
+            return booleanSize(value);
+        case 'function':
+            return functionSize;
+        case 'number':
+            return numberSize(value);
+        case 'object':
+            return objectSize(value, replacer);
+        case 'string':
+            return stringSize(value);
+        case 'symbol':
+            return symbolSize;
+        case 'undefined':
+            return undefinedSize;
+    }
+
+    return 0;
+}
+
+export function jsonSize(value: unknown, replacer?: (this: unknown, key: string, value: unknown) => unknown) {
+    return _jsonSize(undefined, '', value, replacer);
+}

--- a/packages/sdk-core/src/common/limitObjectDepth.ts
+++ b/packages/sdk-core/src/common/limitObjectDepth.ts
@@ -1,0 +1,30 @@
+type DeepPartial<T extends object> = Partial<{ [K in keyof T]: T[K] extends object ? DeepPartial<T[K]> : T[K] }>;
+
+const REMOVED_PLACEHOLDER = '<removed>';
+
+export type Limited<T extends object> = DeepPartial<T> | typeof REMOVED_PLACEHOLDER;
+
+export function limitObjectDepth<T extends object>(obj: T, depth: number): Limited<T> {
+    if (!(depth < Infinity)) {
+        return obj;
+    }
+
+    if (depth < 0) {
+        return REMOVED_PLACEHOLDER;
+    }
+
+    const limitIfObject = (value: unknown) =>
+        typeof value === 'object' && value ? limitObjectDepth(value, depth - 1) : value;
+
+    const result: DeepPartial<T> = {};
+    for (const key in obj) {
+        const value = obj[key];
+        if (Array.isArray(value)) {
+            result[key] = value.map(limitIfObject) as never;
+        } else {
+            result[key] = limitIfObject(value) as never;
+        }
+    }
+
+    return result;
+}

--- a/packages/sdk-core/src/model/configuration/BacktraceConfiguration.ts
+++ b/packages/sdk-core/src/model/configuration/BacktraceConfiguration.ts
@@ -86,7 +86,7 @@ export interface BacktraceBreadcrumbsSettings {
      * Use `false` to disable the limit.
      * @default 1048576 // 1MB
      */
-    maximumBreadcrumbsSize?: number | false;
+    maximumTotalBreadcrumbsSize?: number | false;
 
     /**
      * Inspects breadcrumb and allows to modify it. If the undefined value is being

--- a/packages/sdk-core/src/model/configuration/BacktraceConfiguration.ts
+++ b/packages/sdk-core/src/model/configuration/BacktraceConfiguration.ts
@@ -47,31 +47,46 @@ export interface BacktraceBreadcrumbsSettings {
     /**
      * Specifies maximum number of breadcrumbs stored by the library. By default, only 100 breadcrumbs
      * will be stored.
+     *
+     * Use `false` to disable the limit.
+     * @default 100
      */
-    maximumBreadcrumbs?: number;
+    maximumBreadcrumbs?: number | false;
 
     /**
      * Specifies maximum object depth that are included in breadcrumb attributes.
+     *
+     * Use `false` to disable the limit.
+     * @default 2
      */
-    maximumAttributesDepth?: number;
+    maximumAttributesDepth?: number | false;
 
     /**
      * Specifies maximum breadcrumb message length.
      * If the size is exceeded, message will be truncated.
+     *
+     * Use `false` to disable the limit.
+     * @default 255
      */
-    maximumBreadcrumbMessageLength?: number;
+    maximumBreadcrumbMessageLength?: number | false;
 
     /**
      * Specifies maximum single breadcrumb size in bytes.
-     * If the size is exceeded, data will be removed from the breadcrumb.
+     * If the size is exceeded, the breadcrumb will be skipped.
+     *
+     * Use `false` to disable the limit.
+     * @default 65536 // 64kB
      */
-    maximumBreadcrumbSize?: number;
+    maximumBreadcrumbSize?: number | false;
 
     /**
      * Specifies maximum breadcrumbs size in bytes.
      * If the size is exceeded, oldest breadcrumbs will be skipped.
+     *
+     * Use `false` to disable the limit.
+     * @default 1048576 // 1MB
      */
-    maximumBreadcrumbsSize?: number;
+    maximumBreadcrumbsSize?: number | false;
 
     /**
      * Inspects breadcrumb and allows to modify it. If the undefined value is being

--- a/packages/sdk-core/src/model/configuration/BacktraceConfiguration.ts
+++ b/packages/sdk-core/src/model/configuration/BacktraceConfiguration.ts
@@ -51,6 +51,29 @@ export interface BacktraceBreadcrumbsSettings {
     maximumBreadcrumbs?: number;
 
     /**
+     * Specifies maximum object depth that are included in breadcrumb attributes.
+     */
+    maximumAttributesDepth?: number;
+
+    /**
+     * Specifies maximum breadcrumb message length.
+     * If the size is exceeded, message will be truncated.
+     */
+    maximumBreadcrumbMessageLength?: number;
+
+    /**
+     * Specifies maximum single breadcrumb size in bytes.
+     * If the size is exceeded, data will be removed from the breadcrumb.
+     */
+    maximumBreadcrumbSize?: number;
+
+    /**
+     * Specifies maximum breadcrumbs size in bytes.
+     * If the size is exceeded, oldest breadcrumbs will be skipped.
+     */
+    maximumBreadcrumbsSize?: number;
+
+    /**
      * Inspects breadcrumb and allows to modify it. If the undefined value is being
      * returned from the method, no breadcrumb will be added to the breadcrumb storage.
      */

--- a/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
@@ -23,6 +23,13 @@ import { InMemoryBreadcrumbsStorage } from './storage/InMemoryBreadcrumbsStorage
 
 const BREADCRUMB_ATTRIBUTE_NAME = 'breadcrumbs.lastId';
 
+/**
+ * @returns `undefined` if value is `false`, else `value` if defined, else `defaultValue`
+ */
+const defaultIfNotFalse = <T>(value: T | false, defaultValue: T) => {
+    return value === false ? undefined : value !== undefined ? value : defaultValue;
+};
+
 export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule {
     /**
      * Breadcrumbs type
@@ -45,11 +52,11 @@ export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule
 
     constructor(configuration?: BacktraceBreadcrumbsSettings, options?: BreadcrumbsSetup) {
         this._limits = {
-            maximumBreadcrumbs: configuration?.maximumBreadcrumbs ?? 100,
-            maximumAttributesDepth: configuration?.maximumAttributesDepth ?? 2,
-            maximumBreadcrumbMessageLength: configuration?.maximumBreadcrumbMessageLength ?? 255,
-            maximumBreadcrumbSize: configuration?.maximumBreadcrumbSize ?? 64 * 1024,
-            maximumBreadcrumbsSize: configuration?.maximumBreadcrumbsSize ?? 1024 * 1024,
+            maximumBreadcrumbs: defaultIfNotFalse(configuration?.maximumBreadcrumbs, 100),
+            maximumAttributesDepth: defaultIfNotFalse(configuration?.maximumAttributesDepth, 2),
+            maximumBreadcrumbMessageLength: defaultIfNotFalse(configuration?.maximumBreadcrumbMessageLength, 255),
+            maximumBreadcrumbSize: defaultIfNotFalse(configuration?.maximumBreadcrumbSize, 64 * 1024),
+            maximumBreadcrumbsSize: defaultIfNotFalse(configuration?.maximumBreadcrumbsSize, 1024 * 1024),
         };
 
         this.breadcrumbsType = configuration?.eventType ?? defaultBreadcurmbType;

--- a/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
@@ -56,7 +56,7 @@ export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule
             maximumAttributesDepth: defaultIfNotFalse(configuration?.maximumAttributesDepth, 2),
             maximumBreadcrumbMessageLength: defaultIfNotFalse(configuration?.maximumBreadcrumbMessageLength, 255),
             maximumBreadcrumbSize: defaultIfNotFalse(configuration?.maximumBreadcrumbSize, 64 * 1024),
-            maximumBreadcrumbsSize: defaultIfNotFalse(configuration?.maximumBreadcrumbsSize, 1024 * 1024),
+            maximumTotalBreadcrumbsSize: defaultIfNotFalse(configuration?.maximumTotalBreadcrumbsSize, 1024 * 1024),
         };
 
         this.breadcrumbsType = configuration?.eventType ?? defaultBreadcurmbType;

--- a/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
@@ -8,6 +8,7 @@ import {
     defaultBreadcurmbType,
 } from '.';
 import { jsonEscaper } from '../../common/jsonEscaper';
+import { jsonSize } from '../../common/jsonSize';
 import { limitObjectDepth } from '../../common/limitObjectDepth';
 import { BacktraceBreadcrumbsSettings } from '../../model/configuration/BacktraceConfiguration';
 import { AttributeType } from '../../model/data/BacktraceData';
@@ -16,7 +17,7 @@ import { BacktraceModule, BacktraceModuleBindData } from '../BacktraceModule';
 import { BreadcrumbsEventSubscriber } from './events/BreadcrumbsEventSubscriber';
 import { ConsoleEventSubscriber } from './events/ConsoleEventSubscriber';
 import { BreadcrumbLimits } from './model/BreadcrumbLimits';
-import { RawBreadcrumb } from './model/RawBreadcrumb';
+import { LimitedRawBreadcrumb, RawBreadcrumb } from './model/RawBreadcrumb';
 import { InMemoryBreadcrumbsStorage } from './storage/InMemoryBreadcrumbsStorage';
 
 const BREADCRUMB_ATTRIBUTE_NAME = 'breadcrumbs.lastId';
@@ -136,20 +137,11 @@ export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule
             return false;
         }
 
-        const breadcrumbMessage = this.prepareBreadcrumbMessage(message);
-
         let rawBreadcrumb: RawBreadcrumb = {
-            message:
-                this._limits.maximumBreadcrumbMessageLength !== undefined
-                    ? breadcrumbMessage.substring(0, this._limits.maximumBreadcrumbMessageLength)
-                    : breadcrumbMessage,
+            message: this.prepareBreadcrumbMessage(message),
             level,
             type,
-            attributes: attributes
-                ? this._limits.maximumAttributesDepth !== undefined
-                    ? limitObjectDepth(attributes, this._limits.maximumAttributesDepth)
-                    : attributes
-                : undefined,
+            attributes,
         };
 
         if (this._interceptor) {
@@ -168,7 +160,32 @@ export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule
             return false;
         }
 
-        this._storage.add(rawBreadcrumb);
+        if (this._limits.maximumBreadcrumbMessageLength !== undefined) {
+            rawBreadcrumb = {
+                ...rawBreadcrumb,
+                message: rawBreadcrumb.message.substring(0, this._limits.maximumBreadcrumbMessageLength),
+            };
+        }
+
+        let limitedBreadcrumb: RawBreadcrumb | LimitedRawBreadcrumb;
+        if (this._limits.maximumAttributesDepth !== undefined && rawBreadcrumb.attributes) {
+            limitedBreadcrumb = {
+                ...rawBreadcrumb,
+                attributes: limitObjectDepth(rawBreadcrumb.attributes, this._limits.maximumAttributesDepth),
+            };
+        } else {
+            limitedBreadcrumb = rawBreadcrumb;
+        }
+
+        if (this._limits.maximumBreadcrumbSize !== undefined) {
+            const breadcrumbSize = jsonSize(limitedBreadcrumb, jsonEscaper());
+            if (breadcrumbSize > this._limits.maximumBreadcrumbSize) {
+                // TODO: Trim the breadcrumb
+                return false;
+            }
+        }
+
+        this._storage.add(limitedBreadcrumb);
         return true;
     }
 

--- a/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
@@ -3,6 +3,7 @@ import {
     BreadcrumbLogLevel,
     BreadcrumbsSetup,
     BreadcrumbsStorage,
+    BreadcrumbsStorageFactory,
     BreadcrumbType,
     defaultBreadcrumbsLogLevel,
     defaultBreadcurmbType,
@@ -43,20 +44,21 @@ export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule
     private _storage: BreadcrumbsStorage;
 
     constructor(configuration?: BacktraceBreadcrumbsSettings, options?: BreadcrumbsSetup) {
+        this._limits = {
+            maximumBreadcrumbs: configuration?.maximumBreadcrumbs ?? 100,
+            maximumAttributesDepth: configuration?.maximumAttributesDepth ?? 2,
+            maximumBreadcrumbMessageLength: configuration?.maximumBreadcrumbMessageLength ?? 255,
+            maximumBreadcrumbSize: configuration?.maximumBreadcrumbSize ?? 64 * 1024,
+            maximumBreadcrumbsSize: configuration?.maximumBreadcrumbsSize ?? 1024 * 1024,
+        };
+
         this.breadcrumbsType = configuration?.eventType ?? defaultBreadcurmbType;
         this.logLevel = configuration?.logLevel ?? defaultBreadcrumbsLogLevel;
-        this._storage = options?.storage ?? new InMemoryBreadcrumbsStorage(configuration?.maximumBreadcrumbs);
+        this._storage = (options?.storage ?? InMemoryBreadcrumbsStorage.factory)({ limits: this._limits });
         this._interceptor = configuration?.intercept;
         if (options?.subscribers) {
             this._eventSubscribers.push(...options.subscribers);
         }
-
-        this._limits = {
-            maximumAttributesDepth: configuration?.maximumAttributesDepth,
-            maximumBreadcrumbMessageLength: configuration?.maximumBreadcrumbMessageLength,
-            maximumBreadcrumbSize: configuration?.maximumBreadcrumbSize,
-            maximumBreadcrumbsSize: configuration?.maximumBreadcrumbsSize,
-        };
     }
 
     public addEventSubscriber(subscriber: BreadcrumbsEventSubscriber) {
@@ -66,8 +68,17 @@ export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule
         this._eventSubscribers.push(subscriber);
     }
 
-    public setStorage(storage: BreadcrumbsStorage) {
-        this._storage = storage;
+    public setStorage(storageFactory: BreadcrumbsStorageFactory): void;
+    /**
+     * @deprecated Use `useStorage` with `BreadcrumbsStorageFactory`.
+     */
+    public setStorage(storage: BreadcrumbsStorage): void;
+    public setStorage(storage: BreadcrumbsStorage | BreadcrumbsStorageFactory) {
+        if (typeof storage === 'function') {
+            this._storage = storage({ limits: this._limits });
+        } else {
+            this._storage = storage;
+        }
     }
 
     public dispose(): void {

--- a/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
@@ -136,8 +136,13 @@ export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule
             return false;
         }
 
+        const breadcrumbMessage = this.prepareBreadcrumbMessage(message);
+
         let rawBreadcrumb: RawBreadcrumb = {
-            message: this.prepareBreadcrumbMessage(message),
+            message:
+                this._limits.maximumBreadcrumbMessageLength !== undefined
+                    ? breadcrumbMessage.substring(0, this._limits.maximumBreadcrumbMessageLength)
+                    : breadcrumbMessage,
             level,
             type,
             attributes: attributes

--- a/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
@@ -14,6 +14,7 @@ import { BacktraceReport } from '../../model/report/BacktraceReport';
 import { BacktraceModule, BacktraceModuleBindData } from '../BacktraceModule';
 import { BreadcrumbsEventSubscriber } from './events/BreadcrumbsEventSubscriber';
 import { ConsoleEventSubscriber } from './events/ConsoleEventSubscriber';
+import { BreadcrumbLimits } from './model/BreadcrumbLimits';
 import { RawBreadcrumb } from './model/RawBreadcrumb';
 import { InMemoryBreadcrumbsStorage } from './storage/InMemoryBreadcrumbsStorage';
 
@@ -34,6 +35,7 @@ export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule
      */
     private _enabled = false;
 
+    private readonly _limits: BreadcrumbLimits;
     private readonly _eventSubscribers: BreadcrumbsEventSubscriber[] = [new ConsoleEventSubscriber()];
     private readonly _interceptor?: (breadcrumb: RawBreadcrumb) => RawBreadcrumb | undefined;
     private _storage: BreadcrumbsStorage;
@@ -46,6 +48,13 @@ export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule
         if (options?.subscribers) {
             this._eventSubscribers.push(...options.subscribers);
         }
+
+        this._limits = {
+            maximumAttributesDepth: configuration?.maximumAttributesDepth,
+            maximumBreadcrumbMessageLength: configuration?.maximumBreadcrumbMessageLength,
+            maximumBreadcrumbSize: configuration?.maximumBreadcrumbSize,
+            maximumBreadcrumbsSize: configuration?.maximumBreadcrumbsSize,
+        };
     }
 
     public addEventSubscriber(subscriber: BreadcrumbsEventSubscriber) {

--- a/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
@@ -8,6 +8,7 @@ import {
     defaultBreadcurmbType,
 } from '.';
 import { jsonEscaper } from '../../common/jsonEscaper';
+import { limitObjectDepth } from '../../common/limitObjectDepth';
 import { BacktraceBreadcrumbsSettings } from '../../model/configuration/BacktraceConfiguration';
 import { AttributeType } from '../../model/data/BacktraceData';
 import { BacktraceReport } from '../../model/report/BacktraceReport';
@@ -139,8 +140,13 @@ export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule
             message: this.prepareBreadcrumbMessage(message),
             level,
             type,
-            attributes,
+            attributes: attributes
+                ? this._limits.maximumAttributesDepth !== undefined
+                    ? limitObjectDepth(attributes, this._limits.maximumAttributesDepth)
+                    : attributes
+                : undefined,
         };
+
         if (this._interceptor) {
             const interceptorBreadcrumb = this._interceptor(rawBreadcrumb);
             if (!interceptorBreadcrumb) {

--- a/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsSetup.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsSetup.ts
@@ -1,7 +1,7 @@
 import { BreadcrumbsEventSubscriber } from './events/BreadcrumbsEventSubscriber';
-import { BreadcrumbsStorage } from './storage/BreadcrumbsStorage';
+import { BreadcrumbsStorageFactory } from './storage/BreadcrumbsStorage';
 
 export interface BreadcrumbsSetup {
-    storage?: BreadcrumbsStorage;
+    storage?: BreadcrumbsStorageFactory;
     subscribers?: BreadcrumbsEventSubscriber[];
 }

--- a/packages/sdk-core/src/modules/breadcrumbs/model/Breadcrumb.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/model/Breadcrumb.ts
@@ -1,3 +1,4 @@
+import { Limited } from '../../../common/limitObjectDepth';
 import { AttributeType } from '../../../model/data/BacktraceData';
 
 export interface Breadcrumb {
@@ -6,5 +7,5 @@ export interface Breadcrumb {
     timestamp: number;
     level: string;
     type: string;
-    attributes?: Record<string, AttributeType>;
+    attributes?: Limited<Record<string, AttributeType>>;
 }

--- a/packages/sdk-core/src/modules/breadcrumbs/model/BreadcrumbLimits.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/model/BreadcrumbLimits.ts
@@ -1,0 +1,24 @@
+export interface BreadcrumbLimits {
+    /**
+     * Specifies maximum object depth that are included in breadcrumb attributes.
+     */
+    maximumAttributesDepth?: number;
+
+    /**
+     * Specifies maximum breadcrumb message length.
+     * If the size is exceeded, message will be truncated.
+     */
+    maximumBreadcrumbMessageLength?: number;
+
+    /**
+     * Specifies maximum single breadcrumb size in bytes.
+     * If the size is exceeded, attributes will be removed.
+     */
+    maximumBreadcrumbSize?: number;
+
+    /**
+     * Specifies maximum breadcrumbs size in bytes.
+     * If the size is exceeded, oldest breadcrumbs will be skipped.
+     */
+    maximumBreadcrumbsSize?: number;
+}

--- a/packages/sdk-core/src/modules/breadcrumbs/model/BreadcrumbLimits.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/model/BreadcrumbLimits.ts
@@ -1,24 +1,30 @@
 export interface BreadcrumbLimits {
     /**
+     * Specifies maximum number of breadcrumbs stored by the library. By default, only 100 breadcrumbs
+     * will be stored.
+     */
+    readonly maximumBreadcrumbs?: number;
+
+    /**
      * Specifies maximum object depth that are included in breadcrumb attributes.
      */
-    maximumAttributesDepth?: number;
+    readonly maximumAttributesDepth?: number;
 
     /**
      * Specifies maximum breadcrumb message length.
      * If the size is exceeded, message will be truncated.
      */
-    maximumBreadcrumbMessageLength?: number;
+    readonly maximumBreadcrumbMessageLength?: number;
 
     /**
      * Specifies maximum single breadcrumb size in bytes.
      * If the size is exceeded, attributes will be removed.
      */
-    maximumBreadcrumbSize?: number;
+    readonly maximumBreadcrumbSize?: number;
 
     /**
      * Specifies maximum breadcrumbs size in bytes.
      * If the size is exceeded, oldest breadcrumbs will be skipped.
      */
-    maximumBreadcrumbsSize?: number;
+    readonly maximumBreadcrumbsSize?: number;
 }

--- a/packages/sdk-core/src/modules/breadcrumbs/model/BreadcrumbLimits.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/model/BreadcrumbLimits.ts
@@ -1,30 +1,39 @@
 export interface BreadcrumbLimits {
     /**
-     * Specifies maximum number of breadcrumbs stored by the library. By default, only 100 breadcrumbs
-     * will be stored.
+     * Specifies maximum number of breadcrumbs stored by the library.
+     *
+     * @default 100
      */
     readonly maximumBreadcrumbs?: number;
 
     /**
      * Specifies maximum object depth that are included in breadcrumb attributes.
+     *
+     * @default 2
      */
     readonly maximumAttributesDepth?: number;
 
     /**
      * Specifies maximum breadcrumb message length.
      * If the size is exceeded, message will be truncated.
+     *
+     * @default 255
      */
     readonly maximumBreadcrumbMessageLength?: number;
 
     /**
      * Specifies maximum single breadcrumb size in bytes.
      * If the size is exceeded, the breadcrumb will be skipped.
+     *
+     * @default 65536 // 64kB
      */
     readonly maximumBreadcrumbSize?: number;
 
     /**
      * Specifies maximum breadcrumbs size in bytes.
      * If the size is exceeded, oldest breadcrumbs will be skipped.
+     *
+     * @default 1048576 // 1MB
      */
-    readonly maximumBreadcrumbsSize?: number;
+    readonly maximumTotalBreadcrumbsSize?: number;
 }

--- a/packages/sdk-core/src/modules/breadcrumbs/model/BreadcrumbLimits.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/model/BreadcrumbLimits.ts
@@ -18,7 +18,7 @@ export interface BreadcrumbLimits {
 
     /**
      * Specifies maximum single breadcrumb size in bytes.
-     * If the size is exceeded, attributes will be removed.
+     * If the size is exceeded, the breadcrumb will be skipped.
      */
     readonly maximumBreadcrumbSize?: number;
 

--- a/packages/sdk-core/src/modules/breadcrumbs/model/RawBreadcrumb.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/model/RawBreadcrumb.ts
@@ -7,5 +7,12 @@ export interface RawBreadcrumb {
     message: string;
     level: BreadcrumbLogLevel;
     type: BreadcrumbType;
+    attributes?: Record<string, AttributeType>;
+}
+
+export interface LimitedRawBreadcrumb {
+    message: string;
+    level: BreadcrumbLogLevel;
+    type: BreadcrumbType;
     attributes?: Limited<Record<string, AttributeType>>;
 }

--- a/packages/sdk-core/src/modules/breadcrumbs/model/RawBreadcrumb.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/model/RawBreadcrumb.ts
@@ -1,3 +1,4 @@
+import { Limited } from '../../../common/limitObjectDepth';
 import { AttributeType } from '../../../model/data';
 import { BreadcrumbLogLevel } from './BreadcrumbLogLevel';
 import { BreadcrumbType } from './BreadcrumbType';
@@ -6,5 +7,5 @@ export interface RawBreadcrumb {
     message: string;
     level: BreadcrumbLogLevel;
     type: BreadcrumbType;
-    attributes?: Record<string, AttributeType>;
+    attributes?: Limited<Record<string, AttributeType>>;
 }

--- a/packages/sdk-core/src/modules/breadcrumbs/storage/BreadcrumbsStorage.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/storage/BreadcrumbsStorage.ts
@@ -1,5 +1,5 @@
 import { BacktraceAttachment } from '../../../model/attachment';
-import { RawBreadcrumb } from '../model/RawBreadcrumb';
+import { LimitedRawBreadcrumb, RawBreadcrumb } from '../model/RawBreadcrumb';
 
 export interface BreadcrumbsStorage {
     /**
@@ -11,7 +11,7 @@ export interface BreadcrumbsStorage {
      * Adds breadcrumb to the storage
      * @param rawBreadcrumb breadcrumb data
      */
-    add(rawBreadcrumb: RawBreadcrumb): number;
+    add(rawBreadcrumb: RawBreadcrumb | LimitedRawBreadcrumb): number;
 
     /**
      * Gets attachments associated with this storage.

--- a/packages/sdk-core/src/modules/breadcrumbs/storage/BreadcrumbsStorage.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/storage/BreadcrumbsStorage.ts
@@ -1,6 +1,26 @@
 import { BacktraceAttachment } from '../../../model/attachment';
 import { LimitedRawBreadcrumb, RawBreadcrumb } from '../model/RawBreadcrumb';
 
+export interface BreadcrumbsStorageOptions {
+    readonly limits: BreadcrumbsStorageLimits;
+}
+
+export interface BreadcrumbsStorageLimits {
+    /**
+     * Specifies maximum number of breadcrumbs stored by the storage. By default, only 100 breadcrumbs
+     * will be stored.
+     */
+    readonly maximumBreadcrumbs?: number;
+
+    /**
+     * Specifies maximum breadcrumbs size in bytes.
+     * If the size is exceeded, oldest breadcrumbs will be skipped.
+     */
+    readonly maximumBreadcrumbsSize?: number;
+}
+
+export type BreadcrumbsStorageFactory = (options: BreadcrumbsStorageOptions) => BreadcrumbsStorage;
+
 export interface BreadcrumbsStorage {
     /**
      * Id of the last breadcrumb added to the SDK

--- a/packages/sdk-core/src/modules/breadcrumbs/storage/InMemoryBreadcrumbsStorage.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/storage/InMemoryBreadcrumbsStorage.ts
@@ -6,7 +6,7 @@ import { Breadcrumb } from '../model/Breadcrumb';
 import { BreadcrumbLogLevel } from '../model/BreadcrumbLogLevel';
 import { BreadcrumbType } from '../model/BreadcrumbType';
 import { RawBreadcrumb } from '../model/RawBreadcrumb';
-import { BreadcrumbsStorage } from './BreadcrumbsStorage';
+import { BreadcrumbsStorage, BreadcrumbsStorageOptions } from './BreadcrumbsStorage';
 
 export class InMemoryBreadcrumbsStorage implements BreadcrumbsStorage, BacktraceAttachment {
     public get lastBreadcrumbId(): number {
@@ -26,6 +26,10 @@ export class InMemoryBreadcrumbsStorage implements BreadcrumbsStorage, Backtrace
 
     public getAttachments(): BacktraceAttachment<unknown>[] {
         return [this];
+    }
+
+    public static factory({ limits }: BreadcrumbsStorageOptions) {
+        return new InMemoryBreadcrumbsStorage(limits.maximumBreadcrumbs);
     }
 
     /**

--- a/packages/sdk-core/src/modules/breadcrumbs/storage/InMemoryBreadcrumbsStorage.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/storage/InMemoryBreadcrumbsStorage.ts
@@ -21,7 +21,7 @@ export class InMemoryBreadcrumbsStorage implements BreadcrumbsStorage, Backtrace
     private _breadcrumbs: OverwritingArray<Breadcrumb>;
 
     constructor(private readonly _limits: BreadcrumbsStorageLimits) {
-        this._breadcrumbs = new OverwritingArray<Breadcrumb>(_limits.maximumBreadcrumbs ?? Infinity);
+        this._breadcrumbs = new OverwritingArray<Breadcrumb>(_limits.maximumBreadcrumbs ?? 100);
     }
 
     public getAttachments(): BacktraceAttachment<unknown>[] {

--- a/packages/sdk-core/src/modules/breadcrumbs/storage/InMemoryBreadcrumbsStorage.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/storage/InMemoryBreadcrumbsStorage.ts
@@ -21,7 +21,7 @@ export class InMemoryBreadcrumbsStorage implements BreadcrumbsStorage, Backtrace
     private _breadcrumbs: OverwritingArray<Breadcrumb>;
 
     constructor(private readonly _limits: BreadcrumbsStorageLimits) {
-        this._breadcrumbs = new OverwritingArray<Breadcrumb>(_limits.maximumBreadcrumbs ?? 100);
+        this._breadcrumbs = new OverwritingArray<Breadcrumb>(_limits.maximumBreadcrumbs ?? Infinity);
     }
 
     public getAttachments(): BacktraceAttachment<unknown>[] {

--- a/packages/sdk-core/src/modules/breadcrumbs/storage/InMemoryBreadcrumbsStorage.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/storage/InMemoryBreadcrumbsStorage.ts
@@ -6,7 +6,7 @@ import { Breadcrumb } from '../model/Breadcrumb';
 import { BreadcrumbLogLevel } from '../model/BreadcrumbLogLevel';
 import { BreadcrumbType } from '../model/BreadcrumbType';
 import { RawBreadcrumb } from '../model/RawBreadcrumb';
-import { BreadcrumbsStorage, BreadcrumbsStorageOptions } from './BreadcrumbsStorage';
+import { BreadcrumbsStorage, BreadcrumbsStorageLimits, BreadcrumbsStorageOptions } from './BreadcrumbsStorage';
 
 export class InMemoryBreadcrumbsStorage implements BreadcrumbsStorage, BacktraceAttachment {
     public get lastBreadcrumbId(): number {
@@ -20,8 +20,8 @@ export class InMemoryBreadcrumbsStorage implements BreadcrumbsStorage, Backtrace
     private _lastBreadcrumbId: number = TimeHelper.toTimestampInSec(TimeHelper.now());
     private _breadcrumbs: OverwritingArray<Breadcrumb>;
 
-    constructor(maximumBreadcrumbs = 100) {
-        this._breadcrumbs = new OverwritingArray<Breadcrumb>(maximumBreadcrumbs);
+    constructor(private readonly _limits: BreadcrumbsStorageLimits) {
+        this._breadcrumbs = new OverwritingArray<Breadcrumb>(_limits.maximumBreadcrumbs ?? 100);
     }
 
     public getAttachments(): BacktraceAttachment<unknown>[] {
@@ -29,7 +29,7 @@ export class InMemoryBreadcrumbsStorage implements BreadcrumbsStorage, Backtrace
     }
 
     public static factory({ limits }: BreadcrumbsStorageOptions) {
-        return new InMemoryBreadcrumbsStorage(limits.maximumBreadcrumbs);
+        return new InMemoryBreadcrumbsStorage(limits);
     }
 
     /**
@@ -37,7 +37,26 @@ export class InMemoryBreadcrumbsStorage implements BreadcrumbsStorage, Backtrace
      * @returns Breadcrumbs JSON
      */
     public get(): string {
-        return JSON.stringify([...this._breadcrumbs.values()], jsonEscaper());
+        const sizeLimit = this._limits.maximumBreadcrumbsSize;
+        const breadcrumbs = [...this._breadcrumbs.values()];
+        if (sizeLimit === undefined) {
+            return JSON.stringify(breadcrumbs, jsonEscaper());
+        }
+
+        let breadcrumbsSize = 2;
+        const breadcrumbsToSubmit: string[] = [];
+        for (let i = breadcrumbs.length - 1; i >= 0; i--) {
+            const json = JSON.stringify(breadcrumbs[i], jsonEscaper());
+            const length = json.length + (i === 0 ? 0 : 1); // Add the comma if not first element
+            if (breadcrumbsSize + length > sizeLimit) {
+                break;
+            }
+
+            breadcrumbsToSubmit.unshift(json);
+            breadcrumbsSize += length;
+        }
+
+        return `[${breadcrumbsToSubmit.join(',')}]`;
     }
 
     public add(rawBreadcrumb: RawBreadcrumb): number {

--- a/packages/sdk-core/tests/_mocks/fileSystem.ts
+++ b/packages/sdk-core/tests/_mocks/fileSystem.ts
@@ -4,7 +4,7 @@ import { FileSystem } from '../../src/modules/storage/FileSystem';
 
 export type MockedFileSystem<T extends FileSystem> = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    [K in keyof T]: T[K] extends (...args: any) => any ? jest.Mock<ReturnType<T[K]>, Parameters<T[K]>> : never;
+    [K in keyof T]: T[K] extends (...args: any) => any ? jest.Mock<ReturnType<T[K]>, Parameters<T[K]>> : T[K];
 } & { files: Record<string, string> };
 
 export function mockFileSystem(files?: Record<string, string>): MockedFileSystem<FileSystem> {

--- a/packages/sdk-core/tests/breadcrumbs/InMemoryBreadcrumbsStorage.spec.ts
+++ b/packages/sdk-core/tests/breadcrumbs/InMemoryBreadcrumbsStorage.spec.ts
@@ -1,0 +1,175 @@
+import { Breadcrumb, BreadcrumbLogLevel, BreadcrumbType, RawBreadcrumb } from '../../src';
+import { InMemoryBreadcrumbsStorage } from '../../src/modules/breadcrumbs/storage/InMemoryBreadcrumbsStorage';
+
+describe('InMemoryBreadcrumbsStorage', () => {
+    it('should return added breadcrumbs', () => {
+        const storage = new InMemoryBreadcrumbsStorage({
+            maximumBreadcrumbs: 100,
+        });
+
+        const breadcrumbs: RawBreadcrumb[] = [
+            {
+                level: BreadcrumbLogLevel.Info,
+                message: 'a',
+                type: BreadcrumbType.Manual,
+                attributes: {
+                    foo: 'bar',
+                },
+            },
+            {
+                level: BreadcrumbLogLevel.Debug,
+                message: 'b',
+                type: BreadcrumbType.Http,
+            },
+            {
+                level: BreadcrumbLogLevel.Warning,
+                message: 'c',
+                type: BreadcrumbType.Navigation,
+                attributes: {},
+            },
+        ];
+
+        const expected: Breadcrumb[] = [
+            {
+                id: expect.any(Number),
+                level: 'info',
+                message: 'a',
+                timestamp: expect.any(Number),
+                type: 'manual',
+                attributes: {
+                    foo: 'bar',
+                },
+            },
+            {
+                id: expect.any(Number),
+                level: 'debug',
+                message: 'b',
+                timestamp: expect.any(Number),
+                type: 'http',
+            },
+            {
+                id: expect.any(Number),
+                level: 'warning',
+                message: 'c',
+                timestamp: expect.any(Number),
+                type: 'navigation',
+                attributes: {},
+            },
+        ];
+
+        for (const breadcrumb of breadcrumbs) {
+            storage.add(breadcrumb);
+        }
+
+        const actual = JSON.parse(storage.get());
+        expect(actual).toEqual(expected);
+    });
+
+    it('should return no more than maximumBreadcrumbs breadcrumbs', () => {
+        const storage = new InMemoryBreadcrumbsStorage({
+            maximumBreadcrumbs: 2,
+        });
+
+        const breadcrumbs: RawBreadcrumb[] = [
+            {
+                level: BreadcrumbLogLevel.Info,
+                message: 'a',
+                type: BreadcrumbType.Manual,
+                attributes: {
+                    foo: 'bar',
+                },
+            },
+            {
+                level: BreadcrumbLogLevel.Debug,
+                message: 'b',
+                type: BreadcrumbType.Http,
+            },
+            {
+                level: BreadcrumbLogLevel.Warning,
+                message: 'c',
+                type: BreadcrumbType.Navigation,
+                attributes: {},
+            },
+        ];
+
+        const expected: Breadcrumb[] = [
+            {
+                id: expect.any(Number),
+                level: 'debug',
+                message: 'b',
+                timestamp: expect.any(Number),
+                type: 'http',
+            },
+            {
+                id: expect.any(Number),
+                level: 'warning',
+                message: 'c',
+                timestamp: expect.any(Number),
+                type: 'navigation',
+                attributes: {},
+            },
+        ];
+
+        for (const breadcrumb of breadcrumbs) {
+            storage.add(breadcrumb);
+        }
+
+        const actual = JSON.parse(storage.get());
+        expect(actual).toEqual(expected);
+    });
+
+    it('should return breadcrumbs up to the json size', () => {
+        const breadcrumbs: RawBreadcrumb[] = [
+            {
+                level: BreadcrumbLogLevel.Info,
+                message: 'a',
+                type: BreadcrumbType.Manual,
+                attributes: {
+                    foo: 'bar',
+                },
+            },
+            {
+                level: BreadcrumbLogLevel.Debug,
+                message: 'b',
+                type: BreadcrumbType.Http,
+            },
+            {
+                level: BreadcrumbLogLevel.Warning,
+                message: 'c',
+                type: BreadcrumbType.Navigation,
+                attributes: {},
+            },
+        ];
+
+        const expected: Breadcrumb[] = [
+            {
+                id: expect.any(Number),
+                level: 'debug',
+                message: 'b',
+                timestamp: expect.any(Number),
+                type: 'http',
+            },
+            {
+                id: expect.any(Number),
+                level: 'warning',
+                message: 'c',
+                timestamp: expect.any(Number),
+                type: 'navigation',
+                attributes: {},
+            },
+        ];
+
+        const size = JSON.stringify(expected).length;
+        const storage = new InMemoryBreadcrumbsStorage({
+            maximumBreadcrumbs: 100,
+            maximumBreadcrumbsSize: size,
+        });
+
+        for (const breadcrumb of breadcrumbs) {
+            storage.add(breadcrumb);
+        }
+
+        const actual = JSON.parse(storage.get());
+        expect(actual).toEqual(expected);
+    });
+});

--- a/packages/sdk-core/tests/breadcrumbs/breadcrumbsCreationTests.spec.ts
+++ b/packages/sdk-core/tests/breadcrumbs/breadcrumbsCreationTests.spec.ts
@@ -4,7 +4,7 @@ import { InMemoryBreadcrumbsStorage } from '../../src/modules/breadcrumbs/storag
 
 describe('Breadcrumbs creation tests', () => {
     it('Last breadcrumb id attribute should be equal to last bredcrumb id in the array', () => {
-        const storage = new InMemoryBreadcrumbsStorage(100);
+        const storage = new InMemoryBreadcrumbsStorage({ maximumBreadcrumbs: 100 });
         storage.add({ level: BreadcrumbLogLevel.Info, message: 'test', type: BreadcrumbType.Manual });
 
         const lastBreadcrumbId = storage.lastBreadcrumbId;
@@ -14,8 +14,8 @@ describe('Breadcrumbs creation tests', () => {
     });
 
     it('Each breadcrumb should have different id', () => {
-        const storage = new InMemoryBreadcrumbsStorage(100);
-        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage });
+        const storage = new InMemoryBreadcrumbsStorage({ maximumBreadcrumbs: 100 });
+        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage: () => storage });
         breadcrumbsManager.initialize();
         breadcrumbsManager.info('test');
         breadcrumbsManager.info('test2');
@@ -26,7 +26,7 @@ describe('Breadcrumbs creation tests', () => {
     });
 
     it('Should update breadcrumb id every time after adding a breadcrumb', () => {
-        const storage = new InMemoryBreadcrumbsStorage(100);
+        const storage = new InMemoryBreadcrumbsStorage({ maximumBreadcrumbs: 100 });
 
         storage.add({ level: BreadcrumbLogLevel.Info, message: 'test', type: BreadcrumbType.Manual });
         const breadcrumbId1 = storage.lastBreadcrumbId;
@@ -38,8 +38,8 @@ describe('Breadcrumbs creation tests', () => {
 
     it('Should set expected breadcrumb message', () => {
         const message = 'test';
-        const storage = new InMemoryBreadcrumbsStorage(100);
-        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage });
+        const storage = new InMemoryBreadcrumbsStorage({ maximumBreadcrumbs: 100 });
+        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage: () => storage });
         breadcrumbsManager.initialize();
         breadcrumbsManager.info(message);
         const [breadcrumb] = JSON.parse(storage.get() as string);
@@ -51,8 +51,8 @@ describe('Breadcrumbs creation tests', () => {
         const input = 1;
         const expectedBreadcrumbValueOutput = input.toString();
 
-        const storage = new InMemoryBreadcrumbsStorage(100);
-        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage });
+        const storage = new InMemoryBreadcrumbsStorage({ maximumBreadcrumbs: 100 });
+        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage: () => storage });
         breadcrumbsManager.initialize();
         breadcrumbsManager.info(input as unknown as string);
         const [breadcrumb] = JSON.parse(storage.get() as string);
@@ -64,8 +64,8 @@ describe('Breadcrumbs creation tests', () => {
         const input = { foo: 1, bar: true, baz: undefined };
         const expectedBreadcrumbValueOutput = JSON.stringify(input);
 
-        const storage = new InMemoryBreadcrumbsStorage(100);
-        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage });
+        const storage = new InMemoryBreadcrumbsStorage({ maximumBreadcrumbs: 100 });
+        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage: () => storage });
         breadcrumbsManager.initialize();
         breadcrumbsManager.info(input as unknown as string);
         const [breadcrumb] = JSON.parse(storage.get() as string);
@@ -77,8 +77,8 @@ describe('Breadcrumbs creation tests', () => {
         const input = null;
         const expectedBreadcrumbValueOutput = '';
 
-        const storage = new InMemoryBreadcrumbsStorage(100);
-        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage });
+        const storage = new InMemoryBreadcrumbsStorage({ maximumBreadcrumbs: 100 });
+        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage: () => storage });
         breadcrumbsManager.initialize();
         breadcrumbsManager.info(input as unknown as string);
         const [breadcrumb] = JSON.parse(storage.get() as string);
@@ -89,8 +89,8 @@ describe('Breadcrumbs creation tests', () => {
     it('Should set expected breadcrumb level', () => {
         const message = 'test';
         const level = BreadcrumbLogLevel.Warning;
-        const storage = new InMemoryBreadcrumbsStorage(100);
-        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage });
+        const storage = new InMemoryBreadcrumbsStorage({ maximumBreadcrumbs: 100 });
+        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage: () => storage });
         breadcrumbsManager.initialize();
         breadcrumbsManager.log(message, level);
         const [breadcrumb] = JSON.parse(storage.get() as string);
@@ -102,8 +102,8 @@ describe('Breadcrumbs creation tests', () => {
         const message = 'test';
         const level = BreadcrumbLogLevel.Warning;
         const type = BreadcrumbType.Configuration;
-        const storage = new InMemoryBreadcrumbsStorage(100);
-        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage });
+        const storage = new InMemoryBreadcrumbsStorage({ maximumBreadcrumbs: 100 });
+        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage: () => storage });
         breadcrumbsManager.initialize();
         breadcrumbsManager.addBreadcrumb(message, level, type);
         const [breadcrumb] = JSON.parse(storage.get() as string);
@@ -115,8 +115,8 @@ describe('Breadcrumbs creation tests', () => {
         const message = 'test';
         const level = BreadcrumbLogLevel.Warning;
         const attributes = { foo: 'bar', baz: 1 };
-        const storage = new InMemoryBreadcrumbsStorage(100);
-        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage });
+        const storage = new InMemoryBreadcrumbsStorage({ maximumBreadcrumbs: 100 });
+        const breadcrumbsManager = new BreadcrumbsManager(undefined, { storage: () => storage });
         breadcrumbsManager.initialize();
         breadcrumbsManager.log(message, level, attributes);
         const [breadcrumb] = JSON.parse(storage.get() as string);

--- a/packages/sdk-core/tests/breadcrumbs/breadcrumbsFilteringOptionsTests.spec.ts
+++ b/packages/sdk-core/tests/breadcrumbs/breadcrumbsFilteringOptionsTests.spec.ts
@@ -6,13 +6,13 @@ describe('Breadcrumbs filtering options tests', () => {
     describe('Event type tests', () => {
         it('Should filter out breadcrumbs based on the event type', () => {
             const message = 'test';
-            const storage = new InMemoryBreadcrumbsStorage(100);
+            const storage = new InMemoryBreadcrumbsStorage({ maximumBreadcrumbs: 100 });
             const breadcrumbsManager = new BreadcrumbsManager(
                 {
                     eventType: BreadcrumbType.Configuration,
                 },
                 {
-                    storage,
+                    storage: () => storage,
                 },
             );
             breadcrumbsManager.initialize();
@@ -26,13 +26,13 @@ describe('Breadcrumbs filtering options tests', () => {
         it('Should allow to add a breadcrumb with allowed event type', () => {
             const message = 'test';
             const allowedBreadcrumbType = BreadcrumbType.Configuration;
-            const storage = new InMemoryBreadcrumbsStorage(100);
+            const storage = new InMemoryBreadcrumbsStorage({ maximumBreadcrumbs: 100 });
             const breadcrumbsManager = new BreadcrumbsManager(
                 {
                     eventType: allowedBreadcrumbType,
                 },
                 {
-                    storage,
+                    storage: () => storage,
                 },
             );
             breadcrumbsManager.initialize();
@@ -47,13 +47,13 @@ describe('Breadcrumbs filtering options tests', () => {
     describe('Log level tests', () => {
         it('Should filter out breadcrumbs based on the log level', () => {
             const message = 'test';
-            const storage = new InMemoryBreadcrumbsStorage(100);
+            const storage = new InMemoryBreadcrumbsStorage({ maximumBreadcrumbs: 100 });
             const breadcrumbsManager = new BreadcrumbsManager(
                 {
                     logLevel: BreadcrumbLogLevel.Error,
                 },
                 {
-                    storage,
+                    storage: () => storage,
                 },
             );
             breadcrumbsManager.initialize();
@@ -67,13 +67,13 @@ describe('Breadcrumbs filtering options tests', () => {
         it('Should allow to add a breadcrumb with allowed log level', () => {
             const message = 'test';
             const allowedLogLevel = BreadcrumbLogLevel.Debug;
-            const storage = new InMemoryBreadcrumbsStorage(100);
+            const storage = new InMemoryBreadcrumbsStorage({ maximumBreadcrumbs: 100 });
             const breadcrumbsManager = new BreadcrumbsManager(
                 {
                     logLevel: allowedLogLevel,
                 },
                 {
-                    storage,
+                    storage: () => storage,
                 },
             );
             breadcrumbsManager.initialize();
@@ -123,13 +123,13 @@ describe('Breadcrumbs filtering options tests', () => {
     describe('Breadcrumbs overflow tests', () => {
         it('Should always store maximum breadcrumbs', () => {
             const maximumBreadcrumbs = 2;
-            const storage = new InMemoryBreadcrumbsStorage(maximumBreadcrumbs);
+            const storage = new InMemoryBreadcrumbsStorage({ maximumBreadcrumbs });
             const breadcrumbsManager = new BreadcrumbsManager(
                 {
                     maximumBreadcrumbs,
                 },
                 {
-                    storage,
+                    storage: () => storage,
                 },
             );
             breadcrumbsManager.initialize();
@@ -151,13 +151,13 @@ describe('Breadcrumbs filtering options tests', () => {
 
         it('Should drop the oldest event to free up the space for the new one', () => {
             const maximumBreadcrumbs = 2;
-            const storage = new InMemoryBreadcrumbsStorage(maximumBreadcrumbs);
+            const storage = new InMemoryBreadcrumbsStorage({ maximumBreadcrumbs });
             const breadcrumbsManager = new BreadcrumbsManager(
                 {
                     maximumBreadcrumbs,
                 },
                 {
-                    storage,
+                    storage: () => storage,
                 },
             );
             breadcrumbsManager.initialize();

--- a/packages/sdk-core/tests/breadcrumbs/breadcrumbsInterceptorTests.spec.ts
+++ b/packages/sdk-core/tests/breadcrumbs/breadcrumbsInterceptorTests.spec.ts
@@ -3,13 +3,13 @@ import { Breadcrumb } from '../../src/modules/breadcrumbs/model/Breadcrumb';
 import { InMemoryBreadcrumbsStorage } from '../../src/modules/breadcrumbs/storage/InMemoryBreadcrumbsStorage';
 describe('Breadcrumbs interceptor tests', () => {
     it('Should filter out the breadcrumb', () => {
-        const storage = new InMemoryBreadcrumbsStorage(100);
+        const storage = new InMemoryBreadcrumbsStorage({ maximumBreadcrumbs: 100 });
         const breadcrumbsManager = new BreadcrumbsManager(
             {
                 intercept: () => undefined,
             },
             {
-                storage,
+                storage: () => storage,
             },
         );
         breadcrumbsManager.initialize();
@@ -21,7 +21,7 @@ describe('Breadcrumbs interceptor tests', () => {
 
     it('Should remove pii information from breadcrumb', () => {
         const expectedBreadcrumbMessage = 'bar';
-        const storage = new InMemoryBreadcrumbsStorage(100);
+        const storage = new InMemoryBreadcrumbsStorage({ maximumBreadcrumbs: 100 });
         const breadcrumbsManager = new BreadcrumbsManager(
             {
                 intercept: (breadcrumb) => {
@@ -30,7 +30,7 @@ describe('Breadcrumbs interceptor tests', () => {
                 },
             },
             {
-                storage,
+                storage: () => storage,
             },
         );
         breadcrumbsManager.initialize();

--- a/packages/sdk-core/tests/common/jsonSize.spec.ts
+++ b/packages/sdk-core/tests/common/jsonSize.spec.ts
@@ -1,0 +1,530 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { jsonEscaper } from '../../src/common/jsonEscaper';
+import { jsonSize } from '../../src/common/jsonSize';
+
+describe('jsonSize', () => {
+    it('should compute string size', () => {
+        const value = 'foo\n\t\rbar""\'\'```123';
+        const expected = JSON.stringify(value).length;
+
+        const actual = jsonSize(value);
+        expect(actual).toEqual(expected);
+    });
+
+    it('should compute number size', () => {
+        const value = 34534134.24875381;
+        const expected = JSON.stringify(value).length;
+
+        const actual = jsonSize(value);
+        expect(actual).toEqual(expected);
+    });
+
+    it('should compute boolean true size', () => {
+        const value = true;
+        const expected = JSON.stringify(value).length;
+
+        const actual = jsonSize(value);
+        expect(actual).toEqual(expected);
+    });
+
+    it('should compute boolean false size', () => {
+        const value = true;
+        const expected = JSON.stringify(value).length;
+
+        const actual = jsonSize(value);
+        expect(actual).toEqual(expected);
+    });
+
+    it('should compute bigint size', () => {
+        const value = BigInt('32785893475875872652349587624379564329785674325692483657894236597436279586342978563');
+        const expected = value.toString().length;
+
+        const actual = jsonSize(value);
+        expect(actual).toEqual(expected);
+    });
+
+    it('should compute symbol size', () => {
+        const value = Symbol.for('foobar');
+        const expected = JSON.stringify(value)?.length ?? 0;
+
+        const actual = jsonSize(value);
+        expect(actual).toEqual(expected);
+    });
+
+    it('should compute function size', () => {
+        const value = function (arg1: number) {
+            return arg1;
+        };
+
+        const expected = JSON.stringify(value)?.length ?? 0;
+
+        const actual = jsonSize(value);
+        expect(actual).toEqual(expected);
+    });
+
+    it('should compute undefined size', () => {
+        const value = undefined;
+        const expected = JSON.stringify(value)?.length ?? 0;
+
+        const actual = jsonSize(value);
+        expect(actual).toEqual(expected);
+    });
+
+    it('should compute null size', () => {
+        const value = null;
+        const expected = JSON.stringify(value)?.length ?? 0;
+
+        const actual = jsonSize(value);
+        expect(actual).toEqual(expected);
+    });
+
+    describe('objects with values', () => {
+        it('should compute object size with number value', () => {
+            const value = {
+                num: 123,
+            };
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute object size with number key', () => {
+            const value = {
+                [123]: '123',
+            };
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute object size with string value', () => {
+            const value = {
+                string: 'str',
+            };
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute object size with true value', () => {
+            const value = {
+                true: true,
+            };
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute object size with true key', () => {
+            const value = {
+                [true as never]: 'true',
+            };
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute object size with false value', () => {
+            const value = {
+                false: false,
+            };
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute object size with false key', () => {
+            const value = {
+                [false as never]: 'false',
+            };
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute object size with null value', () => {
+            const value = {
+                null: null,
+            };
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute object size with null key', () => {
+            const value = {
+                [null as never]: 'null',
+            };
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute object size with undefined value', () => {
+            const value = {
+                undefined: undefined,
+            };
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute object size with undefined key', () => {
+            const value = {
+                [undefined as never]: 'undefined',
+            };
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute object size with symbol value', () => {
+            const value = {
+                symbol: Symbol.for('key'),
+            };
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute object size with symbol key', () => {
+            const value = {
+                [Symbol.for('key')]: 'symbol',
+            };
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute object size with function value', () => {
+            const value = {
+                fun: (arg: number) => {},
+            };
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute object size with function key', () => {
+            const value = {
+                [((arg: number) => {}) as never]: 'fun',
+            };
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute object size with array value', () => {
+            const value = {
+                array: ['element'],
+            };
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute object size with array key', () => {
+            const value = {
+                [['element'] as never]: 'array',
+            };
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute object size with object value', () => {
+            const value = {
+                obj: { foo: 'bar' },
+            };
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute object size with object key', () => {
+            const value = {
+                [{ foo: 'bar' } as never]: 'object',
+            };
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute object size with multiple keys', () => {
+            const value = {
+                key1: 'key1',
+                key2: 'key2',
+                key3: 'key3',
+            };
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute object size with no keys', () => {
+            const value = {};
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute object size with toJSON function', () => {
+            const value = {
+                a: 123,
+                b: 'xyz',
+                toJSON() {
+                    return {
+                        foo: 'bar',
+                    };
+                },
+            };
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute object size with every key type', () => {
+            const value = {
+                num: 123,
+                [123]: '123',
+                string: 'str',
+                true: true,
+                [true as never]: 'true',
+                false: false,
+                [false as never]: 'false',
+                null: null,
+                [null as never]: 'null',
+                undefined: undefined,
+                [undefined as never]: 'undefined',
+                symbol: Symbol.for('key'),
+                [Symbol.for('key')]: 'symbol',
+                fun: (arg: number) => {},
+                [((arg: number) => {}) as never]: 'fun',
+                array: ['element'],
+                [['element'] as never]: 'array',
+                obj: { foo: 'bar' },
+                [{ foo: 'bar' } as never]: 'object',
+            };
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+    });
+
+    describe('arrays with values', () => {
+        it('should compute array size with number value', () => {
+            const value = [123];
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute array size with string value', () => {
+            const value = ['str'];
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute array size with true value', () => {
+            const value = [true];
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute array size with false value', () => {
+            const value = [false];
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute array size with null value', () => {
+            const value = [null];
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute array size with undefined value', () => {
+            const value = [undefined];
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute array size with symbol value', () => {
+            const value = [Symbol.for('symbol')];
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute array size with function value', () => {
+            const value = [(arg: number) => {}];
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute array size with array value', () => {
+            const value = [['123']];
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute array size with object value', () => {
+            const value = [{ foo: 'bar' }];
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute array size with multiple values', () => {
+            const value = ['el1', 'el2', 'el3'];
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute array size with every value type', () => {
+            const value = [
+                123,
+                'str',
+                true,
+                false,
+                null,
+                undefined,
+                Symbol.for('symbol'),
+                (arg: number) => {},
+                ['123'],
+                { foo: 'bar' },
+            ];
+
+            const expected = JSON.stringify(value).length;
+
+            const actual = jsonSize(value);
+            expect(actual).toEqual(expected);
+        });
+    });
+
+    describe('circular references', () => {
+        it('should compute object size for self-referencing object', () => {
+            const value = {
+                a: {
+                    b: {
+                        c: undefined as object | undefined,
+                    },
+                },
+            };
+
+            value.a.b.c = value;
+
+            const expected = JSON.stringify(value, jsonEscaper()).length;
+            const actual = jsonSize(value, jsonEscaper());
+
+            expect(actual).toEqual(expected);
+        });
+
+        it('should compute array size for self-referencing array', () => {
+            const value: unknown[] = ['a', 'b', 'c'];
+            value.push(value);
+
+            const expected = JSON.stringify(value, jsonEscaper()).length;
+            const actual = jsonSize(value, jsonEscaper());
+
+            expect(actual).toEqual(expected);
+        });
+
+        // TODO: This case reports invalid size (36 vs expected 28)
+        // As most likely this will be rarely used, and the difference is not that large,
+        // I'm leaving this commented for now
+        // it('should compute object size for self-referencing object with toJSON', () => {
+        //     const value = {
+        //         a: {
+        //             b: {
+        //                 toJSON() {
+        //                     return value;
+        //                 },
+        //             },
+        //         },
+        //     };
+
+        //     const expected = JSON.stringify(value, jsonEscaper()).length;
+        //     const actual = jsonSize(value, jsonEscaper());
+
+        //     expect(actual).toEqual(expected);
+        // });
+    });
+});

--- a/packages/sdk-core/tests/common/limitObjectDepth.spec.ts
+++ b/packages/sdk-core/tests/common/limitObjectDepth.spec.ts
@@ -1,0 +1,117 @@
+import { limitObjectDepth } from '../../src/common/limitObjectDepth';
+
+const EXPECTED_REMOVED_PLACEHOLDER = '<removed>';
+
+describe('limitObjectDepth', () => {
+    it(`should replace object keys below depth with ${EXPECTED_REMOVED_PLACEHOLDER}`, () => {
+        const obj = {
+            a0: {
+                a1: {
+                    a2: {
+                        foo: 'bar',
+                    },
+                    b2: 'xyz',
+                },
+                b1: 'test',
+            },
+        };
+
+        const depth = 2;
+        const expected = {
+            a0: {
+                a1: {
+                    a2: EXPECTED_REMOVED_PLACEHOLDER,
+                    b2: 'xyz',
+                },
+                b1: 'test',
+            },
+        };
+
+        const actual = limitObjectDepth(obj, depth);
+        expect(actual).toEqual(expected);
+    });
+
+    it('should replace objects in arrays below depth with <removed>', () => {
+        const obj = {
+            a0: {
+                a1: [{ a2: { foo: 'bar' } }, { b2: 'xyz' }],
+                b1: 'test',
+                c1: {
+                    a2: [
+                        {
+                            foo: 'baz',
+                        },
+                        'xyz',
+                    ],
+                },
+            },
+        };
+
+        const depth = 2;
+        const expected = {
+            a0: {
+                a1: [{ a2: EXPECTED_REMOVED_PLACEHOLDER }, { b2: 'xyz' }],
+                b1: 'test',
+                c1: {
+                    a2: [EXPECTED_REMOVED_PLACEHOLDER, 'xyz'],
+                },
+            },
+        };
+
+        const actual = limitObjectDepth(obj, depth);
+        expect(actual).toEqual(expected);
+    });
+
+    it('should not change object if depth is greater than the object max depth', () => {
+        const obj = {
+            a0: {
+                a1: {
+                    a2: {
+                        foo: 'bar',
+                    },
+                    b2: 'xyz',
+                },
+                b1: 'test',
+            },
+        };
+
+        const depth = 10;
+
+        const actual = limitObjectDepth(obj, depth);
+        expect(actual).toEqual(obj);
+    });
+
+    it(`should not replace null/undefined with ${EXPECTED_REMOVED_PLACEHOLDER}`, () => {
+        const obj = {
+            a0: {
+                a1: {
+                    a2: null,
+                    b2: undefined,
+                    c2: 'xyz',
+                },
+                b1: 'test',
+            },
+        };
+
+        const depth = 2;
+
+        const actual = limitObjectDepth(obj, depth);
+        expect(actual).toEqual(obj);
+    });
+
+    it('should return the exact same object if depth is Infinity', () => {
+        const obj = {
+            a0: {
+                a1: {
+                    a2: null,
+                    b2: undefined,
+                    c2: 'xyz',
+                },
+                b1: 'test',
+            },
+        };
+
+        const actual = limitObjectDepth(obj, Infinity);
+        expect(actual).toBe(obj);
+    });
+});


### PR DESCRIPTION
This PR adds limits for controlling breadcrumb file sizes:
* `maximumAttributesDepth`
* `maximumBreadcrumbMessageLength`
* `maximumBreadcrumbSize`
* `maximumBreadcrumbsSize`

It also allows to disable all breadcrumb limits by setting `false` to them.

Platform-specific changes will be included in subsequent pull requests.