### PR TITLE
node: version 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26753,7 +26753,7 @@
             "version": "0.5.0",
             "license": "MIT",
             "dependencies": {
-                "@backtrace/node": "^0.5.0"
+                "@backtrace/node": "^0.6.0"
             },
             "devDependencies": {
                 "@rollup/plugin-commonjs": "^26.0.1",
@@ -26811,7 +26811,7 @@
             "version": "0.4.1",
             "license": "MIT",
             "dependencies": {
-                "@backtrace/node": "^0.5.0"
+                "@backtrace/node": "^0.6.0"
             },
             "devDependencies": {
                 "@nestjs/core": "^10",
@@ -26876,7 +26876,7 @@
         },
         "packages/node": {
             "name": "@backtrace/node",
-            "version": "0.5.0",
+            "version": "0.6.0",
             "license": "MIT",
             "dependencies": {
                 "@backtrace/sdk-core": "^0.6.0",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -89,7 +89,7 @@
         "/renderer"
     ],
     "dependencies": {
-        "@backtrace/node": "^0.5.0"
+        "@backtrace/node": "^0.6.0"
     },
     "peerDependencies": {
         "electron": "12 - 28"

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -62,7 +62,7 @@
         "typescript": "^5.0.4"
     },
     "dependencies": {
-        "@backtrace/node": "^0.5.0"
+        "@backtrace/node": "^0.6.0"
     },
     "peerDependencies": {
         "@nestjs/common": "^9 || ^10"

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 0.6.0
+
+-   update `@backtrace/sdk-core` to `0.6.0`
+-   reduce breadcrumbs size (#228)
+-   use `application` and `application.version` attribute validation from `sdk-core` (#296)
+
 # Version 0.5.0
 
 -   update `@backtrace/sdk-core` to `0.5.0`

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/node",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "description": "Backtrace-JavaScript Node.JS integration",
     "main": "lib/bundle.cjs",
     "module": "lib/bundle.mjs",


### PR DESCRIPTION
-   update `@backtrace/sdk-core` to `0.6.0`
-   reduce breadcrumbs size (#228)
-   use `application` and `application.version` attribute validation from `sdk-core` (#296)