### PR TITLE
react-native: remove invalid imports from iOS headers

### DIFF
--- a/packages/react-native/ios/BacktraceApplicationAttributeProvider.h
+++ b/packages/react-native/ios/BacktraceApplicationAttributeProvider.h
@@ -1,12 +1,5 @@
-
-#ifdef RCT_NEW_ARCH_ENABLED
-#import "RNBacktraceReactNativeSpec.h"
-
-@interface BacktraceApplicationAttributeProvider : NSObject <NativeBacktraceReactNativeSpec>
-#else
 #import <React/RCTBridgeModule.h>
 
 @interface BacktraceApplicationAttributeProvider : NSObject <RCTBridgeModule>
-#endif
 
 @end

--- a/packages/react-native/ios/BacktraceCpuAttributeProvider.h
+++ b/packages/react-native/ios/BacktraceCpuAttributeProvider.h
@@ -1,12 +1,6 @@
-#ifdef RCT_NEW_ARCH_ENABLED
-#import "RNBacktraceReactNativeSpec.h"
-
-@interface BacktraceCpuAttributeProvider : NSObject <NativeBacktraceReactNativeSpec>
-#else
 #import <React/RCTBridgeModule.h>
 
 @interface BacktraceCpuAttributeProvider : NSObject <RCTBridgeModule>
-#endif
 
 @end
 

--- a/packages/react-native/ios/BacktraceDeviceAttributeProvider.h
+++ b/packages/react-native/ios/BacktraceDeviceAttributeProvider.h
@@ -1,12 +1,6 @@
-#ifdef RCT_NEW_ARCH_ENABLED
-#import "RNBacktraceReactNativeSpec.h"
-
-@interface BacktraceDeviceAttributeProvider : NSObject <NativeBacktraceReactNativeSpec>
-#else
 #import <React/RCTBridgeModule.h>
 
 @interface BacktraceDeviceAttributeProvider : NSObject <RCTBridgeModule>
-#endif
 
 @end
 

--- a/packages/react-native/ios/BacktraceDirectoryProvider.h
+++ b/packages/react-native/ios/BacktraceDirectoryProvider.h
@@ -1,12 +1,6 @@
-#ifdef RCT_NEW_ARCH_ENABLED
-#import "RNBacktraceReactNativeSpec.h"
-
-@interface BacktraceDirectoryProvider : NSObject <NativeBacktraceReactNativeSpec>
-#else
 #import <React/RCTBridgeModule.h>
 
 @interface BacktraceDirectoryProvider : NSObject <RCTBridgeModule>
-#endif
 
 @end
 

--- a/packages/react-native/ios/BacktraceFileSystemProvider.h
+++ b/packages/react-native/ios/BacktraceFileSystemProvider.h
@@ -1,12 +1,6 @@
-#ifdef RCT_NEW_ARCH_ENABLED
-#import "RNBacktraceReactNativeSpec.h"
-
-@interface BacktraceFileSystemProvider : NSObject <NativeBacktraceReactNativeSpec>
-#else
 #import <React/RCTBridgeModule.h>
 
 @interface BacktraceFileSystemProvider : NSObject <RCTBridgeModule>
-#endif
 
 @end
 

--- a/packages/react-native/ios/BacktraceMemoryUsageAttributeProvider.h
+++ b/packages/react-native/ios/BacktraceMemoryUsageAttributeProvider.h
@@ -1,11 +1,5 @@
-#ifdef RCT_NEW_ARCH_ENABLED
-#import "RNBacktraceReactNativeSpec.h"
-
-@interface BacktraceMemoryUsageAttributeProvider : NSObject <NativeBacktraceReactNativeSpec>
-#else
 #import <React/RCTBridgeModule.h>
 
 @interface BacktraceMemoryUsageAttributeProvider : NSObject <RCTBridgeModule>
-#endif
 
 @end

--- a/packages/react-native/ios/BacktraceReactNative.h
+++ b/packages/react-native/ios/BacktraceReactNative.h
@@ -1,12 +1,5 @@
-
-#ifdef RCT_NEW_ARCH_ENABLED
-#import "RNBacktraceReactNativeSpec.h"
-
-@interface BacktraceReactNative : NSObject <NativeBacktraceReactNativeSpec>
-#else
 #import <React/RCTBridgeModule.h>
 
 @interface BacktraceReactNative : NSObject <RCTBridgeModule>
-#endif
 
 @end

--- a/packages/react-native/ios/BacktraceSystemAttributeProvider.h
+++ b/packages/react-native/ios/BacktraceSystemAttributeProvider.h
@@ -1,12 +1,6 @@
-#ifdef RCT_NEW_ARCH_ENABLED
-#import "RNBacktraceReactNativeSpec.h"
-
-@interface BacktraceSystemAttributeProvider : NSObject <NativeBacktraceReactNativeSpec>
-#else
 #import <React/RCTBridgeModule.h>
 
 @interface BacktraceSystemAttributeProvider : NSObject <RCTBridgeModule>
-#endif
 
 @end
 

--- a/packages/react-native/ios/StreamWriter.h
+++ b/packages/react-native/ios/StreamWriter.h
@@ -1,12 +1,6 @@
-#ifdef RCT_NEW_ARCH_ENABLED
-#import "RNBacktraceReactNativeSpec.h"
-
-@interface StreamWriter : NSObject <NativeBacktraceReactNativeSpec>
-#else
 #import <React/RCTBridgeModule.h>
 
 @interface StreamWriter : NSObject <RCTBridgeModule>
-#endif
 
 @end
 


### PR DESCRIPTION
This PR removes invalid imports in iOS headers for new architecture, causing build errors when switching to new architecture.