### PR TITLE
node: replace native-reg with call to reg query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13356,14 +13356,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/native-reg": {
-            "version": "1.1.1",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "dependencies": {
-                "node-gyp-build": "4"
-            }
-        },
         "node_modules/natural-compare": {
             "version": "1.4.0",
             "dev": true,
@@ -13459,15 +13451,6 @@
             "dependencies": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
-            }
-        },
-        "node_modules/node-gyp-build": {
-            "version": "4.7.1",
-            "license": "MIT",
-            "bin": {
-                "node-gyp-build": "bin.js",
-                "node-gyp-build-optional": "optional.js",
-                "node-gyp-build-test": "build-test.js"
             }
         },
         "node_modules/node-int64": {
@@ -19044,8 +19027,7 @@
             "license": "MIT",
             "dependencies": {
                 "@backtrace/sdk-core": "^0.3.2",
-                "form-data": "^4.0.0",
-                "native-reg": "^1.1.1"
+                "form-data": "^4.0.0"
             },
             "devDependencies": {
                 "@types/jest": "^29.5.1",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -50,7 +50,6 @@
     },
     "dependencies": {
         "@backtrace/sdk-core": "^0.3.2",
-        "form-data": "^4.0.0",
-        "native-reg": "^1.1.1"
+        "form-data": "^4.0.0"
     }
 }

--- a/packages/node/src/attributes/MachineIdentitfierAttributeProvider.ts
+++ b/packages/node/src/attributes/MachineIdentitfierAttributeProvider.ts
@@ -1,12 +1,12 @@
 import { BacktraceAttributeProvider, IdGenerator } from '@backtrace/sdk-core';
 import { execSync } from 'child_process';
-import { getValue, HKEY } from 'native-reg';
 
 export class MachineIdentitfierAttributeProvider implements BacktraceAttributeProvider {
     public static readonly SUPPORTED_PLATFORMS = ['win32', 'darwin', 'linux', 'freebsd'];
     private readonly MACHINE_ID_ATTRIBUTE = 'guid';
 
     private readonly COMMANDS = {
+        win32: 'reg query "HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Cryptography" /v MachineGuid',
         darwin: 'ioreg -rd1 -c IOPlatformExpertDevice',
         linux: '( cat /var/lib/dbus/machine-id /etc/machine-id 2> /dev/null || hostname ) | head -n 1 || :',
         freebsd: 'kenv -q smbios.system.uuid || sysctl -n kern.hostuuid',
@@ -26,8 +26,9 @@ export class MachineIdentitfierAttributeProvider implements BacktraceAttributePr
     public generateGuid() {
         switch (process.platform) {
             case 'win32': {
-                return this.getWindowsMachineId()
-                    ?.replace(/\r+|\n+|\s+/gi, '')
+                return execSync(this.COMMANDS['win32'])
+                    .toString()
+                    .match(/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/i)?.[0]
                     .toLowerCase();
             }
             case 'darwin': {
@@ -49,10 +50,5 @@ export class MachineIdentitfierAttributeProvider implements BacktraceAttributePr
                 return null;
             }
         }
-    }
-
-    private getWindowsMachineId() {
-        const regVal = getValue(HKEY.LOCAL_MACHINE, 'SOFTWARE\\Microsoft\\Cryptography', 'MachineGuid');
-        return regVal?.toString();
     }
 }


### PR DESCRIPTION
This change removes the `native-reg` dependency from `node` SDK.
This should fix some errors with rebuilding native dependencies on Electron.