### PR TITLE
node: version 0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26771,7 +26771,7 @@
             "version": "0.6.0",
             "license": "MIT",
             "dependencies": {
-                "@backtrace/node": "^0.6.0"
+                "@backtrace/node": "^0.6.1"
             },
             "devDependencies": {
                 "@rollup/plugin-commonjs": "^26.0.1",
@@ -26829,7 +26829,7 @@
             "version": "0.5.0",
             "license": "MIT",
             "dependencies": {
-                "@backtrace/node": "^0.6.0"
+                "@backtrace/node": "^0.6.1"
             },
             "devDependencies": {
                 "@nestjs/core": "^10",
@@ -26894,7 +26894,7 @@
         },
         "packages/node": {
             "name": "@backtrace/node",
-            "version": "0.6.0",
+            "version": "0.6.1",
             "license": "MIT",
             "dependencies": {
                 "@backtrace/sdk-core": "^0.6.0",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -89,7 +89,7 @@
         "/renderer"
     ],
     "dependencies": {
-        "@backtrace/node": "^0.6.0"
+        "@backtrace/node": "^0.6.1"
     },
     "peerDependencies": {
         "electron": "12 - 28"

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -62,7 +62,7 @@
         "typescript": "^5.0.4"
     },
     "dependencies": {
-        "@backtrace/node": "^0.6.0"
+        "@backtrace/node": "^0.6.1"
     },
     "peerDependencies": {
         "@nestjs/common": "^9 || ^10"

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.6.1
+
+-   fix invalid breadcrumb name in `FileBreadcrumbsStorage` (#303)
+
 # Version 0.6.0
 
 -   update `@backtrace/sdk-core` to `0.6.0`

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/node",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "Backtrace-JavaScript Node.JS integration",
     "main": "lib/bundle.cjs",
     "module": "lib/bundle.mjs",


### PR DESCRIPTION
-   fix invalid breadcrumb name in `FileBreadcrumbsStorage` (#303)