### PR TITLE
electron: version 0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19002,10 +19002,10 @@
         },
         "packages/electron": {
             "name": "@backtrace/electron",
-            "version": "0.3.0",
+            "version": "0.3.2",
             "license": "MIT",
             "dependencies": {
-                "@backtrace/node": "^0.3.1"
+                "@backtrace/node": "^0.3.2"
             },
             "peerDependencies": {
                 "electron": "12 - 28"

--- a/packages/electron/CHANGELOG.md
+++ b/packages/electron/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.3.2
+
+-   update `@backtrace/node` to `0.3.2`
+
 # Version 0.3.0
 
 -   update `@backtrace/node` to `0.3.0`

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/electron",
-    "version": "0.3.0",
+    "version": "0.3.2",
     "description": "Backtrace-JavaScript Electron integration",
     "main": "main/index.js",
     "types": "main/index.d.ts",
@@ -35,7 +35,7 @@
         "/renderer"
     ],
     "dependencies": {
-        "@backtrace/node": "^0.3.1"
+        "@backtrace/node": "^0.3.2"
     },
     "peerDependencies": {
         "electron": "12 - 28"


### PR DESCRIPTION
-   update `@backtrace/node` to `0.3.2`