### PR TITLE
Exit on disabled database

### DIFF
--- a/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
+++ b/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
@@ -203,6 +203,9 @@ export class BacktraceDatabase implements BacktraceModule {
         await this.send(abortSignal);
         const records = this.get().filter((n) => n.timestamp <= start);
         for (const record of records) {
+            if (abortSignal?.aborted) {
+                return;
+            }
             this.remove(record);
         }
     }

--- a/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
+++ b/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
@@ -18,6 +18,10 @@ export class BacktraceDatabase implements BacktraceModule {
         return this._enabled;
     }
 
+    /**
+     * Abort controller to cancel asynchronous database operations when
+     * the database is being disabled by the user.
+     */
     private readonly _abortController = new AbortController();
 
     private readonly _databaseRecordContext: BacktraceDatabaseContext;

--- a/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
+++ b/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
@@ -196,6 +196,7 @@ export class BacktraceDatabase implements BacktraceModule {
     /**
      * Sends all records available in the database to Backtrace and removes them
      * no matter if the submission process was successful or not.
+     * @param abortSignal optional abort signal to cancel sending requests
      */
     public async flush(abortSignal?: AbortSignal) {
         const start = TimeHelper.now();
@@ -215,7 +216,7 @@ export class BacktraceDatabase implements BacktraceModule {
             // make a copy of records to not update the array after each remove
             const records = [...this._databaseRecordContext.getBucket(bucketIndex)];
             const signal = anySignal(abortSignal, this._abortController.signal);
-            
+
             for (const record of records) {
                 if (!this.enabled) {
                     return;

--- a/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
+++ b/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
@@ -206,6 +206,9 @@ export class BacktraceDatabase implements BacktraceModule {
             const records = [...this._databaseRecordContext.getBucket(bucketIndex)];
 
             for (const record of records) {
+                if (!this.enabled) {
+                    return;
+                }
                 if (record.locked) {
                     continue;
                 }

--- a/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
+++ b/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
@@ -1,4 +1,4 @@
-import { anySignal, AbortController } from '../../common/AbortController';
+import { AbortController, anySignal } from '../../common/AbortController';
 import { IdGenerator } from '../../common/IdGenerator';
 import { TimeHelper } from '../../common/TimeHelper';
 import { BacktraceAttachment } from '../../model/attachment';
@@ -205,17 +205,19 @@ export class BacktraceDatabase implements BacktraceModule {
             this.remove(record);
         }
     }
+
     /**
      * Sends all records available in the database to Backtrace.
+     * @param abortSignal optional abort signal to cancel sending requests
      */
     public async send(abortSignal?: AbortSignal) {
         for (let bucketIndex = 0; bucketIndex < this._databaseRecordContext.bucketCount; bucketIndex++) {
             // make a copy of records to not update the array after each remove
             const records = [...this._databaseRecordContext.getBucket(bucketIndex)];
             const signal = anySignal(abortSignal, this._abortController.signal);
+            
             for (const record of records) {
                 if (!this.enabled) {
-                    signal.throwIfAborted();
                     return;
                 }
                 if (record.locked) {


### PR DESCRIPTION
# Why

We want to exit fast when there is no reason to process reports. This diff allows to exit from the database send method when the database is disabled (for example: via dispose method)