### PR TITLE
react-native: Attribute map - fixed attribute names for react-native

### DIFF
--- a/packages/react-native/ios/BacktraceCpuAttributeProvider.mm
+++ b/packages/react-native/ios/BacktraceCpuAttributeProvider.mm
@@ -24,7 +24,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(get) {
     
     [dictionary setObject: [NSString stringWithFormat:@"%0.0lu", [[NSProcessInfo processInfo] processorCount]] forKey:@"cpu.count"];
     [dictionary setObject: [NSString stringWithFormat:@"%0.0lu", [[NSProcessInfo processInfo] activeProcessorCount]] forKey:@"cpu.count.active"];
-    [dictionary setObject: [NSString stringWithFormat:@"%0.0llu", totalSystemTime] forKey:@"cpu.system"];
+    [dictionary setObject: [NSString stringWithFormat:@"%0.0llu", totalSystemTime] forKey:@"cpu.sys"];
     [dictionary setObject: [NSString stringWithFormat:@"%0.0llu", totalUserTime] forKey:@"cpu.user"];
     [dictionary setObject: [NSString stringWithFormat:@"%0.0llu", totalIdleTime] forKey:@"cpu.idle"];
     [dictionary setObject: [NSString stringWithFormat:@"%0.0llu", totalNiceTime] forKey:@"cpu.nice"];

--- a/packages/react-native/ios/BacktraceMemoryUsageAttributeProvider.mm
+++ b/packages/react-native/ios/BacktraceMemoryUsageAttributeProvider.mm
@@ -14,9 +14,9 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(get) {
                                    (task_info_t)&info,
                                    &systemMemorySize);
     if( kerr == KERN_SUCCESS ) {
-        [dictionary setObject:[NSString stringWithFormat:@"%0.0llu", (info.resident_size / 1048576)] forKey: @"process.vm.rss.size"];
-        [dictionary setObject:[NSString stringWithFormat:@"%0.0llu", (info.virtual_size / 1048576)] forKey: @"process.vm.vma.size"];
-        [dictionary setObject:[NSString stringWithFormat:@"%0.0llu", (info.resident_size_peak / 1048576)] forKey: @"process.vm.rss.peak"];
+        [dictionary setObject:[NSString stringWithFormat:@"%0.0llu", (info.resident_size / 1048576)] forKey: @"vm.rss.size"];
+        [dictionary setObject:[NSString stringWithFormat:@"%0.0llu", (info.virtual_size / 1048576)] forKey: @"vm.vma.size"];
+        [dictionary setObject:[NSString stringWithFormat:@"%0.0llu", (info.resident_size_peak / 1048576)] forKey: @"vm.rss.peak"];
     }
     
     // read memory usage


### PR DESCRIPTION
# Why

We found invalid attribute names while we were reviewing library attributes. This diff fixes attribute map for react-native on ios