### PR TITLE
react-native: fix previous sessions not being cleared

### DIFF
--- a/packages/react-native/android/src/main/java/backtrace/library/BacktraceDirectoryProvider.java
+++ b/packages/react-native/android/src/main/java/backtrace/library/BacktraceDirectoryProvider.java
@@ -39,7 +39,7 @@ public class BacktraceDirectoryProvider extends ReactContextBaseJavaModule {
 
         WritableArray array = new WritableNativeArray();
         for (File directoryFile : file.listFiles()) {
-            array.pushString(directoryFile.getPath());
+            array.pushString(directoryFile.getName());
         }
 
         return array;

--- a/packages/react-native/src/BacktraceClient.ts
+++ b/packages/react-native/src/BacktraceClient.ts
@@ -82,9 +82,8 @@ export class BacktraceClient extends BacktraceCoreClient<BacktraceConfiguration>
             );
 
             this.initializeNativeCrashReporter();
-        } catch (err) {
+        } finally {
             lockId && this.sessionFiles?.unlockPreviousSessions(lockId);
-            throw err;
         }
     }
 


### PR DESCRIPTION
This PR fixes previous sessions not being cleared, even if they are not locked.
The reasons were:
* Android implementation of `readDirSync` returned full paths instead of file names (suprisingly, asynchronous `readDir` is implemented correctly)
* previous sessions were not unlocked when error was not thrown in `BacktraceClient.initialize` (replaced `catch` with `finally`