### PR TITLE
nestjs: version 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22868,7 +22868,7 @@
         },
         "packages/nestjs": {
             "name": "@backtrace/nestjs",
-            "version": "0.3.0",
+            "version": "0.4.0",
             "license": "MIT",
             "dependencies": {
                 "@backtrace/node": "^0.5.0"

--- a/packages/nestjs/CHANGELOG.md
+++ b/packages/nestjs/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 0.4.0
+
+-   update `@backtrace/node` to `0.5.0`
+-   update code to use ES modules (#271)
+-   emit CJS and ES modules (#271)
+
 # Version 0.3.0
 
 -   update `@backtrace/node` to `0.3.0`

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/nestjs",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "Backtrace-JavaScript NestJS integration",
     "main": "lib/bundle.cjs",
     "module": "lib/bundle.mjs",


### PR DESCRIPTION
-   update `@backtrace/node` to `0.5.0`
-   update code to use ES modules (#271)
-   emit CJS and ES modules (#271)