### PR TITLE
sdk-core, browser, react-native: fix abort event not being removed from signal

### DIFF
--- a/packages/react-native/src/ReactNativeRequestHandler.ts
+++ b/packages/react-native/src/ReactNativeRequestHandler.ts
@@ -45,12 +45,14 @@ export class ReactNativeRequestHandler implements BacktraceRequestHandler {
         const controller = new AbortController();
         const id = setTimeout(() => controller.abort(), this._timeout);
 
+        const signal = anySignal(abortSignal, controller.signal);
+
         try {
             const response = await fetch(submissionUrl, {
                 method: 'POST',
                 body: payload,
                 headers: typeof payload === 'string' ? this.JSON_HEADERS : this.MULTIPART_HEADERS,
-                signal: anySignal(abortSignal, controller.signal),
+                signal,
             });
 
             clearInterval(id);
@@ -84,6 +86,11 @@ export class ReactNativeRequestHandler implements BacktraceRequestHandler {
             }
 
             return BacktraceReportSubmissionResult.OnUnknownError(err.message);
+        } finally {
+            // Check for backwards compatibility
+            if ('dispose' in signal && typeof signal.dispose === 'function') {
+                signal.dispose();
+            }
         }
     }
 

--- a/packages/sdk-core/src/modules/metrics/MetricsSubmissionQueue.ts
+++ b/packages/sdk-core/src/modules/metrics/MetricsSubmissionQueue.ts
@@ -42,7 +42,12 @@ export class MetricsSubmissionQueue<T extends MetricsEvent> implements MetricsQu
 
     public async send(abortSignal?: AbortSignal) {
         const eventsToProcess = this._events.splice(0);
-        return await this.submit(eventsToProcess, anySignal(abortSignal, this._abortController.signal));
+        const signal = anySignal(abortSignal, this._abortController.signal);
+        try {
+            return await this.submit(eventsToProcess, signal);
+        } finally {
+            signal.dispose();
+        }
     }
 
     public dispose() {

--- a/packages/session-replay/package.json
+++ b/packages/session-replay/package.json
@@ -13,6 +13,7 @@
         "format": "prettier --write '**/*.ts'",
         "lint": "eslint . --ext .ts",
         "watch": "npm run build -- --watch",
+        "prepublishOnly": "cross-env NODE_ENV=production npm run clean && npm run build",
         "test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" NODE_NO_WARNINGS=1 NODE_ENV=test jest"
     },
     "repository": {


### PR DESCRIPTION
Every time `anySignal` is used, an `abort` event is added to the passed `AbortSignal`.

If the signal is not cancelled, the event is not removed. If the code using `anySignal` is executed multiple times, this can cause events to build up without being cleaned up.

This PR changes this and introduces a function `disposeSignal` that cleans up the signal afterwards.