### PR TITLE
Add support for error.type for electron crashes

### DIFF
--- a/examples/sdk/electron/package-lock.json
+++ b/examples/sdk/electron/package-lock.json
@@ -24,10 +24,10 @@
         },
         "../../../packages/electron": {
             "name": "@backtrace/electron",
-            "version": "0.3.0",
+            "version": "0.3.1",
             "license": "MIT",
             "dependencies": {
-                "@backtrace/node": "^0.3.0"
+                "@backtrace/node": "^0.3.2"
             },
             "peerDependencies": {
                 "electron": "12 - 28"
@@ -2366,7 +2366,7 @@
         "@backtrace/electron": {
             "version": "file:../../../packages/electron",
             "requires": {
-                "@backtrace/node": "^0.3.0"
+                "@backtrace/node": "^0.3.2"
             }
         },
         "@discoveryjs/json-ext": {

--- a/packages/electron/src/main/modules/BacktraceMainElectronModule.ts
+++ b/packages/electron/src/main/modules/BacktraceMainElectronModule.ts
@@ -1,10 +1,11 @@
 import {
+    AttributeType,
     BacktraceData,
     BacktraceModule,
     BacktraceModuleBindData,
     RawBreadcrumb,
     SubmissionUrlInformation,
-    SummedEvent,
+    SummedEvent
 } from '@backtrace/sdk-core';
 import { app, crashReporter } from 'electron';
 import { IpcAttachmentReference } from '../../common/ipc/IpcAttachmentReference';
@@ -96,14 +97,19 @@ export class BacktraceMainElectronModule implements BacktraceModule {
                 app.setPath('crashDumps', options.database.path);
             }
 
+            const getElectronDefaultAttributes = (attributes: Record<string, AttributeType> = attributeManager.get('scoped').attributes) => {
+                attributes['error.type'] = 'Crash';
+                return toStringDictionary(attributes);
+            }
+
             crashReporter.start({
                 submitURL: SubmissionUrlInformation.toMinidumpSubmissionUrl(options.url),
                 uploadToServer: true,
-                extra: toStringDictionary(attributeManager.get('scoped').attributes),
+                extra: getElectronDefaultAttributes(),
             });
 
             attributeManager.attributeEvents.on('scoped-attributes-updated', ({ attributes }) => {
-                const dict = toStringDictionary(attributes);
+                const dict = getElectronDefaultAttributes(attributes);
                 for (const key in dict) {
                     crashReporter.addExtraParameter(key, dict[key]);
                 }

--- a/packages/electron/src/main/modules/BacktraceMainElectronModule.ts
+++ b/packages/electron/src/main/modules/BacktraceMainElectronModule.ts
@@ -105,7 +105,6 @@ export class BacktraceMainElectronModule implements BacktraceModule {
                 }
             });
 
-
             attributeManager.attributeEvents.on('scoped-attributes-updated', ({ attributes }) => {
                 const dict = toStringDictionary(attributes);
                 for (const key in dict) {

--- a/packages/electron/src/main/modules/BacktraceMainElectronModule.ts
+++ b/packages/electron/src/main/modules/BacktraceMainElectronModule.ts
@@ -4,7 +4,7 @@ import {
     BacktraceModuleBindData,
     RawBreadcrumb,
     SubmissionUrlInformation,
-    SummedEvent
+    SummedEvent,
 } from '@backtrace/sdk-core';
 import { app, crashReporter } from 'electron';
 import { IpcAttachmentReference } from '../../common/ipc/IpcAttachmentReference';
@@ -101,8 +101,8 @@ export class BacktraceMainElectronModule implements BacktraceModule {
                 uploadToServer: true,
                 extra: {
                     ...toStringDictionary(attributeManager.get('scoped').attributes),
-                    'error.type': 'Crash'
-                }
+                    'error.type': 'Crash',
+                },
             });
 
             attributeManager.attributeEvents.on('scoped-attributes-updated', ({ attributes }) => {

--- a/packages/electron/src/main/modules/BacktraceMainElectronModule.ts
+++ b/packages/electron/src/main/modules/BacktraceMainElectronModule.ts
@@ -1,5 +1,4 @@
 import {
-    AttributeType,
     BacktraceData,
     BacktraceModule,
     BacktraceModuleBindData,
@@ -97,19 +96,18 @@ export class BacktraceMainElectronModule implements BacktraceModule {
                 app.setPath('crashDumps', options.database.path);
             }
 
-            const getElectronDefaultAttributes = (attributes: Record<string, AttributeType> = attributeManager.get('scoped').attributes) => {
-                attributes['error.type'] = 'Crash';
-                return toStringDictionary(attributes);
-            }
-
             crashReporter.start({
                 submitURL: SubmissionUrlInformation.toMinidumpSubmissionUrl(options.url),
                 uploadToServer: true,
-                extra: getElectronDefaultAttributes(),
+                extra: {
+                    ...toStringDictionary(attributeManager.get('scoped').attributes),
+                    'error.type': 'Crash'
+                }
             });
 
+
             attributeManager.attributeEvents.on('scoped-attributes-updated', ({ attributes }) => {
-                const dict = getElectronDefaultAttributes(attributes);
+                const dict = toStringDictionary(attributes);
                 for (const key in dict) {
                     crashReporter.addExtraParameter(key, dict[key]);
                 }


### PR DESCRIPTION
# Why

This diff adds support for the error.type attribute for electron crashes. 

ref: BT-3057