### PR TITLE
sdk-core: use ESM modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19625,8 +19625,45 @@
             "devDependencies": {
                 "@types/jest": "^29.5.1",
                 "jest": "^29.5.0",
+                "rollup": "^4.21.0",
+                "rollup-plugin-typescript2": "^0.36.0",
                 "ts-jest": "^29.1.0",
                 "typescript": "^5.0.4"
+            }
+        },
+        "packages/sdk-core/node_modules/rollup": {
+            "version": "4.21.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.0.tgz",
+            "integrity": "sha512-vo+S/lfA2lMS7rZ2Qoubi6I5hwZwzXeUIctILZLbHI+laNtvhhOIon2S1JksA5UEDQ7l3vberd0fxK44lTYjbQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "1.0.5"
+            },
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "npm": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.21.0",
+                "@rollup/rollup-android-arm64": "4.21.0",
+                "@rollup/rollup-darwin-arm64": "4.21.0",
+                "@rollup/rollup-darwin-x64": "4.21.0",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.21.0",
+                "@rollup/rollup-linux-arm-musleabihf": "4.21.0",
+                "@rollup/rollup-linux-arm64-gnu": "4.21.0",
+                "@rollup/rollup-linux-arm64-musl": "4.21.0",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.21.0",
+                "@rollup/rollup-linux-riscv64-gnu": "4.21.0",
+                "@rollup/rollup-linux-s390x-gnu": "4.21.0",
+                "@rollup/rollup-linux-x64-gnu": "4.21.0",
+                "@rollup/rollup-linux-x64-musl": "4.21.0",
+                "@rollup/rollup-win32-arm64-msvc": "4.21.0",
+                "@rollup/rollup-win32-ia32-msvc": "4.21.0",
+                "@rollup/rollup-win32-x64-msvc": "4.21.0",
+                "fsevents": "~2.3.2"
             }
         },
         "packages/session-replay": {

--- a/packages/browser/src/BacktraceBrowserSessionProvider.ts
+++ b/packages/browser/src/BacktraceBrowserSessionProvider.ts
@@ -1,5 +1,4 @@
-import { BacktraceSessionProvider, IdGenerator } from '@backtrace/sdk-core';
-import { TimeHelper } from '@backtrace/sdk-core/lib/common/TimeHelper';
+import { BacktraceSessionProvider, IdGenerator, TimeHelper } from '@backtrace/sdk-core';
 
 export class BacktraceBrowserSessionProvider implements BacktraceSessionProvider {
     /**

--- a/packages/browser/src/attributes/WebsiteAttributeProvider.ts
+++ b/packages/browser/src/attributes/WebsiteAttributeProvider.ts
@@ -1,5 +1,4 @@
-import { BacktraceAttributeProvider } from '@backtrace/sdk-core';
-import { TimeHelper } from '@backtrace/sdk-core/lib/common/TimeHelper';
+import { BacktraceAttributeProvider, TimeHelper } from '@backtrace/sdk-core';
 
 const PAGE_START_TIME = TimeHelper.now();
 

--- a/packages/browser/tests/metrics/persistentSessionProviderTests.spec.ts
+++ b/packages/browser/tests/metrics/persistentSessionProviderTests.spec.ts
@@ -1,4 +1,4 @@
-import { TimeHelper } from '@backtrace/sdk-core/lib/common/TimeHelper';
+import { TimeHelper } from '@backtrace/sdk-core';
 import { BacktraceBrowserSessionProvider } from '../../src/BacktraceBrowserSessionProvider';
 describe('Session provider tests', () => {
     it('Should generate a new uuid on new session', () => {

--- a/packages/sdk-core/jest.config.js
+++ b/packages/sdk-core/jest.config.js
@@ -1,6 +1,0 @@
-/** @type {import('ts-jest').JestConfigWithTsJest} */
-module.exports = {
-    preset: 'ts-jest',
-    testEnvironment: 'node',
-    setupFiles: ['./jest.setup.js'],
-};

--- a/packages/sdk-core/jest.config.mjs
+++ b/packages/sdk-core/jest.config.mjs
@@ -1,0 +1,17 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+export default {
+    preset: 'ts-jest/presets/default-esm',
+    testEnvironment: 'node',
+    setupFiles: ['./jest.setup.mjs'],
+    moduleNameMapper: {
+        '^(\\.{1,2}/.*)\\.js$': '$1',
+    },
+    transform: {
+        '^.+\\.tsx?$': [
+            'ts-jest',
+            {
+                useESM: true,
+            },
+        ],
+    },
+};

--- a/packages/sdk-core/jest.setup.mjs
+++ b/packages/sdk-core/jest.setup.mjs
@@ -1,2 +1,5 @@
+import { jest } from '@jest/globals';
+global.jest = jest;
+
 global.BACKTRACE_AGENT_NAME = 'test';
 global.BACKTRACE_AGENT_VERSION = 'test';

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -2,15 +2,17 @@
     "name": "@backtrace/sdk-core",
     "version": "0.4.0",
     "description": "Backtrace-JavaScript SDK core library",
-    "main": "lib/index.js",
+    "main": "lib/bundle.cjs",
+    "module": "lib/bundle.mjs",
     "types": "lib/index.d.ts",
+    "type": "module",
     "scripts": {
-        "build": "tsc",
-        "clean": "tsc -b --clean && rimraf \"lib\"",
+        "build": "rollup -c rollup.config.mjs",
+        "clean": "rimraf lib *.tsbuildinfo",
         "format": "prettier --write '**/*.ts'",
         "lint": "eslint . --ext .ts",
-        "watch": "tsc -w",
-        "test": "cross-env NODE_ENV=test jest"
+        "watch": "npm run build -- --watch",
+        "test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" NODE_NO_WARNINGS=1 NODE_ENV=test jest"
     },
     "repository": {
         "type": "git",
@@ -37,6 +39,8 @@
     "devDependencies": {
         "@types/jest": "^29.5.1",
         "jest": "^29.5.0",
+        "rollup": "^4.21.0",
+        "rollup-plugin-typescript2": "^0.36.0",
         "ts-jest": "^29.1.0",
         "typescript": "^5.0.4"
     }

--- a/packages/sdk-core/rollup.config.mjs
+++ b/packages/sdk-core/rollup.config.mjs
@@ -1,0 +1,20 @@
+import typescript from 'rollup-plugin-typescript2';
+
+/** @type {import('rollup').RollupOptions} */
+export default {
+    input: './src/index.ts',
+    output: [
+        {
+            file: 'lib/bundle.mjs',
+            format: 'esm',
+            sourcemap: true,
+        },
+        {
+            file: 'lib/bundle.cjs',
+            format: 'cjs',
+            sourcemap: true,
+        },
+    ],
+    external: [/node_modules/],
+    plugins: [typescript({ tsconfig: './tsconfig.build.json' })],
+};

--- a/packages/sdk-core/src/modules/metrics/BacktraceMetrics.ts
+++ b/packages/sdk-core/src/modules/metrics/BacktraceMetrics.ts
@@ -25,8 +25,8 @@ export class BacktraceMetrics implements BacktraceModule {
     public readonly DEFAULT_UPDATE_INTERVAL = TimeHelper.convertSecondsToMilliseconds(30 * 60);
     public readonly DEFAULT_SERVER_URL = 'https://events.backtrace.io';
 
-    public readonly metricsHost: string = this._options.metricsSubmissionUrl ?? this.DEFAULT_SERVER_URL;
-    private readonly _updateInterval: number = this._options.autoSendInterval ?? this.DEFAULT_UPDATE_INTERVAL;
+    public readonly metricsHost: string;
+    private readonly _updateInterval: number;
 
     private _updateIntervalId?: ReturnType<typeof setTimeout>;
     private readonly _abortController: AbortController;
@@ -38,6 +38,9 @@ export class BacktraceMetrics implements BacktraceModule {
         private readonly _summedEventsSubmissionQueue: MetricsQueue<SummedEvent>,
         private readonly _uniqueEventsSubmissionQueue: MetricsQueue<UniqueEvent>,
     ) {
+        this.metricsHost = this._options.metricsSubmissionUrl ?? this.DEFAULT_SERVER_URL;
+        this._updateInterval = this._options.autoSendInterval ?? this.DEFAULT_UPDATE_INTERVAL;
+
         this._abortController = createAbortController();
     }
 

--- a/packages/sdk-core/tests/database/databaseContextMemoryStorageTests.spec.ts
+++ b/packages/sdk-core/tests/database/databaseContextMemoryStorageTests.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { BacktraceData, BacktraceDatabaseRecord, BacktraceReportSubmissionResult } from '../../src';
 import { TimeHelper } from '../../src/common/TimeHelper';
 import { BacktraceDatabase } from '../../src/modules/database/BacktraceDatabase';
@@ -14,7 +15,7 @@ describe('Database context memory storage tests', () => {
         // interface. However, if bug happen we want to be sure to not create
         // anything. Instead we want to fail loud and hard.
         createDatabaseDirectory: false,
-        path: path.join(__dirname, 'database'),
+        path: path.join(path.dirname(fileURLToPath(import.meta.url)), 'database'),
     };
 
     afterEach(() => {

--- a/packages/sdk-core/tests/database/databaseContextValidationTests.spec.ts
+++ b/packages/sdk-core/tests/database/databaseContextValidationTests.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { BacktraceDatabaseConfiguration, BacktraceReportSubmissionResult } from '../../src';
 import { BacktraceDatabase } from '../../src/modules/database/BacktraceDatabase';
 import { mockFileSystem } from '../_mocks/fileSystem';
@@ -14,7 +15,7 @@ describe('Database context validation tests', () => {
             // interface. However, if bug happen we want to be sure to not create
             // anything. Instead we want to fail loud and hard.
             createDatabaseDirectory: false,
-            path: path.join(__dirname, 'database'),
+            path: path.join(path.dirname(fileURLToPath(import.meta.url)), 'database'),
         };
 
         afterEach(() => {

--- a/packages/sdk-core/tests/database/databaseRecordBatchTests.spec.ts
+++ b/packages/sdk-core/tests/database/databaseRecordBatchTests.spec.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { BacktraceReportSubmissionResult } from '../../src';
 import { mockFileSystem } from '../_mocks/fileSystem';
 import { BacktraceTestClient } from '../mocks/BacktraceTestClient';
@@ -25,7 +26,7 @@ describe('Database record batch tests', () => {
                 database: {
                     enable: true,
                     autoSend: true,
-                    path: path.join(__dirname, 'database'),
+                    path: path.join(path.dirname(fileURLToPath(import.meta.url)), 'database'),
                     maximumRetries,
                     retryInterval: 1000,
                 },
@@ -58,7 +59,7 @@ describe('Database record batch tests', () => {
                 database: {
                     enable: true,
                     autoSend: true,
-                    path: path.join(__dirname, 'database'),
+                    path: path.join(path.dirname(fileURLToPath(import.meta.url)), 'database'),
                     maximumRetries,
                     retryInterval: 1000,
                 },

--- a/packages/sdk-core/tests/database/databaseSendTests.spec.ts
+++ b/packages/sdk-core/tests/database/databaseSendTests.spec.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { BacktraceDatabaseConfiguration, BacktraceReportSubmissionResult } from '../../src';
 import { BacktraceDatabase } from '../../src/modules/database/BacktraceDatabase';
 import { mockFileSystem } from '../_mocks/fileSystem';
@@ -15,7 +16,7 @@ describe('Database send tests', () => {
         // interface. However, if bug happen we want to be sure to not create
         // anything. Instead we want to fail loud and hard.
         createDatabaseDirectory: false,
-        path: path.join(__dirname, 'database'),
+        path: path.join(path.dirname(fileURLToPath(import.meta.url)), 'database'),
     };
 
     describe('Flush', () => {

--- a/packages/sdk-core/tests/database/databaseStorageFlowTests.spec.ts
+++ b/packages/sdk-core/tests/database/databaseStorageFlowTests.spec.ts
@@ -1,9 +1,9 @@
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { BacktraceReportSubmissionResult } from '../../src';
 import { BacktraceDatabase } from '../../src/modules/database/BacktraceDatabase';
 import { mockFileSystem } from '../_mocks/fileSystem';
 import { BacktraceTestClient } from '../mocks/BacktraceTestClient';
-
 describe('Database storage provider flow tests', () => {
     const testDatabaseSettings = {
         enable: true,
@@ -12,7 +12,7 @@ describe('Database storage provider flow tests', () => {
         // interface. However, if bug happen we want to be sure to not create
         // anything. Instead we want to fail loud and hard.
         createDatabaseDirectory: false,
-        path: path.join(__dirname, 'database'),
+        path: path.join(path.dirname(fileURLToPath(import.meta.url)), 'database'),
     };
 
     afterEach(() => {

--- a/packages/sdk-core/tsconfig.build.json
+++ b/packages/sdk-core/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["node_modules", "tests", "lib"],
+    "compilerOptions": {
+        "rootDir": "./src",
+        "outDir": "./lib"
+    }
+}

--- a/packages/sdk-core/tsconfig.json
+++ b/packages/sdk-core/tsconfig.json
@@ -1,13 +1,11 @@
 {
     "extends": "../../tsconfig.base.json",
-    "include": ["./src"],
     "compilerOptions": {
-        "rootDir": "./src",
         "composite": true,
-        "outDir": "./lib",
         "target": "ESNext",
         "module": "ESNext",
         "moduleResolution": "Bundler"
     },
-    "exclude": ["node_modules", "tests", "lib"]
+    "include": ["src", "tests"],
+    "exclude": ["node_modules", "lib"]
 }

--- a/packages/sdk-core/tsconfig.json
+++ b/packages/sdk-core/tsconfig.json
@@ -4,7 +4,10 @@
     "compilerOptions": {
         "rootDir": "./src",
         "composite": true,
-        "outDir": "./lib"
+        "outDir": "./lib",
+        "target": "ESNext",
+        "module": "ESNext",
+        "moduleResolution": "Bundler"
     },
     "exclude": ["node_modules", "tests", "lib"]
 }


### PR DESCRIPTION
This PR adds ESM module support to `sdk-core`.

`sdk-core` is now bundled into two files:
- `bundle.mjs` - ESM modules
- `bundle.cjs` - CommomJS (Node) modules