### PR TITLE
sdk-core: fix missing instance when builder is used

### DIFF
--- a/packages/sdk-core/src/BacktraceCoreClient.ts
+++ b/packages/sdk-core/src/BacktraceCoreClient.ts
@@ -236,6 +236,7 @@ export abstract class BacktraceCoreClient<O extends BacktraceConfiguration = Bac
         this.sessionFiles?.clearPreviousSessions();
 
         this._enabled = true;
+        BacktraceCoreClient._instance = this;
     }
 
     /**


### PR DESCRIPTION
When `BacktraceBuilder` is used, despite it calling `initialize`, the global instance is not set, leading to errors in React's `ErrorBoundary`.

This change fixes that by setting the instance in `sdk-core`'s `BacktraceCoreClient`.