### PR TITLE
cli: allow for processing of source files without sourcemaps

### DIFF
--- a/tools/cli/src/helpers/logs.ts
+++ b/tools/cli/src/helpers/logs.ts
@@ -1,6 +1,6 @@
 import { Asset, log, LogLevel } from '@backtrace/sourcemap-tools';
 import { CliLogger } from '../logger';
-import { SourceAndSourceMapPaths } from '../models/Asset';
+import { SourceAndOptionalSourceMapPaths } from '../models/Asset';
 
 export function createAssetLogger(
     logger: CliLogger,
@@ -26,5 +26,5 @@ export function createAssetLogger(logger: CliLogger, level?: LogLevel) {
 export const logAssets =
     (logger: CliLogger, level: LogLevel) =>
     (message: string) =>
-    <T extends SourceAndSourceMapPaths>(assets: T) =>
+    <T extends SourceAndOptionalSourceMapPaths>(assets: T) =>
         log(logger, level)<T>(`${assets.source.name}:${assets.sourceMap?.name ?? '?'}: ${message}`)(assets);

--- a/tools/cli/src/models/Asset.ts
+++ b/tools/cli/src/models/Asset.ts
@@ -1,6 +1,17 @@
-import { Asset } from '@backtrace/sourcemap-tools';
+import { Asset, AssetWithContent, RawSourceMap, RawSourceMapWithDebugId } from '@backtrace/sourcemap-tools';
 
-export interface SourceAndSourceMapPaths {
+export interface SourceAndOptionalSourceMapPaths {
     readonly source: Asset;
     readonly sourceMap?: Asset;
+}
+
+export interface SourceAndOptionalSourceMap {
+    readonly source: AssetWithContent<string>;
+    readonly sourceMap?: AssetWithContent<RawSourceMap>;
+}
+
+export interface ProcessedSourceAndOptionalSourceMap {
+    readonly source: AssetWithContent<string>;
+    readonly sourceMap?: AssetWithContent<RawSourceMapWithDebugId>;
+    readonly debugId: string;
 }

--- a/tools/sourcemap-tools/src/helpers/common.ts
+++ b/tools/sourcemap-tools/src/helpers/common.ts
@@ -103,10 +103,16 @@ export function mapAsync<T, B>(fn: (t: T) => B | Promise<B>) {
     };
 }
 
+export function filter<T, S extends T>(fn: (t: T) => t is S): (t: T[]) => S[];
+export function filter<T>(fn: (t: T) => boolean): (t: T[]) => T[];
 export function filter<T>(fn: (t: T) => boolean) {
     return function filter(t: T[]) {
         return t.filter(fn);
     };
+}
+
+export function isDefined<T>(t: T | undefined): t is T {
+    return t !== undefined;
 }
 
 export function filterAsync<T>(fn: (t: T) => boolean | Promise<boolean>) {


### PR DESCRIPTION
This PR allows the processing of source files without sourcemaps.
Source files will have the function snippet and comment added.

Jira task: BT-2497