### PR TITLE
repo: add CONTRIBUTING.md document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,148 @@
+<!-- omit in toc -->
+
+# Contributing to Backtrace Javascript SDK
+
+First off, thanks for taking the time to contribute! ❤️
+
+All types of contributions are encouraged and valued. See the [Table of Contents](#table-of-contents) for different ways to help and details about how this project handles them. Please make sure to read the relevant section before making your contribution. It will make it a lot easier for us maintainers and smooth out the experience for all involved. The community looks forward to your contributions. 🎉
+
+> And if you like the project, but just don't have time to contribute, that's fine. There are other easy ways to support the project and show your appreciation, which we would also be very happy about:
+>
+> -   Star the project
+> -   Refer this project in your project's readme
+> -   Mention the project at local meetups and tell your friends/colleagues
+
+<!-- omit in toc -->
+
+## Table of Contents
+
+-   [Code of Conduct](#code-of-conduct)
+-   [I Have a Question](#i-have-a-question)
+-   [I Want To Contribute](#i-want-to-contribute)
+-   [Reporting Bugs](#reporting-bugs)
+-   [Suggesting Enhancements](#suggesting-enhancements)
+-   [Your First Code Contribution](#your-first-code-contribution)
+-   [Improving The Documentation](#improving-the-documentation)
+-   [Styleguides](#styleguides)
+-   [Commit Messages](#commit-messages)
+-   [Join The Project Team](#join-the-project-team)
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the
+[Sauce Labs Code of Conduct](https://docs.saucelabs.com/contributing/code-of-conduct/).
+By participating, you are expected to uphold this code. Please report unacceptable behavior
+to opensource@saucelabs.com.
+
+## I Have a Question
+
+Before you ask a question, it is best to search for existing [Issues](/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue.
+
+If you then still feel the need to ask a question and need clarification, we recommend the following:
+
+-   Open an [Issue](/issues/new).
+-   Provide as much context as you can about what you're running into.
+-   Provide project and platform versions (nodejs, npm, SDK version, etc), depending on what seems relevant.
+
+We will then take care of the issue as soon as possible.
+
+## I Want To Contribute
+
+> ### Legal Notice <!-- omit in toc -->
+>
+> When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content and that the content you contribute may be provided under the project license.
+
+### Reporting Bugs
+
+<!-- omit in toc -->
+
+#### Before Submitting a Bug Report
+
+A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we ask you to investigate carefully, collect information and describe the issue in detail in your report. Please complete the following steps in advance to help us fix any potential bug as fast as possible.
+
+-   Make sure that you are using the latest version.
+-   Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the relevant SDK documentation. If you are looking for support, you might want to check [this section](#i-have-a-question)).
+-   To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](issues?q=label%3Abug).
+-   Also make sure to search the internet (including Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
+-   Collect information about the bug:
+-   Stack trace (Traceback)
+-   OS, Platform and Version
+-   Version of the runtime environment, SDK version, tooling version, package manager, depending on what seems relevant.
+-   Possibly your input and the output
+-   Can you reliably reproduce the issue? And can you also reproduce it with older versions?
+
+<!-- omit in toc -->
+
+#### How Do I Submit a Good Bug Report?
+
+> You must never report security related issues, vulnerabilities or bugs including sensitive information to the issue tracker, or elsewhere in public. Instead sensitive bugs must be sent by email to security@backtrace.io.
+
+We use GitHub issues to track bugs and errors. If you run into an issue with the project:
+
+-   Open an [Issue](/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
+-   Explain the behavior you would expect and the actual behavior.
+-   Please provide as much context as possible and describe the _reproduction steps_ that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
+-   Provide the information you collected in the previous section.
+
+Once it's filed:
+
+-   The project team will label the issue accordingly.
+-   A team member will try to reproduce the issue with your provided steps. If there are no reproduction steps or no obvious way to reproduce the issue, the team will ask you for those steps and mark the issue as `needs-repro`. Bugs with the `needs-repro` tag will not be addressed until they are reproduced.
+-   If the team is able to reproduce the issue, it will be marked `needs-fix`, as well as possibly other tags (such as `critical`), and the issue will be left to be [implemented by someone](#your-first-code-contribution).
+
+### Suggesting Enhancements
+
+This section guides you through submitting an enhancement suggestion for Backtrace Javascript SDK, **including completely new features and minor improvements to existing functionality**. Following these guidelines will help maintainers and the community to understand your suggestion and find related suggestions.
+
+<!-- omit in toc -->
+
+#### Before Submitting an Enhancement
+
+-   Make sure that you are using the latest version.
+-   Read the relevant SDK/tooling documentation carefully and find out if the functionality is already covered, maybe by an individual configuration.
+-   Perform a [search](/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+-   Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
+
+<!-- omit in toc -->
+
+#### How Do I Submit a Good Enhancement Suggestion?
+
+Enhancement suggestions are tracked as [GitHub issues](/issues).
+
+-   Use a **clear and descriptive title** with valid prefix for the issue to identify the suggestion.
+    -   We use **squash commits** when merging pull requests, so the title should resemble a [commit message](#commit-messages)
+-   Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
+-   **Describe the current behavior** and **explain which behavior you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
+-   **Explain why this enhancement would be useful** to most Backtrace Javascript SDK users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
+
+### Your First Code Contribution
+
+-   Make sure to use `npm` that support workspaces
+-   Add unit tests/smoketests for your change
+-   Run an example with your code change and check the basic functionality
+-   If this is a public API change:
+    -   try to not introduce breaking changes if possible
+    -   update the documentation
+
+## Styleguides
+
+### Commit Messages
+
+Commit message should be short and descriptive of the change. They must also include a valid prefix containing the name of the changed package(s), e.g. `sdk-core` or `node`, separated by commas. If the change is specific to a file, you may use its name in the message.
+
+It is best to keep separate package changes in separate commits, if possible.
+
+Valid examples of commits:
+
+-   `sdk-core: fix invalid ID in breadcrumb generation`
+-   `node: add CPU type to MachineAttributeProvider.ts`
+-   `sdk-core, node: add FileSystem.doesExist`
+
+Commit messages to avoid:
+
+-   `sdk-core: fix error` (ambiguous message - what was the error?)
+-   `change error message in Node on invalid breadcrumb` (missing package prefix)
+
+## Attribution
+
+This guide is based on the **contributing-gen**. [Make your own](https://github.com/bttger/contributing-gen)!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,3 @@
-<!-- omit in toc -->
-
 # Contributing to Backtrace Javascript SDK
 
 First off, thanks for taking the time to contribute! ❤️
@@ -12,20 +10,14 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 > -   Refer this project in your project's readme
 > -   Mention the project at local meetups and tell your friends/colleagues
 
-<!-- omit in toc -->
-
 ## Table of Contents
 
 -   [Code of Conduct](#code-of-conduct)
 -   [I Have a Question](#i-have-a-question)
 -   [I Want To Contribute](#i-want-to-contribute)
--   [Reporting Bugs](#reporting-bugs)
--   [Suggesting Enhancements](#suggesting-enhancements)
--   [Your First Code Contribution](#your-first-code-contribution)
--   [Improving The Documentation](#improving-the-documentation)
+    -   [Your First Code Contribution](#your-first-code-contribution)
 -   [Styleguides](#styleguides)
--   [Commit Messages](#commit-messages)
--   [Join The Project Team](#join-the-project-team)
+    -   [Commit Messages](#commit-messages)
 
 ## Code of Conduct
 
@@ -36,93 +28,24 @@ to opensource@saucelabs.com.
 
 ## I Have a Question
 
-Before you ask a question, it is best to search for existing [Issues](/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue.
-
-If you then still feel the need to ask a question and need clarification, we recommend the following:
-
--   Open an [Issue](/issues/new).
--   Provide as much context as you can about what you're running into.
--   Provide project and platform versions (nodejs, npm, SDK version, etc), depending on what seems relevant.
-
-We will then take care of the issue as soon as possible.
+If you have a question about setting up the SDK or using the tooling, or you believe that you found a bug,
+please contact us at support@backtrace.io!
 
 ## I Want To Contribute
 
-> ### Legal Notice <!-- omit in toc -->
+> ### Legal Notice
 >
 > When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content and that the content you contribute may be provided under the project license.
 
-### Reporting Bugs
-
-<!-- omit in toc -->
-
-#### Before Submitting a Bug Report
-
-A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we ask you to investigate carefully, collect information and describe the issue in detail in your report. Please complete the following steps in advance to help us fix any potential bug as fast as possible.
-
--   Make sure that you are using the latest version.
--   Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the relevant SDK documentation. If you are looking for support, you might want to check [this section](#i-have-a-question)).
--   To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](issues?q=label%3Abug).
--   Also make sure to search the internet (including Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
--   Collect information about the bug:
--   Stack trace (Traceback)
--   OS, Platform and Version
--   Version of the runtime environment, SDK version, tooling version, package manager, depending on what seems relevant.
--   Possibly your input and the output
--   Can you reliably reproduce the issue? And can you also reproduce it with older versions?
-
-<!-- omit in toc -->
-
-#### How Do I Submit a Good Bug Report?
-
-> You must never report security related issues, vulnerabilities or bugs including sensitive information to the issue tracker, or elsewhere in public. Instead sensitive bugs must be sent by email to security@backtrace.io.
-
-We use GitHub issues to track bugs and errors. If you run into an issue with the project:
-
--   Open an [Issue](/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
--   Explain the behavior you would expect and the actual behavior.
--   Please provide as much context as possible and describe the _reproduction steps_ that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
--   Provide the information you collected in the previous section.
-
-Once it's filed:
-
--   The project team will label the issue accordingly.
--   A team member will try to reproduce the issue with your provided steps. If there are no reproduction steps or no obvious way to reproduce the issue, the team will ask you for those steps and mark the issue as `needs-repro`. Bugs with the `needs-repro` tag will not be addressed until they are reproduced.
--   If the team is able to reproduce the issue, it will be marked `needs-fix`, as well as possibly other tags (such as `critical`), and the issue will be left to be [implemented by someone](#your-first-code-contribution).
-
-### Suggesting Enhancements
-
-This section guides you through submitting an enhancement suggestion for Backtrace Javascript SDK, **including completely new features and minor improvements to existing functionality**. Following these guidelines will help maintainers and the community to understand your suggestion and find related suggestions.
-
-<!-- omit in toc -->
-
-#### Before Submitting an Enhancement
-
--   Make sure that you are using the latest version.
--   Read the relevant SDK/tooling documentation carefully and find out if the functionality is already covered, maybe by an individual configuration.
--   Perform a [search](/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
--   Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
-
-<!-- omit in toc -->
-
-#### How Do I Submit a Good Enhancement Suggestion?
-
-Enhancement suggestions are tracked as [GitHub issues](/issues).
-
--   Use a **clear and descriptive title** with valid prefix for the issue to identify the suggestion.
-    -   We use **squash commits** when merging pull requests, so the title should resemble a [commit message](#commit-messages)
--   Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
--   **Describe the current behavior** and **explain which behavior you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
--   **Explain why this enhancement would be useful** to most Backtrace Javascript SDK users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
-
 ### Your First Code Contribution
 
--   Make sure to use `npm` that support workspaces
+-   Make sure to use `npm` version that support workspaces
 -   Add unit tests/smoketests for your change
 -   Run an example with your code change and check the basic functionality
 -   If this is a public API change:
     -   try to not introduce breaking changes if possible
     -   update the documentation
+-   Please follow our [styleguides](#styleguides)
 
 ## Styleguides
 
@@ -142,7 +65,3 @@ Commit messages to avoid:
 
 -   `sdk-core: fix error` (ambiguous message - what was the error?)
 -   `change error message in Node on invalid breadcrumb` (missing package prefix)
-
-## Attribution
-
-This guide is based on the **contributing-gen**. [Make your own](https://github.com/bttger/contributing-gen)!


### PR DESCRIPTION
This PR adds a `CONTRIBUTING.md` document describing our requirements and needs for contributing to the project.

Generated with https://generator.contributing.md/, then adopted to our repository.