### PR TITLE
react: version 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22995,7 +22995,7 @@
         },
         "packages/react": {
             "name": "@backtrace/react",
-            "version": "0.3.1",
+            "version": "0.4.0",
             "license": "MIT",
             "devDependencies": {
                 "@backtrace/browser": "^0.4.0",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 0.4.0
+
+-   update `@backtrace/browser` to `0.4.0`
+-   update code to use ES modules (#269, #279)
+-   emit CJS and ES modules (#269, #279)
+
 # Version 0.3.1
 
 -   added a new HTTP header to report submission layer (#246)

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/react",
-    "version": "0.3.1",
+    "version": "0.4.0",
     "description": "Backtrace-Javascript React integration",
     "main": "lib/bundle.cjs",
     "module": "lib/bundle.mjs",


### PR DESCRIPTION
-   update `@backtrace/browser` to `0.4.0`
-   update code to use ES modules (#269, #279)
-   emit CJS and ES modules (#269, #279)