### PR TITLE
sdk-core: unref setinterval

### DIFF
--- a/packages/sdk-core/src/common/intervalHelper.ts
+++ b/packages/sdk-core/src/common/intervalHelper.ts
@@ -1,0 +1,13 @@
+/**
+ * Due to the event loop, NodeJS application might not exit 
+ * due to some background work that the SDK delegates to setIntervals.
+ * Thanks to this helper we can cancell interval in NodeJS process.
+ * @param interval setInterval interval
+ */
+export function unrefInterval(interval: number | NodeJS.Timeout) {
+    if(!interval || typeof interval === 'number') {
+        return;
+    }
+
+    interval.unref();
+}

--- a/packages/sdk-core/src/common/intervalHelper.ts
+++ b/packages/sdk-core/src/common/intervalHelper.ts
@@ -1,11 +1,11 @@
 /**
- * Due to the event loop, NodeJS application might not exit 
+ * Due to the event loop, NodeJS application might not exit
  * due to some background work that the SDK delegates to setIntervals.
  * Thanks to this helper we can cancell interval in NodeJS process.
  * @param interval setInterval interval
  */
 export function unrefInterval(interval: number | NodeJS.Timeout) {
-    if(!interval || typeof interval === 'number') {
+    if (!interval || typeof interval === 'number') {
         return;
     }
 

--- a/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
+++ b/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
@@ -1,5 +1,6 @@
 import { anySignal, createAbortController } from '../../common/AbortController.js';
 import { IdGenerator } from '../../common/IdGenerator.js';
+import { unrefInterval } from '../../common/intervalHelper.js';
 import { TimeHelper } from '../../common/TimeHelper.js';
 import { BacktraceAttachment } from '../../model/attachment/index.js';
 import { BacktraceDatabaseConfiguration } from '../../model/configuration/BacktraceDatabaseConfiguration.js';
@@ -13,7 +14,7 @@ import {
     AttachmentBacktraceDatabaseRecord,
     BacktraceDatabaseRecord,
     BacktraceDatabaseRecordCountByType,
-    ReportBacktraceDatabaseRecord,
+    ReportBacktraceDatabaseRecord
 } from './model/BacktraceDatabaseRecord.js';
 
 export class BacktraceDatabase implements BacktraceModule {
@@ -35,7 +36,7 @@ export class BacktraceDatabase implements BacktraceModule {
 
     private readonly _recordLimits: BacktraceDatabaseRecordCountByType;
     private readonly _retryInterval: number;
-    private _intervalId?: ReturnType<typeof setInterval>;
+    private _intervalId?: NodeJS.Timeout | number;;
 
     private _enabled = false;
 
@@ -368,6 +369,7 @@ export class BacktraceDatabase implements BacktraceModule {
             await this.send();
         };
         this._intervalId = setInterval(sendDatabaseReports, this._retryInterval);
+        unrefInterval(this._intervalId);
         await this.send();
     }
 

--- a/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
+++ b/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
@@ -14,7 +14,7 @@ import {
     AttachmentBacktraceDatabaseRecord,
     BacktraceDatabaseRecord,
     BacktraceDatabaseRecordCountByType,
-    ReportBacktraceDatabaseRecord
+    ReportBacktraceDatabaseRecord,
 } from './model/BacktraceDatabaseRecord.js';
 
 export class BacktraceDatabase implements BacktraceModule {

--- a/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
+++ b/packages/sdk-core/src/modules/database/BacktraceDatabase.ts
@@ -36,7 +36,7 @@ export class BacktraceDatabase implements BacktraceModule {
 
     private readonly _recordLimits: BacktraceDatabaseRecordCountByType;
     private readonly _retryInterval: number;
-    private _intervalId?: NodeJS.Timeout | number;;
+    private _intervalId?: NodeJS.Timeout | number;
 
     private _enabled = false;
 

--- a/packages/sdk-core/src/modules/metrics/BacktraceMetrics.ts
+++ b/packages/sdk-core/src/modules/metrics/BacktraceMetrics.ts
@@ -63,7 +63,6 @@ export class BacktraceMetrics implements BacktraceModule {
             this.handleAbort(() => this.send(this._abortController.signal));
         }, this._updateInterval) as NodeJS.Timeout | number;
 
-
         unrefInterval(this._updateIntervalId);
     }
 

--- a/packages/sdk-core/src/modules/metrics/BacktraceMetrics.ts
+++ b/packages/sdk-core/src/modules/metrics/BacktraceMetrics.ts
@@ -1,11 +1,12 @@
 import { createAbortController } from '../../common/AbortController.js';
 import { AbortError } from '../../common/AbortError.js';
+import { unrefInterval } from '../../common/intervalHelper.js';
 import { TimeHelper } from '../../common/TimeHelper.js';
 import { BacktraceMetricsOptions } from '../../model/configuration/BacktraceConfiguration.js';
 import { AttributeType } from '../../model/data/BacktraceData.js';
-import { BacktraceModule } from '../BacktraceModule.js';
 import { AttributeManager } from '../attribute/AttributeManager.js';
 import { ReportDataBuilder } from '../attribute/ReportDataBuilder.js';
+import { BacktraceModule } from '../BacktraceModule.js';
 import { BacktraceSessionProvider } from './BacktraceSessionProvider.js';
 import { MetricsQueue } from './MetricsQueue.js';
 import { SummedEvent } from './model/SummedEvent.js';
@@ -28,7 +29,7 @@ export class BacktraceMetrics implements BacktraceModule {
     public readonly metricsHost: string;
     private readonly _updateInterval: number;
 
-    private _updateIntervalId?: ReturnType<typeof setTimeout>;
+    private _updateIntervalId?: NodeJS.Timeout | number;
     private readonly _abortController: AbortController;
 
     constructor(
@@ -60,7 +61,10 @@ export class BacktraceMetrics implements BacktraceModule {
         }
         this._updateIntervalId = setInterval(() => {
             this.handleAbort(() => this.send(this._abortController.signal));
-        }, this._updateInterval);
+        }, this._updateInterval) as NodeJS.Timeout | number;
+
+
+        unrefInterval(this._updateIntervalId);
     }
 
     /**


### PR DESCRIPTION
**Why**

This pull request allows to unref a timeout object created by the setInerval function. By doing that we can easily exit a node process, without waiting on the background process work to finish. 