### PR TITLE
session-replay: PII defaults

### DIFF
--- a/examples/sdk/browser/index.html
+++ b/examples/sdk/browser/index.html
@@ -24,6 +24,7 @@
                 <h1 class="card-header" style="text-align: center">Welcome to the Backtrace demo</h1>
                 <p style="text-align: center">Please pick one of the available options:</p>
                 <br />
+                <input class="center" type="text" placeholder="Test Session Replay Input!">
                 <div class="action-container center">
                     <div class="action-button center">
                         <a class="text" id="send-error" target="_blank"> Send an error</a>

--- a/examples/sdk/browser/index.html
+++ b/examples/sdk/browser/index.html
@@ -24,6 +24,7 @@
                 <h1 class="card-header" style="text-align: center">Welcome to the Backtrace demo</h1>
                 <p style="text-align: center">Please pick one of the available options:</p>
                 <br />
+                <p style="text-align: center" class="bt-unmask">This text has class rr-unmask, and will be unmasked on Session Replay.</p>
                 <input class="center" type="text" placeholder="Test Session Replay Input!">
                 <div class="action-container center">
                     <div class="action-button center">

--- a/package-lock.json
+++ b/package-lock.json
@@ -11237,8 +11237,9 @@
         },
         "node_modules/jest-environment-jsdom": {
             "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
+            "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jest/environment": "^29.7.0",
                 "@jest/fake-timers": "^29.7.0",
@@ -19157,6 +19158,9 @@
             "license": "MIT",
             "dependencies": {
                 "rrweb": "^2.0.0-alpha.15"
+            },
+            "devDependencies": {
+                "jest-environment-jsdom": "^29.7.0"
             },
             "peerDependencies": {
                 "@backtrace/sdk-core": "^0.3.2"

--- a/packages/session-replay/jest.config.js
+++ b/packages/session-replay/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+    preset: 'ts-jest',
+    testEnvironment: 'jsdom',
+};

--- a/packages/session-replay/package.json
+++ b/packages/session-replay/package.json
@@ -9,7 +9,8 @@
         "clean": "tsc -b --clean && rimraf \"lib\"",
         "format": "prettier --write '**/*.ts'",
         "lint": "eslint . --ext .ts",
-        "watch": "tsc -w"
+        "watch": "tsc -w",
+        "test": "cross-env NODE_ENV=test jest"
     },
     "repository": {
         "type": "git",
@@ -29,5 +30,8 @@
     },
     "dependencies": {
         "rrweb": "^2.0.0-alpha.15"
+    },
+    "devDependencies": {
+        "jest-environment-jsdom": "^29.7.0"
     }
 }

--- a/packages/session-replay/src/BacktraceSessionRecorder.ts
+++ b/packages/session-replay/src/BacktraceSessionRecorder.ts
@@ -22,12 +22,12 @@ export class BacktraceSessionRecorder implements BacktraceAttachment {
 
     public start() {
         this._stop = record({
-            blockClass: this._options.privacy?.blockClass,
+            blockClass: this._options.privacy?.blockClass ?? 'bt-block',
             blockSelector: this._options.privacy?.blockSelector,
-            ignoreClass: this._options.privacy?.ignoreClass,
+            ignoreClass: this._options.privacy?.ignoreClass ?? 'bt-ignore',
             ignoreSelector: this._options.privacy?.ignoreSelector,
-            ignoreCSSAttributes: this._options.privacy?.ignoreCSSAttributes,
-            maskTextClass: this._options.privacy?.maskTextClass,
+            ignoreCSSAttributes: new Set(this._options.privacy?.ignoreCSSAttributes),
+            maskTextClass: this._options.privacy?.maskTextClass ?? 'bt-mask',
             maskTextSelector: this._options.privacy?.maskTextSelector,
             maskAllInputs: this._options.privacy?.maskAllInputs ?? true,
             maskInputFn: this._options.privacy?.maskInputFn,

--- a/packages/session-replay/src/BacktraceSessionRecorder.ts
+++ b/packages/session-replay/src/BacktraceSessionRecorder.ts
@@ -22,6 +22,16 @@ export class BacktraceSessionRecorder implements BacktraceAttachment {
 
     public start() {
         this._stop = record({
+            blockClass: this._options.privacy?.blockClass,
+            blockSelector: this._options.privacy?.blockSelector,
+            ignoreClass: this._options.privacy?.ignoreClass,
+            ignoreSelector: this._options.privacy?.ignoreSelector,
+            ignoreCSSAttributes: this._options.privacy?.ignoreCSSAttributes,
+            maskTextClass: this._options.privacy?.maskTextClass,
+            maskTextSelector: this._options.privacy?.maskTextSelector,
+            maskAllInputs: this._options.privacy?.maskAllInputs ?? true,
+            maskInputFn: this._options.privacy?.maskInputFn,
+            maskTextFn: this._options.privacy?.maskTextFn,
             ...this._options.advancedOptions,
             sampling: {
                 mousemove: this._options.sampling?.mousemove,
@@ -29,10 +39,12 @@ export class BacktraceSessionRecorder implements BacktraceAttachment {
                 input: this._options.sampling?.input,
                 media: this._options.sampling?.media,
                 scroll: this._options.sampling?.scroll,
-                ...this._options.advancedOptions,
+                ...this._options.advancedOptions?.sampling,
             },
             emit: (event, isCheckout) => this.onEmit(event, isCheckout),
-            checkoutEveryNth: this._maxEventCount && Math.ceil(this._maxEventCount / 2),
+            checkoutEveryNth:
+                this._options.advancedOptions?.checkoutEveryNth ??
+                (this._maxEventCount && Math.ceil(this._maxEventCount / 2)),
         });
     }
 

--- a/packages/session-replay/src/BacktraceSessionRecorder.ts
+++ b/packages/session-replay/src/BacktraceSessionRecorder.ts
@@ -34,7 +34,7 @@ export class BacktraceSessionRecorder implements BacktraceAttachment {
             maskTextFn: maskTextFn({
                 maskAllText: this._options.privacy?.maskAllText ?? true,
                 maskTextClass: this._options.privacy?.maskTextClass ?? 'bt-mask',
-                unmaskTextClass: this._options.privacy?.maskTextClass ?? 'bt-unmask',
+                unmaskTextClass: this._options.privacy?.unmaskTextClass ?? 'bt-unmask',
                 maskTextSelector: this._options.privacy?.maskTextSelector,
                 unmaskTextSelector: this._options.privacy?.unmaskTextSelector,
                 maskTextFn: this._options.privacy?.maskTextFn,

--- a/packages/session-replay/src/BacktraceSessionRecorder.ts
+++ b/packages/session-replay/src/BacktraceSessionRecorder.ts
@@ -2,6 +2,7 @@ import { BacktraceAttachment, OverwritingArray } from '@backtrace/sdk-core';
 import { eventWithTime } from '@rrweb/types';
 import { record } from 'rrweb';
 import { BacktraceSessionRecorderOptions } from './options';
+import { maskTextFn } from './privacy/maskTextFn';
 
 export class BacktraceSessionRecorder implements BacktraceAttachment {
     public readonly name = 'bt-session-replay-0';
@@ -27,11 +28,17 @@ export class BacktraceSessionRecorder implements BacktraceAttachment {
             ignoreClass: this._options.privacy?.ignoreClass ?? 'bt-ignore',
             ignoreSelector: this._options.privacy?.ignoreSelector,
             ignoreCSSAttributes: new Set(this._options.privacy?.ignoreCSSAttributes),
-            maskTextClass: this._options.privacy?.maskTextClass ?? 'bt-mask',
-            maskTextSelector: this._options.privacy?.maskTextSelector,
+            maskTextSelector: '*', // Pass all text to maskTextFn
             maskAllInputs: this._options.privacy?.maskAllInputs ?? true,
             maskInputFn: this._options.privacy?.maskInputFn,
-            maskTextFn: this._options.privacy?.maskTextFn,
+            maskTextFn: maskTextFn({
+                maskAllText: this._options.privacy?.maskAllText ?? true,
+                maskTextClass: this._options.privacy?.maskTextClass ?? 'bt-mask',
+                unmaskTextClass: this._options.privacy?.maskTextClass ?? 'bt-unmask',
+                maskTextSelector: this._options.privacy?.maskTextSelector,
+                unmaskTextSelector: this._options.privacy?.unmaskTextSelector,
+                maskTextFn: this._options.privacy?.maskTextFn,
+            }),
             ...this._options.advancedOptions,
             sampling: {
                 mousemove: this._options.sampling?.mousemove,

--- a/packages/session-replay/src/options.ts
+++ b/packages/session-replay/src/options.ts
@@ -98,7 +98,7 @@ export interface BacktraceSessionReplayPrivacyOptions {
     /**
      * Array of CSS attributes that should be ignored.
      */
-    readonly ignoreCSSAttributes?: string;
+    readonly ignoreCSSAttributes?: Set<string>;
 
     /**
      * Use a `string` or `RegExp` to configure which elements should be masked.
@@ -124,7 +124,7 @@ export interface BacktraceSessionReplayPrivacyOptions {
      * Can be an object with the following keys:
      * * `color`
      * * `date`
-     * * `'datetime-local'`
+     * * `datetime-local`
      * * `email`
      * * `month`
      * * `number`

--- a/packages/session-replay/src/options.ts
+++ b/packages/session-replay/src/options.ts
@@ -72,8 +72,8 @@ export interface BacktraceSessionRecorderSamplingOptions {
 
 export interface BacktraceSessionReplayPrivacyOptions {
     /**
-     * Use a `string` or `RegExp` to configure which elements should be blocked.
-     * @default "rr-block"
+     * Blocks elements with this class.
+     * @default "bt-block"
      */
     readonly blockClass?: string | RegExp;
 
@@ -84,8 +84,8 @@ export interface BacktraceSessionReplayPrivacyOptions {
     readonly blockSelector?: string;
 
     /**
-     * Use a `string` or `RegExp` to configure which elements should be ignored.
-     * @default "rr-ignore"
+     * Ignores elements with this class.
+     * @default "bt-ignore"
      */
     readonly ignoreClass?: string;
 
@@ -101,8 +101,8 @@ export interface BacktraceSessionReplayPrivacyOptions {
     readonly ignoreCSSAttributes?: Set<string>;
 
     /**
-     * Use a `string` or `RegExp` to configure which elements should be masked.
-     * @default "rr-mask"
+     * Masks elements with this class.
+     * @default "bt-mask"
      */
     readonly maskTextClass?: string;
 

--- a/packages/session-replay/src/options.ts
+++ b/packages/session-replay/src/options.ts
@@ -107,19 +107,37 @@ export interface BacktraceSessionReplayPrivacyOptions {
     readonly maskTextClass?: string;
 
     /**
-     * Use a `string` to configure which selector should be masked.
+     * Unmasks elements with this class.
+     * @default "bt-unmask"
+     */
+    readonly unmaskTextClass?: string | RegExp;
+
+    /**
+     * Masks elements matching this selector.
      * @default undefined
      */
     readonly maskTextSelector?: string;
 
     /**
+     * Unmasks elements matching this selector.
+     * @default undefined
+     */
+    readonly unmaskTextSelector?: string;
+
+    /**
      * If `true`, will mask all inputs.
-     * @default false
+     * @default true
      */
     readonly maskAllInputs?: boolean;
 
     /**
-     * Mask specific kinds of input.
+     * If `true`, will mask all text.
+     * @default true
+     */
+    readonly maskAllText?: boolean;
+
+    /**
+     * Mask specific kinds of inputs.
      *
      * Can be an object with the following keys:
      * * `color`

--- a/packages/session-replay/src/privacy/maskTextFn.ts
+++ b/packages/session-replay/src/privacy/maskTextFn.ts
@@ -1,0 +1,88 @@
+import { MaskTextFn } from 'rrweb-snapshot';
+
+export interface MaskTextFnOptions {
+    readonly maskAllText: boolean;
+    readonly maskTextSelector?: string;
+    readonly unmaskTextSelector?: string;
+    readonly maskTextClass?: string | RegExp;
+    readonly unmaskTextClass?: string | RegExp;
+    readonly maskTextFn?: MaskTextFn;
+}
+
+function maskCharacters(text: string) {
+    return text.replace(/[\S]/g, '*');
+}
+
+function testSelector(element: HTMLElement, selector?: string) {
+    if (!selector) {
+        return false;
+    }
+
+    return element.matches(selector);
+}
+
+function testClass(element: HTMLElement, expr?: string | RegExp) {
+    if (!expr) {
+        return false;
+    }
+
+    const test = typeof expr === 'string' ? (v: string) => v === expr : (v: string) => expr.test(v);
+    for (const c of element.classList) {
+        if (test(c)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Tests if element should be masked or not.
+ *
+ * Prefers masking elements, i.e. to be unmasked, the element cannot be matched by mask
+ * and has to be matched by unmask.
+ */
+function testElementPreferMask(element: HTMLElement, options: MaskTextFnOptions) {
+    if (testSelector(element, options.maskTextSelector) || testClass(element, options.maskTextClass)) {
+        return true;
+    }
+
+    if (testSelector(element, options.unmaskTextSelector) || testClass(element, options.unmaskTextClass)) {
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Tests if element should be masked or not.
+ *
+ * Prefers unmasking elements, i.e. to be masked, the element cannot be matched by unmask
+ * and has to be matched by mask.
+ */
+function testElementPreferUnmask(element: HTMLElement, options: MaskTextFnOptions) {
+    if (testSelector(element, options.unmaskTextSelector) || testClass(element, options.unmaskTextClass)) {
+        return false;
+    }
+
+    if (testSelector(element, options.maskTextSelector) || testClass(element, options.maskTextClass)) {
+        return true;
+    }
+
+    return false;
+}
+
+export function maskTextFn(options: MaskTextFnOptions): MaskTextFn {
+    const maskText = options.maskTextFn ? options.maskTextFn : maskCharacters;
+
+    return function maskTextFn(text, element) {
+        if (!element) {
+            return options.maskAllText ? maskText(text, element) : text;
+        }
+
+        const shouldBeMasked = options.maskAllText
+            ? testElementPreferMask(element, options)
+            : testElementPreferUnmask(element, options);
+
+        return shouldBeMasked ? maskText(text, element) : text;
+    };
+}

--- a/packages/session-replay/tests/privacy/maskTextFn.spec.ts
+++ b/packages/session-replay/tests/privacy/maskTextFn.spec.ts
@@ -1,0 +1,365 @@
+import { maskTextFn } from '../../src/privacy/maskTextFn';
+
+describe('maskTextFn', () => {
+    describe('mask all text enabled', () => {
+        it('should mask text without element', () => {
+            const mask = maskTextFn({
+                maskAllText: true,
+            });
+
+            const actual = mask('abc', null);
+            expect(actual).toEqual('***');
+        });
+
+        it('should mask all text', () => {
+            const element = document.createElement('div');
+
+            const mask = maskTextFn({
+                maskAllText: true,
+            });
+
+            const actual = mask('abc', element);
+            expect(actual).toEqual('***');
+        });
+
+        it('should call maskTextFn if matched by mask and use its return value', () => {
+            const customMask = jest.fn().mockReturnValue('masked');
+            const element = document.createElement('div');
+
+            const mask = maskTextFn({
+                maskAllText: true,
+                maskTextFn: customMask,
+            });
+
+            const actual = mask('abc', element);
+            expect(customMask).toHaveBeenCalled();
+            expect(actual).toEqual('masked');
+        });
+
+        it('should not call maskTextFn if matched by unmask', () => {
+            const customMask = jest.fn().mockReturnValue('masked');
+            const element = document.createElement('div');
+
+            const mask = maskTextFn({
+                maskAllText: true,
+                unmaskTextSelector: '*',
+                maskTextFn: customMask,
+            });
+
+            const actual = mask('abc', element);
+            expect(customMask).not.toHaveBeenCalled();
+            expect(actual).toEqual('abc');
+        });
+
+        it('should mask text that is matched by maskTextSelector', () => {
+            const element = document.createElement('div');
+
+            const mask = maskTextFn({
+                maskAllText: true,
+                maskTextSelector: 'div',
+            });
+
+            const actual = mask('abc', element);
+            expect(actual).toEqual('***');
+        });
+
+        it('should mask text that is not matched by maskTextSelector', () => {
+            const element = document.createElement('div');
+
+            const mask = maskTextFn({
+                maskAllText: true,
+                maskTextSelector: 'p',
+            });
+
+            const actual = mask('abc', element);
+            expect(actual).toEqual('***');
+        });
+
+        it('should mask text that is matched by maskTextClass', () => {
+            const element = document.createElement('div');
+            element.classList.add('mask');
+
+            const mask = maskTextFn({
+                maskAllText: true,
+                maskTextClass: 'mask',
+            });
+
+            const actual = mask('abc', element);
+            expect(actual).toEqual('***');
+        });
+
+        it('should mask text that is not matched by maskTextClass', () => {
+            const element = document.createElement('div');
+            element.classList.add('other');
+
+            const mask = maskTextFn({
+                maskAllText: true,
+                maskTextClass: 'mask',
+            });
+
+            const actual = mask('abc', element);
+            expect(actual).toEqual('***');
+        });
+
+        it('should not mask text that is matched by unmaskTextSelector', () => {
+            const element = document.createElement('div');
+            element.classList.add('other');
+
+            const mask = maskTextFn({
+                maskAllText: true,
+                unmaskTextSelector: 'div',
+            });
+
+            const actual = mask('abc', element);
+            expect(actual).toEqual('abc');
+        });
+
+        it('should mask text that is not matched by unmaskTextSelector', () => {
+            const element = document.createElement('div');
+            element.classList.add('other');
+
+            const mask = maskTextFn({
+                maskAllText: true,
+                unmaskTextSelector: 'p',
+            });
+
+            const actual = mask('abc', element);
+            expect(actual).toEqual('***');
+        });
+
+        it('should not mask text that is matched by unmaskTextClass', () => {
+            const element = document.createElement('div');
+            element.classList.add('unmask');
+
+            const mask = maskTextFn({
+                maskAllText: true,
+                unmaskTextClass: 'unmask',
+            });
+
+            const actual = mask('abc', element);
+            expect(actual).toEqual('abc');
+        });
+
+        it('should mask text that is not matched by unmaskTextSelector', () => {
+            const element = document.createElement('div');
+            element.classList.add('other');
+
+            const mask = maskTextFn({
+                maskAllText: true,
+                unmaskTextClass: 'unmask',
+            });
+
+            const actual = mask('abc', element);
+            expect(actual).toEqual('***');
+        });
+
+        it('should mask text that is matched by maskTextSelector and unmaskTextSelector', () => {
+            const element = document.createElement('div');
+
+            const mask = maskTextFn({
+                maskAllText: true,
+                maskTextSelector: 'div',
+                unmaskTextSelector: 'div',
+            });
+
+            const actual = mask('abc', element);
+            expect(actual).toEqual('***');
+        });
+
+        it('should mask text that is matched by maskTextClass and unmaskTextClass', () => {
+            const element = document.createElement('div');
+            element.classList.add('mask');
+            element.classList.add('unmask');
+
+            const mask = maskTextFn({
+                maskAllText: true,
+                maskTextClass: 'mask',
+                unmaskTextClass: 'unmask',
+            });
+
+            const actual = mask('abc', element);
+            expect(actual).toEqual('***');
+        });
+    });
+
+    describe('mask all text disabled', () => {
+        it('should not mask text without element', () => {
+            const mask = maskTextFn({
+                maskAllText: false,
+            });
+
+            const actual = mask('abc', null);
+            expect(actual).toEqual('abc');
+        });
+
+        it('should not mask all text', () => {
+            const element = document.createElement('div');
+
+            const mask = maskTextFn({
+                maskAllText: false,
+            });
+
+            const actual = mask('abc', element);
+            expect(actual).toEqual('abc');
+        });
+
+        it('should not call maskTextFn if not matched by mask', () => {
+            const customMask = jest.fn().mockReturnValue('masked');
+            const element = document.createElement('div');
+
+            const mask = maskTextFn({
+                maskAllText: false,
+                maskTextFn: customMask,
+            });
+
+            const actual = mask('abc', element);
+            expect(customMask).not.toHaveBeenCalled();
+            expect(actual).toEqual('abc');
+        });
+
+        it('should call maskTextFn and use its masked value if matched by mask', () => {
+            const customMask = jest.fn().mockReturnValue('masked');
+            const element = document.createElement('div');
+
+            const mask = maskTextFn({
+                maskAllText: true,
+                maskTextSelector: '*',
+                maskTextFn: customMask,
+            });
+
+            const actual = mask('abc', element);
+            expect(customMask).toHaveBeenCalled();
+            expect(actual).toEqual('masked');
+        });
+
+        it('should mask text that is matched by maskTextSelector', () => {
+            const element = document.createElement('div');
+
+            const mask = maskTextFn({
+                maskAllText: false,
+                maskTextSelector: 'div',
+            });
+
+            const actual = mask('abc', element);
+            expect(actual).toEqual('***');
+        });
+
+        it('should not mask text that is not matched by maskTextSelector', () => {
+            const element = document.createElement('div');
+
+            const mask = maskTextFn({
+                maskAllText: false,
+                maskTextSelector: 'p',
+            });
+
+            const actual = mask('abc', element);
+            expect(actual).toEqual('abc');
+        });
+
+        it('should mask text that is matched by maskTextClass', () => {
+            const element = document.createElement('div');
+            element.classList.add('mask');
+
+            const mask = maskTextFn({
+                maskAllText: false,
+                maskTextClass: 'mask',
+            });
+
+            const actual = mask('abc', element);
+            expect(actual).toEqual('***');
+        });
+
+        it('should not mask text that is not matched by maskTextClass', () => {
+            const element = document.createElement('div');
+            element.classList.add('other');
+
+            const mask = maskTextFn({
+                maskAllText: false,
+                maskTextClass: 'mask',
+            });
+
+            const actual = mask('abc', element);
+            expect(actual).toEqual('abc');
+        });
+
+        it('should not mask text that is matched by unmaskTextSelector', () => {
+            const element = document.createElement('div');
+            element.classList.add('other');
+
+            const mask = maskTextFn({
+                maskAllText: false,
+                unmaskTextSelector: 'div',
+            });
+
+            const actual = mask('abc', element);
+            expect(actual).toEqual('abc');
+        });
+
+        it('should not mask text that is not matched by unmaskTextSelector', () => {
+            const element = document.createElement('div');
+            element.classList.add('other');
+
+            const mask = maskTextFn({
+                maskAllText: false,
+                unmaskTextSelector: 'p',
+            });
+
+            const actual = mask('abc', element);
+            expect(actual).toEqual('abc');
+        });
+
+        it('should not mask text that is matched by unmaskTextClass', () => {
+            const element = document.createElement('div');
+            element.classList.add('unmask');
+
+            const mask = maskTextFn({
+                maskAllText: false,
+                unmaskTextClass: 'unmask',
+            });
+
+            const actual = mask('abc', element);
+            expect(actual).toEqual('abc');
+        });
+
+        it('should not mask text that is not matched by unmaskTextSelector', () => {
+            const element = document.createElement('div');
+            element.classList.add('other');
+
+            const mask = maskTextFn({
+                maskAllText: false,
+                unmaskTextClass: 'unmask',
+            });
+
+            const actual = mask('abc', element);
+            expect(actual).toEqual('abc');
+        });
+
+        it('should not mask text that is matched by maskTextSelector and unmaskTextSelector', () => {
+            const element = document.createElement('div');
+
+            const mask = maskTextFn({
+                maskAllText: false,
+                maskTextSelector: 'div',
+                unmaskTextSelector: 'div',
+            });
+
+            const actual = mask('abc', element);
+            expect(actual).toEqual('abc');
+        });
+
+        it('should not mask text that is matched by maskTextClass and unmaskTextClass', () => {
+            const element = document.createElement('div');
+            element.classList.add('mask');
+            element.classList.add('unmask');
+
+            const mask = maskTextFn({
+                maskAllText: false,
+                maskTextClass: 'mask',
+                unmaskTextClass: 'unmask',
+            });
+
+            const actual = mask('abc', element);
+            expect(actual).toEqual('abc');
+        });
+    });
+});


### PR DESCRIPTION
This PR adds the following:
* pass privacy options to `rrweb` settings,
* mask all inputs by default,
* add input to browser example to demonstrate masking.