### PR TITLE
node: version 0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19023,7 +19023,7 @@
         },
         "packages/node": {
             "name": "@backtrace/node",
-            "version": "0.3.1",
+            "version": "0.3.2",
             "license": "MIT",
             "dependencies": {
                 "@backtrace/sdk-core": "^0.3.2",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.3.2
+
+-   remove `native-reg` and use `reg query` executable to determine Windows machine GUID (#250)
+
 # Version 0.3.1
 
 -   added a new HTTP header to report submission layer (#246)

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/node",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "description": "Backtrace-JavaScript Node.JS integration",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",


### PR DESCRIPTION
-   remove `native-reg` and use `reg query` executable to determine Windows machine GUID (#250)