### PR TITLE
backtrace-node: Use https client only when the protocol is set to https:

### DIFF
--- a/packages/node/src/BacktraceNodeRequestHandler.ts
+++ b/packages/node/src/BacktraceNodeRequestHandler.ts
@@ -142,7 +142,7 @@ export class BacktraceNodeRequestHandler implements BacktraceRequestHandler {
     }
 
     private getHttpClient(submissionUrl: URL) {
-        return submissionUrl.protocol === 'http' ? http : https;
+        return submissionUrl.protocol === 'https:' ? https : http;
     }
     private createFormData(json: string, attachments?: BacktraceAttachment<Buffer | Readable | string | Uint8Array>[]) {
         const formData = new FormData();


### PR DESCRIPTION
# Why


Due to invalid protocol check, we cannot send reports via HTTP. This pull request fixes this behavior and now we correctly compare the protocol 