### PR TITLE
node: fix invalid breadcrumb name in FileBreadcrumbsStorage

### DIFF
--- a/packages/node/src/breadcrumbs/FileBreadcrumbsStorage.ts
+++ b/packages/node/src/breadcrumbs/FileBreadcrumbsStorage.ts
@@ -94,7 +94,7 @@ export class FileBreadcrumbsStorage implements BreadcrumbsStorage {
             {
                 get: () => {
                     const files = [...this._sink.files].map((f) => f.path.toString('utf-8'));
-                    return files.map((f) => new BacktraceFileAttachment(f, f, this._fileSystem));
+                    return files.map((f) => new BacktraceFileAttachment(f, path.basename(f), this._fileSystem));
                 },
                 type: 'dynamic',
             },

--- a/packages/node/src/breadcrumbs/FileBreadcrumbsStorage.ts
+++ b/packages/node/src/breadcrumbs/FileBreadcrumbsStorage.ts
@@ -86,16 +86,13 @@ export class FileBreadcrumbsStorage implements BreadcrumbsStorage {
 
     public getAttachments(): BacktraceAttachment<Readable>[] {
         const files = [...this._sink.files].map((f) => f.path.toString('utf-8'));
-        return files.map((f) => new BacktraceFileAttachment(f, f, this._fileSystem));
+        return files.map((f) => new BacktraceFileAttachment(f, path.basename(f), this._fileSystem));
     }
 
     public getAttachmentProviders(): BacktraceAttachmentProvider[] {
         return [
             {
-                get: () => {
-                    const files = [...this._sink.files].map((f) => f.path.toString('utf-8'));
-                    return files.map((f) => new BacktraceFileAttachment(f, path.basename(f), this._fileSystem));
-                },
+                get: () => this.getAttachments(),
                 type: 'dynamic',
             },
         ];


### PR DESCRIPTION
The breadcrumb name was set to file path, resulting in UI not being able to pick up the breadcrumbs.

This PR fixes the issue.