### PR TITLE
session-replay: version 0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19631,7 +19631,7 @@
         },
         "packages/session-replay": {
             "name": "@backtrace/session-replay",
-            "version": "0.1.0",
+            "version": "0.1.1",
             "license": "MIT",
             "dependencies": {
                 "rrweb": "^2.0.0-alpha.15"

--- a/packages/session-replay/CHANGELOG.md
+++ b/packages/session-replay/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.1.1
+
+-   output ES and CJS modules (#272)
+-   bundle `rrweb` in the library (#272)
+
 # Version 0.1.0
 
 Initial release.

--- a/packages/session-replay/package.json
+++ b/packages/session-replay/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/session-replay",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Backtrace-JavaScript Session Replay module",
     "main": "lib/bundle.cjs",
     "module": "lib/bundle.mjs",


### PR DESCRIPTION
-   output ES and CJS modules (#272)
-   bundle `rrweb` in the library (#272)