### PR TITLE
Use transfer encoding header

### DIFF
--- a/packages/browser/src/BacktraceBrowserRequestHandler.ts
+++ b/packages/browser/src/BacktraceBrowserRequestHandler.ts
@@ -12,8 +12,12 @@ export class BacktraceBrowserRequestHandler implements BacktraceRequestHandler {
     private readonly _timeout: number;
     private readonly JSON_HEADERS = {
         'Content-type': 'application/json',
+        'Transfer-Encoding': 'chunked',
     };
 
+    private readonly MULTIPART_HEADERS = {
+        'Transfer-Encoding': 'chunked',
+    };
     constructor(
         private readonly _options: {
             url: string;
@@ -45,7 +49,7 @@ export class BacktraceBrowserRequestHandler implements BacktraceRequestHandler {
             const response = await fetch(submissionUrl, {
                 method: 'POST',
                 body: payload,
-                headers: typeof payload === 'string' ? this.JSON_HEADERS : {},
+                headers: typeof payload === 'string' ? this.JSON_HEADERS : this.MULTIPART_HEADERS,
                 signal: anySignal(abortSignal, controller.signal),
             });
 

--- a/packages/node/src/BacktraceNodeRequestHandler.ts
+++ b/packages/node/src/BacktraceNodeRequestHandler.ts
@@ -16,6 +16,11 @@ export class BacktraceNodeRequestHandler implements BacktraceRequestHandler {
 
     private readonly JSON_HEADERS = {
         'Content-type': 'application/json',
+        'Transfer-Encoding': 'chunked',
+    };
+
+    private readonly MULTIPART_HEADERS = {
+        'Transfer-Encoding': 'chunked',
     };
 
     constructor(
@@ -63,7 +68,10 @@ export class BacktraceNodeRequestHandler implements BacktraceRequestHandler {
                         rejectUnauthorized: this._options.ignoreSslCertificate === true,
                         timeout: this._timeout,
                         method: 'POST',
-                        headers: typeof payload === 'string' ? this.JSON_HEADERS : payload.getHeaders(),
+                        headers:
+                            typeof payload === 'string'
+                                ? this.JSON_HEADERS
+                                : { ...payload.getHeaders(), ...this.MULTIPART_HEADERS },
                     },
                     (response) => {
                         let result = '';

--- a/packages/react-native/src/ReactNativeRequestHandler.ts
+++ b/packages/react-native/src/ReactNativeRequestHandler.ts
@@ -12,6 +12,7 @@ export class ReactNativeRequestHandler implements BacktraceRequestHandler {
     private readonly _timeout: number;
     private readonly JSON_HEADERS = {
         'Content-type': 'application/json',
+        'Transfer-Encoding': 'chunked',
     };
     private readonly MULTIPART_HEADERS = {
         'Transfer-Encoding': 'chunked',


### PR DESCRIPTION
# Why

This pull request adds a transfer encoding header to javascript submission layers.