### PR TITLE
sdk-core: add useModule to builder, export dataStructures

### DIFF
--- a/packages/sdk-core/src/builder/BacktraceCoreClientBuilder.ts
+++ b/packages/sdk-core/src/builder/BacktraceCoreClientBuilder.ts
@@ -1,5 +1,6 @@
 import { BacktraceReportSubmission } from '../model/http/BacktraceReportSubmission';
 import { BacktraceRequestHandler } from '../model/http/BacktraceRequestHandler';
+import { BacktraceModule } from '../modules/BacktraceModule';
 import { BacktraceAttributeProvider } from '../modules/attribute/BacktraceAttributeProvider';
 import { BreadcrumbsEventSubscriber, BreadcrumbsStorage } from '../modules/breadcrumbs';
 import { BacktraceStackTraceConverter } from '../modules/converter';
@@ -79,6 +80,15 @@ export abstract class BacktraceCoreClientBuilder<S extends Partial<CoreClientSet
 
     public useUniqueMetricsQueue(queue: MetricsQueue<UniqueEvent>) {
         this.clientSetup.uniqueMetricsQueue = queue;
+        return this;
+    }
+
+    public useModule(module: BacktraceModule) {
+        if (!this.clientSetup.modules) {
+            this.clientSetup.modules = [module];
+        } else {
+            this.clientSetup.modules.push(module);
+        }
         return this;
     }
 }

--- a/packages/sdk-core/src/dataStructures/index.ts
+++ b/packages/sdk-core/src/dataStructures/index.ts
@@ -1,0 +1,2 @@
+export * from './OverwritingArray';
+export * from './OverwritingArrayIterator';

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -6,6 +6,7 @@ export { anySignal } from './common/AbortController';
 export * from './common/IdGenerator';
 export * from './common/TimeHelper';
 export * from './common/jsonEscaper';
+export * from './dataStructures';
 export * from './model/attachment';
 export * from './model/configuration/BacktraceConfiguration';
 export * from './model/configuration/BacktraceDatabaseConfiguration';


### PR DESCRIPTION
This PR exposes modules to public API.

We require this to extend client with plugins such as session replay.