### PR TITLE
electron: version 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26750,7 +26750,7 @@
         },
         "packages/electron": {
             "name": "@backtrace/electron",
-            "version": "0.5.0",
+            "version": "0.6.0",
             "license": "MIT",
             "dependencies": {
                 "@backtrace/node": "^0.6.0"

--- a/packages/electron/CHANGELOG.md
+++ b/packages/electron/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.6.0
+
+-   update `@backtrace/node` to `0.6.0`
+-   reduce breadcrumb size (#231)
+
 # Version 0.5.0
 
 -   update `@backtrace/node` to `0.5.0`

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/electron",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "description": "Backtrace-JavaScript Electron integration",
     "main": "./main/index.cjs",
     "module": "./main/index.mjs",


### PR DESCRIPTION
-   update `@backtrace/node` to `0.6.0`
-   reduce breadcrumb size (#231)