### PR TITLE
session-replay: update rrweb and implement fixes

### DIFF
--- a/examples/sdk/browser/package-lock.json
+++ b/examples/sdk/browser/package-lock.json
@@ -9,6 +9,8 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
+                "@backtrace/browser": "file:../../../packages/browser",
+                "@backtrace/session-replay": "file:../../../packages/session-replay",
                 "@reduxjs/toolkit": "^1.9.5"
             },
             "devDependencies": {
@@ -17,6 +19,37 @@
                 "typescript": "^5.0.4",
                 "webpack": "^5.87.0",
                 "webpack-cli": "^5.1.4"
+            }
+        },
+        "../../../packages/browser": {
+            "version": "0.3.1",
+            "license": "MIT",
+            "dependencies": {
+                "@backtrace/sdk-core": "^0.3.2",
+                "ua-parser-js": "^1.0.35"
+            },
+            "devDependencies": {
+                "@reduxjs/toolkit": "^1.9.5",
+                "@types/jest": "^29.5.1",
+                "@types/ua-parser-js": "^0.7.36",
+                "jest": "^29.5.0",
+                "jest-environment-jsdom": "^29.5.0",
+                "ts-jest": "^29.1.0",
+                "ts-loader": "^9.4.3",
+                "typescript": "^5.0.4",
+                "webpack": "^5.87.0",
+                "webpack-cli": "^5.1.4"
+            }
+        },
+        "../../../packages/session-replay": {
+            "name": "@backtrace/session-replay",
+            "version": "0.0.1",
+            "license": "MIT",
+            "dependencies": {
+                "rrweb": "^2.0.0-alpha.15"
+            },
+            "peerDependencies": {
+                "@backtrace/sdk-core": "^0.3.2"
             }
         },
         "node_modules/@babel/runtime": {
@@ -29,6 +62,14 @@
             "engines": {
                 "node": ">=6.9.0"
             }
+        },
+        "node_modules/@backtrace/browser": {
+            "resolved": "../../../packages/browser",
+            "link": true
+        },
+        "node_modules/@backtrace/session-replay": {
+            "resolved": "../../../packages/session-replay",
+            "link": true
         },
         "node_modules/@discoveryjs/json-ext": {
             "version": "0.5.7",
@@ -2417,6 +2458,29 @@
             "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
             "requires": {
                 "regenerator-runtime": "^0.14.0"
+            }
+        },
+        "@backtrace/browser": {
+            "version": "file:../../../packages/browser",
+            "requires": {
+                "@backtrace/sdk-core": "^0.3.2",
+                "@reduxjs/toolkit": "^1.9.5",
+                "@types/jest": "^29.5.1",
+                "@types/ua-parser-js": "^0.7.36",
+                "jest": "^29.5.0",
+                "jest-environment-jsdom": "^29.5.0",
+                "ts-jest": "^29.1.0",
+                "ts-loader": "^9.4.3",
+                "typescript": "^5.0.4",
+                "ua-parser-js": "^1.0.35",
+                "webpack": "^5.87.0",
+                "webpack-cli": "^5.1.4"
+            }
+        },
+        "@backtrace/session-replay": {
+            "version": "file:../../../packages/session-replay",
+            "requires": {
+                "rrweb": "^2.0.0-alpha.15"
             }
         },
         "@discoveryjs/json-ext": {

--- a/examples/sdk/browser/package.json
+++ b/examples/sdk/browser/package.json
@@ -41,7 +41,7 @@
     },
     "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
-        "@backtrace/browser": "^0.2.0",
-        "@backtrace/session-replay": "^0.0.1"
+        "@backtrace/browser": "file:../../../packages/browser",
+        "@backtrace/session-replay": "file:../../../packages/session-replay"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3853,10 +3853,11 @@
             }
         },
         "node_modules/@rrweb/types": {
-            "version": "2.0.0-alpha.11",
-            "license": "MIT",
+            "version": "2.0.0-alpha.15",
+            "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.0.0-alpha.15.tgz",
+            "integrity": "sha512-NsD2D8oFYT+XZidklW3T/waqDyaUqu+GqBNMZRJ5UQ7hbwtlx0lmt6ZCvKa29cT/6GfEwNYxAQqelodAwRnHTw==",
             "dependencies": {
-                "rrweb-snapshot": "^2.0.0-alpha.11"
+                "rrweb-snapshot": "^2.0.0-alpha.15"
             }
         },
         "node_modules/@sideway/address": {
@@ -8978,10 +8979,6 @@
             "dependencies": {
                 "pend": "~1.2.0"
             }
-        },
-        "node_modules/fflate": {
-            "version": "0.4.8",
-            "license": "MIT"
         },
         "node_modules/figgy-pudding": {
             "version": "3.5.2",
@@ -15316,29 +15313,31 @@
             }
         },
         "node_modules/rrdom": {
-            "version": "0.1.7",
-            "license": "MIT",
+            "version": "2.0.0-alpha.15",
+            "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.0.0-alpha.15.tgz",
+            "integrity": "sha512-c7BMmqJf6u9cm5G1wx7Mgnc5pyNog4CLaGTDUZCDGZAIfRIFOWwu7A4f2z9IPiEeokgc5wq8R/8/dKp6xpg8Ug==",
             "dependencies": {
-                "rrweb-snapshot": "^2.0.0-alpha.4"
+                "rrweb-snapshot": "^2.0.0-alpha.15"
             }
         },
         "node_modules/rrweb": {
-            "version": "2.0.0-alpha.4",
-            "license": "MIT",
+            "version": "2.0.0-alpha.15",
+            "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.0.0-alpha.15.tgz",
+            "integrity": "sha512-kunhB/pSYeYT9Lusmo5Q0h0kK7//GN3VzZ9vBkcDEeUKa8zk5KdgDmIJ7SM3qWcwR09UKW17FS9HjNGMKjeg/w==",
             "dependencies": {
-                "@rrweb/types": "^2.0.0-alpha.4",
+                "@rrweb/types": "^2.0.0-alpha.15",
                 "@types/css-font-loading-module": "0.0.7",
                 "@xstate/fsm": "^1.4.0",
                 "base64-arraybuffer": "^1.0.1",
-                "fflate": "^0.4.4",
                 "mitt": "^3.0.0",
-                "rrdom": "^0.1.7",
-                "rrweb-snapshot": "^2.0.0-alpha.4"
+                "rrdom": "^2.0.0-alpha.15",
+                "rrweb-snapshot": "^2.0.0-alpha.15"
             }
         },
         "node_modules/rrweb-snapshot": {
-            "version": "2.0.0-alpha.11",
-            "license": "MIT"
+            "version": "2.0.0-alpha.15",
+            "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.15.tgz",
+            "integrity": "sha512-U5lOYoMt6YsmxKcnWVhX1ller6B8/OICQqLWqvylajTYv5oRHgAk68AFDTAXxLsjMSTQjtr1Vp+REFSmnhWrIg=="
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
@@ -19157,7 +19156,7 @@
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
-                "rrweb": "^2.0.0-alpha.4"
+                "rrweb": "^2.0.0-alpha.15"
             },
             "peerDependencies": {
                 "@backtrace/sdk-core": "^0.3.2"

--- a/packages/session-replay/package.json
+++ b/packages/session-replay/package.json
@@ -28,6 +28,6 @@
         "@backtrace/sdk-core": "^0.3.2"
     },
     "dependencies": {
-        "rrweb": "^2.0.0-alpha.4"
+        "rrweb": "^2.0.0-alpha.15"
     }
 }

--- a/packages/session-replay/src/BacktraceSessionRecorder.ts
+++ b/packages/session-replay/src/BacktraceSessionRecorder.ts
@@ -8,7 +8,6 @@ export class BacktraceSessionRecorder implements BacktraceAttachment {
     public readonly type = 'dynamic';
 
     private readonly _maxEventCount?: number;
-    private readonly _maxTime?: number;
 
     private readonly _previousEvents: OverwritingArray<eventWithTime>;
     private _events: eventWithTime[] = [];
@@ -18,7 +17,6 @@ export class BacktraceSessionRecorder implements BacktraceAttachment {
     constructor(private readonly _options: BacktraceSessionRecorderOptions) {
         this._events = [];
         this._maxEventCount = !_options.disableMaxEventCount ? _options.maxEventCount ?? 100 : undefined;
-        this._maxTime = !_options.disableMaxTime ? _options.maxTime : undefined;
         this._previousEvents = new OverwritingArray<eventWithTime>(this._maxEventCount ?? 100);
     }
 
@@ -35,7 +33,6 @@ export class BacktraceSessionRecorder implements BacktraceAttachment {
             },
             emit: (event, isCheckout) => this.onEmit(event, isCheckout),
             checkoutEveryNth: this._maxEventCount && Math.ceil(this._maxEventCount / 2),
-            checkoutEveryNms: this._maxTime && Math.ceil(this._maxTime / 2),
         });
     }
 

--- a/packages/session-replay/src/options.ts
+++ b/packages/session-replay/src/options.ts
@@ -195,21 +195,6 @@ export interface BacktraceSessionRecorderOptions {
     readonly disableMaxEventCount?: boolean;
 
     /**
-     * Maximum timeframe for recorded events to be sent with the report.
-     *
-     * Set `disableMaxTime` to `true` to disable the limit.
-     * @default undefined
-     */
-    readonly maxTime?: number;
-
-    /**
-     * Disables `maxEventCount` limit.
-     *
-     * @default false
-     */
-    readonly disableMaxTime?: boolean;
-
-    /**
      * Sampling options. Use those to reduce event count or size.
      */
     readonly sampling?: BacktraceSessionRecorderSamplingOptions;

--- a/packages/session-replay/src/options.ts
+++ b/packages/session-replay/src/options.ts
@@ -1,6 +1,6 @@
 import { MouseInteractions, eventWithTime } from '@rrweb/types';
+import { recordOptions } from 'rrweb';
 import { MaskInputFn, MaskInputOptions, MaskTextFn } from 'rrweb-snapshot';
-import { recordOptions } from 'rrweb/typings/types';
 
 export interface BacktraceSessionRecorderSamplingOptions {
     /**


### PR DESCRIPTION
This PR adds the following:
* update `rrweb` to `2.0.0-alpha-15`
* use `OverwritingArray` with `_previousEvents` to fix `isCheckout` error
* remove `maxTime` - the behavior can be misleading in this case, user can always use `checkoutEveryNms` from advanced options
* when buffer is full, send always `_maxEventCount` events, no less, no more