### PR TITLE
browser: version 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22730,7 +22730,7 @@
         },
         "packages/browser": {
             "name": "@backtrace/browser",
-            "version": "0.3.1",
+            "version": "0.4.0",
             "license": "MIT",
             "devDependencies": {
                 "@backtrace/sdk-core": "^0.5.0",
@@ -22998,7 +22998,7 @@
             "version": "0.3.1",
             "license": "MIT",
             "devDependencies": {
-                "@backtrace/browser": "^0.3.1",
+                "@backtrace/browser": "^0.4.0",
                 "@backtrace/sdk-core": "^0.5.0",
                 "@rollup/plugin-commonjs": "^26.0.1",
                 "@rollup/plugin-json": "^6.1.0",

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 0.4.0
+
+-   update `@backtrace/sdk-core` to `0.5.0`
+-   update code to use ES modules (#268, #279)
+-   emit CJS and ES modules (#268, #279)
+-   fix abort event not being removed from signal (#265)
+
 # Version 0.3.1
 
 -   added a new HTTP header to report submission layer (#246)

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/browser",
-    "version": "0.3.1",
+    "version": "0.4.0",
     "description": "Backtrace-JavaScript web browser integration",
     "main": "lib/bundle.cjs",
     "module": "lib/bundle.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,7 +40,7 @@
         "/lib"
     ],
     "devDependencies": {
-        "@backtrace/browser": "^0.3.1",
+        "@backtrace/browser": "^0.4.0",
         "@backtrace/sdk-core": "^0.5.0",
         "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-json": "^6.1.0",


### PR DESCRIPTION
-   update `@backtrace/sdk-core` to `0.5.0`
-   update code to use ES modules (#268, #279)
-   emit CJS and ES modules (#268, #279)
-   fix abort event not being removed from signal (#265)