### PR TITLE
sdk-core, node: attribute validation

### DIFF
--- a/packages/node/src/attributes/ApplicationInformationAttributeProvider.ts
+++ b/packages/node/src/attributes/ApplicationInformationAttributeProvider.ts
@@ -36,12 +36,6 @@ export class ApplicationInformationAttributeProvider implements BacktraceAttribu
             this._applicationVersion = this._applicationVersion ?? (applicationData['version'] as string);
         }
 
-        if (!this._application || !this._applicationVersion) {
-            throw new Error(
-                'Cannot find information about the package. Please define application and application.version attribute',
-            );
-        }
-
         return {
             package: applicationData,
             [this.APPLICATION_ATTRIBUTE]: this._application,

--- a/packages/sdk-core/tests/client/clientTests.spec.ts
+++ b/packages/sdk-core/tests/client/clientTests.spec.ts
@@ -1,6 +1,12 @@
 import { BacktraceReport, BacktraceStringAttachment } from '../../src/index.js';
+import { AttributeManager } from '../../src/modules/attribute/AttributeManager.js';
 import { BacktraceTestClient } from '../mocks/BacktraceTestClient.js';
+import { testHttpClient } from '../mocks/testHttpClient.js';
 describe('Client tests', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
     describe('Send tests', () => {
         const client = BacktraceTestClient.buildFakeClient();
 
@@ -126,6 +132,100 @@ describe('Client tests', () => {
                 [clientAttachment, reportAttachment],
                 undefined,
             );
+        });
+    });
+
+    describe('Validation tests', () => {
+        it('should throw on initialize when application and application.version attributes are missing', () => {
+            const instance = new BacktraceTestClient({}, testHttpClient);
+            expect(() => instance.initialize()).toThrow(/application: must be defined and not an empty string/);
+            expect(() => instance.initialize()).toThrow(/application.version: must be defined and not an empty string/);
+        });
+
+        it('should throw on initialize when application attribute is missing', () => {
+            const instance = new BacktraceTestClient({}, testHttpClient, [
+                {
+                    type: 'scoped',
+                    get: () => ({
+                        'application.version': '1.2.3',
+                    }),
+                },
+            ]);
+            expect(() => instance.initialize()).toThrow(/application: must be defined and not an empty string/);
+        });
+
+        it('should throw on initialize when application.version attribute is missing', () => {
+            const instance = new BacktraceTestClient({}, testHttpClient, [
+                {
+                    type: 'scoped',
+                    get: () => ({
+                        application: 'my-app',
+                    }),
+                },
+            ]);
+            expect(() => instance.initialize()).toThrow(/application.version: must be defined and not an empty string/);
+        });
+
+        it('should not throw on initialize when application and application.version attributes are defined as scoped', () => {
+            const instance = new BacktraceTestClient({}, testHttpClient, [
+                {
+                    type: 'scoped',
+                    get: () => ({
+                        application: 'my-app',
+                        'application.version': '1.2.3',
+                    }),
+                },
+            ]);
+            expect(() => instance.initialize()).not.toThrow();
+        });
+
+        it('should not throw on initialize when application and application.version attributes are defined as dynamic', () => {
+            const instance = new BacktraceTestClient({}, testHttpClient, [
+                {
+                    type: 'dynamic',
+                    get: () => ({
+                        application: 'my-app',
+                        'application.version': '1.2.3',
+                    }),
+                },
+            ]);
+            expect(() => instance.initialize()).not.toThrow();
+        });
+
+        it('should only test scoped attributes and not all when application and application.version attributes are defined as scoped', () => {
+            const instance = new BacktraceTestClient({}, testHttpClient, [
+                {
+                    type: 'scoped',
+                    get: () => ({
+                        application: 'my-app',
+                        'application.version': '1.2.3',
+                    }),
+                },
+            ]);
+
+            const getAttributesSpy = jest.spyOn(AttributeManager.prototype, 'get');
+            instance.initialize();
+
+            expect(getAttributesSpy).toHaveBeenCalledWith('scoped');
+            expect(getAttributesSpy).not.toHaveBeenCalledWith();
+        });
+
+        it('should test both scoped attributes and all when application and application.version attributes are defined as dynamic', () => {
+            const instance = new BacktraceTestClient({}, testHttpClient, [
+                {
+                    type: 'dynamic',
+                    get: () => ({
+                        application: 'my-app',
+                        'application.version': '1.2.3',
+                    }),
+                },
+            ]);
+
+            const getAttributesSpy = jest.spyOn(AttributeManager.prototype, 'get');
+            instance.initialize();
+
+            expect(getAttributesSpy).toHaveBeenCalledWith('scoped');
+            expect(getAttributesSpy).toHaveBeenCalledWith();
         });
     });
 });


### PR DESCRIPTION
This PR adds attribute validation on initialize, which checks the following attributes:
* `application`
* `application.version`

This also removes the check from `node`.