### PR TITLE
react-native: fix invalid RN object returned from iOS BacktraceReactNative.initialize function

### DIFF
--- a/packages/react-native/ios/BacktraceReactNative.mm
+++ b/packages/react-native/ios/BacktraceReactNative.mm
@@ -15,7 +15,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(initialize:(NSString*)submissionUrl
     }
     instance = [[BacktraceCrashReporter alloc] initWithBacktraceUrl:submissionUrl andDatabasePath: databasePath andAttributes: attributes andOomSupport:TRUE andAttachments:attachmentPaths];
     [instance start];
-    return instance;
+    return nil;
 }
 
 RCT_EXPORT_METHOD(useAttachments: (NSArray*) attachmentPaths) {


### PR DESCRIPTION
This PR returns `nil` instead of `instance` from `BacktraceReactNative.initialize`, as the `instance` object was impossible to serialize to JSON.

https://reactnative.dev/docs/0.70/native-modules-ios#synchronous-methods
>The return type of this method must be of object type (id) and should be serializable to JSON. This means that the hook can only return nil or JSON values (e.g. NSNumber, NSString, NSArray, NSDictionary).