### PR TITLE
sdk-core: use core client as event emitter, send reports from database via client

### DIFF
--- a/packages/sdk-core/src/common/Events.ts
+++ b/packages/sdk-core/src/common/Events.ts
@@ -1,33 +1,31 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-interface EventCallback {
-    callback: (...args: any[]) => unknown;
+interface EventCallback<A extends any[] = any[]> {
+    callback: (...args: A) => unknown;
     once?: boolean;
 }
 
-export class Events<
-    E extends Record<string | number | symbol, (...args: any[]) => unknown> = Record<
-        string | number | symbol,
-        (...args: any[]) => unknown
-    >,
-> {
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type EventMap = Record<string, any[]>;
+
+export class Events<E extends EventMap = EventMap> {
     private readonly _callbacks: Partial<Record<keyof E, EventCallback[]>> = {};
 
-    public on<N extends keyof E>(event: N, callback: E[N]): this {
+    public on<N extends keyof E>(event: N, callback: (...args: E[N]) => unknown): this {
         this.addCallback(event, { callback });
         return this;
     }
 
-    public once<N extends keyof E>(event: N, callback: E[N]): this {
+    public once<N extends keyof E>(event: N, callback: (...args: E[N]) => unknown): this {
         this.addCallback(event, { callback, once: true });
         return this;
     }
 
-    public off<N extends keyof E>(event: N, callback: E[N]): this {
+    public off<N extends keyof E>(event: N, callback: (...args: E[N]) => unknown): this {
         this.removeCallback(event, callback);
         return this;
     }
 
-    public emit<N extends keyof E>(event: N, ...args: Parameters<E[N]>): boolean {
+    public emit<N extends keyof E>(event: N, ...args: E[N]): boolean {
         const callbacks = this._callbacks[event];
         if (!callbacks || !callbacks.length) {
             return false;
@@ -48,7 +46,7 @@ export class Events<
         return true;
     }
 
-    private addCallback(event: keyof E, callback: EventCallback) {
+    private addCallback<A extends unknown[]>(event: keyof E, callback: EventCallback<A>) {
         const list = this._callbacks[event];
         if (list) {
             list.push(callback);
@@ -57,7 +55,7 @@ export class Events<
         }
     }
 
-    private removeCallback(event: keyof E, callback: EventCallback['callback']) {
+    private removeCallback<A extends unknown[]>(event: keyof E, callback: EventCallback<A>['callback']) {
         const list = this._callbacks[event];
         if (!list) {
             return;

--- a/packages/sdk-core/src/events/AttachmentEvents.ts
+++ b/packages/sdk-core/src/events/AttachmentEvents.ts
@@ -1,5 +1,5 @@
 import { BacktraceAttachment } from '../model/attachment/index.js';
 
 export type AttachmentEvents = {
-    'scoped-attachments-updated'(attachments: BacktraceAttachment[]): void;
+    'scoped-attachments-updated': [attachments: BacktraceAttachment[]];
 };

--- a/packages/sdk-core/src/events/AttributeEvents.ts
+++ b/packages/sdk-core/src/events/AttributeEvents.ts
@@ -1,5 +1,5 @@
 import { ReportData } from '../model/report/ReportData.js';
 
 export type AttributeEvents = {
-    'scoped-attributes-updated'(attributes: ReportData): void;
+    'scoped-attributes-updated': [attributes: ReportData];
 };

--- a/packages/sdk-core/src/events/ClientEvents.ts
+++ b/packages/sdk-core/src/events/ClientEvents.ts
@@ -3,13 +3,13 @@ import { BacktraceData } from '../model/data/index.js';
 import { BacktraceReportSubmissionResult, BacktraceSubmissionResponse } from '../model/http/index.js';
 import { BacktraceReport } from '../model/report/BacktraceReport.js';
 
-export type ReportEvents = {
-    'before-skip'(report: BacktraceReport): void;
-    'before-send'(report: BacktraceReport, data: BacktraceData, attachments: BacktraceAttachment[]): void;
-    'after-send'(
+export type ClientEvents = {
+    'before-skip': [report: BacktraceReport];
+    'before-send': [report: BacktraceReport, data: BacktraceData, attachments: BacktraceAttachment[]];
+    'after-send': [
         report: BacktraceReport,
         data: BacktraceData,
         attachments: BacktraceAttachment[],
         result: BacktraceReportSubmissionResult<BacktraceSubmissionResponse>,
-    ): void;
+    ];
 };

--- a/packages/sdk-core/src/modules/BacktraceModule.ts
+++ b/packages/sdk-core/src/modules/BacktraceModule.ts
@@ -1,5 +1,3 @@
-import { Events } from '../common/Events.js';
-import { ReportEvents } from '../events/ReportEvents.js';
 import {
     BacktraceConfiguration,
     BacktraceCoreClient,
@@ -17,7 +15,6 @@ export interface BacktraceModuleBindData {
     readonly options: BacktraceConfiguration;
     readonly attributeManager: AttributeManager;
     readonly attachmentManager: AttachmentManager;
-    readonly reportEvents: Events<ReportEvents>;
     readonly reportSubmission: BacktraceReportSubmission;
     readonly requestHandler: BacktraceRequestHandler;
     readonly database?: BacktraceDatabase;

--- a/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
@@ -66,7 +66,7 @@ export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule
         }
     }
 
-    public bind({ client, reportEvents, attachmentManager }: BacktraceModuleBindData): void {
+    public bind({ client, attachmentManager }: BacktraceModuleBindData): void {
         if (this._storage.getAttachmentProviders) {
             attachmentManager.addProviders(...this._storage.getAttachmentProviders());
         } else {
@@ -77,7 +77,7 @@ export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule
             [BREADCRUMB_ATTRIBUTE_NAME]: this._storage.lastBreadcrumbId,
         }));
 
-        reportEvents.on('before-skip', (report) => this.logReport(report));
+        client.on('before-skip', (report) => this.logReport(report));
     }
 
     public initialize() {

--- a/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
+++ b/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
@@ -82,7 +82,7 @@ export class BacktraceDatabase implements BacktraceModule {
         return true;
     }
 
-    public bind({ reportEvents }: BacktraceModuleBindData): void {
+    public bind({ client }: BacktraceModuleBindData): void {
         if (this._enabled) {
             return;
         }
@@ -91,7 +91,7 @@ export class BacktraceDatabase implements BacktraceModule {
             return;
         }
 
-        reportEvents.on('before-send', (_, data, attachments) => {
+        client.on('before-send', (_, data, attachments) => {
             const record = this.add(data, attachments);
 
             if (!record || record.locked) {
@@ -101,7 +101,7 @@ export class BacktraceDatabase implements BacktraceModule {
             record.locked = true;
         });
 
-        reportEvents.on('after-send', (_, data, __, submissionResult) => {
+        client.on('after-send', (_, data, __, submissionResult) => {
             const record = this._databaseRecordContext.find(
                 (record) => record.type === 'report' && record.data.uuid === data.uuid,
             );

--- a/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
+++ b/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
@@ -6,10 +6,10 @@ import { BacktraceAttachment } from '../../model/attachment/index.js';
 import { BacktraceDatabaseConfiguration } from '../../model/configuration/BacktraceDatabaseConfiguration.js';
 import { BacktraceData } from '../../model/data/BacktraceData.js';
 import { BacktraceReportSubmission } from '../../model/http/BacktraceReportSubmission.js';
-import { BacktraceReportSubmissionResult, BacktraceSubmissionResponse } from '../../model/http/index.js';
 import { BacktraceModule, BacktraceModuleBindData } from '../BacktraceModule.js';
 import { SessionFiles } from '../storage/index.js';
 import { BacktraceDatabaseContext } from './BacktraceDatabaseContext.js';
+import { BacktraceDatabaseEvents } from './BacktraceDatabaseEvents.js';
 import { BacktraceDatabaseStorageProvider } from './BacktraceDatabaseStorageProvider.js';
 import {
     AttachmentBacktraceDatabaseRecord,
@@ -17,16 +17,6 @@ import {
     BacktraceDatabaseRecordCountByType,
     ReportBacktraceDatabaseRecord,
 } from './model/BacktraceDatabaseRecord.js';
-
-type BacktraceDatabaseEvents = {
-    added: [record: BacktraceDatabaseRecord];
-    removed: [record: BacktraceDatabaseRecord];
-    'before-send': [record: BacktraceDatabaseRecord];
-    'after-send': [
-        record: BacktraceDatabaseRecord,
-        result: BacktraceReportSubmissionResult<BacktraceSubmissionResponse>,
-    ];
-};
 
 export class BacktraceDatabase extends Events<BacktraceDatabaseEvents> implements BacktraceModule {
     /**

--- a/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
+++ b/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
@@ -360,6 +360,10 @@ export class BacktraceDatabase implements BacktraceModule {
     }
 
     private async setupDatabaseAutoSend() {
+        if (!this._enabled) {
+            return;
+        }
+
         if (this._options?.autoSend === false) {
             return;
         }

--- a/packages/sdk-core/src/modules/database/BacktraceDatabaseEvents.ts
+++ b/packages/sdk-core/src/modules/database/BacktraceDatabaseEvents.ts
@@ -1,0 +1,13 @@
+import { BacktraceReportSubmissionResult } from '../../model/data/BacktraceSubmissionResult.js';
+import { BacktraceSubmissionResponse } from '../../model/http/index.js';
+import { BacktraceDatabaseRecord } from './model/BacktraceDatabaseRecord.js';
+
+export type BacktraceDatabaseEvents = {
+    added: [record: BacktraceDatabaseRecord];
+    removed: [record: BacktraceDatabaseRecord];
+    'before-send': [record: BacktraceDatabaseRecord];
+    'after-send': [
+        record: BacktraceDatabaseRecord,
+        result: BacktraceReportSubmissionResult<BacktraceSubmissionResponse>,
+    ];
+};

--- a/packages/sdk-core/src/modules/storage/SessionFiles.ts
+++ b/packages/sdk-core/src/modules/storage/SessionFiles.ts
@@ -11,7 +11,7 @@ interface FileSession {
 }
 
 type SessionEvents = {
-    unlocked(): void;
+    unlocked: [];
 };
 
 const SESSION_MARKER_PREFIX = 'bt-session';

--- a/packages/sdk-core/tests/mocks/testHttpClient.ts
+++ b/packages/sdk-core/tests/mocks/testHttpClient.ts
@@ -2,5 +2,5 @@ import { BacktraceReportSubmissionResult, BacktraceRequestHandler } from '../../
 
 export const testHttpClient: BacktraceRequestHandler = {
     post: jest.fn().mockResolvedValue(Promise.resolve(BacktraceReportSubmissionResult.Ok('Ok'))),
-    postError: jest.fn().mockResolvedValue(Promise.resolve()),
+    postError: jest.fn().mockResolvedValue(Promise.resolve(BacktraceReportSubmissionResult.Ok('Ok'))),
 };


### PR DESCRIPTION
This PR adds event support for client directly.

### Client events
You can attach to `before-skip`, `before-send`, and `after-send` events on client instance:

```typescript
const client = BacktraceClient.initialize({ ... });
client.on('after-send', (report, data, attachments, result) => { ... });
```

This is required for me to use in smoketests, so I know if `after-send` is executed after e.g. an exception is thrown.

### Database events
`BacktraceDatabase` now emits events of it's own:

```ts
type BacktraceDatabaseEvents = {
    added: [record: BacktraceDatabaseRecord];
    removed: [record: BacktraceDatabaseRecord];
    'before-send': [record: BacktraceDatabaseRecord];
    'after-send': [
        record: BacktraceDatabaseRecord,
        result: BacktraceReportSubmissionResult<BacktraceSubmissionResponse>,
    ];
};
```