### PR TITLE
nestjs: fix skipIfClientUndefined not working in BacktraceModule

### DIFF
--- a/packages/nestjs/src/backtrace.module.ts
+++ b/packages/nestjs/src/backtrace.module.ts
@@ -40,7 +40,12 @@ const { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN } = new ConfigurableModule
                     (instanceOrOptions instanceof BacktraceClient ? instanceOrOptions : instanceOrOptions?.client) ??
                     BacktraceClient.instance;
 
-                if (!instance) {
+                const skipIfClientUndefined =
+                    instanceOrOptions instanceof BacktraceClient
+                        ? false
+                        : instanceOrOptions?.options?.skipIfClientUndefined;
+
+                if (!instance && !skipIfClientUndefined) {
                     throw new Error(
                         'Backtrace instance is not available. Initialize it first, or pass it into the module using register/registerAsync.',
                     );

--- a/packages/nestjs/tests/backtrace.module.spec.ts
+++ b/packages/nestjs/tests/backtrace.module.spec.ts
@@ -56,4 +56,18 @@ describe('BacktraceModule', () => {
             }).compile(),
         ).rejects.toThrowError(/Backtrace instance is not available\./);
     });
+
+    it('should not throw an error when instance is not initialized and skipIfClientUndefined is true', async () => {
+        await expect(
+            Test.createTestingModule({
+                imports: [
+                    BacktraceModule.register({
+                        options: {
+                            skipIfClientUndefined: true,
+                        },
+                    }),
+                ],
+            }).compile(),
+        ).resolves.not.toThrow();
+    });
 });


### PR DESCRIPTION
This PR fixes the bug that caused an error to be thrown when registering `BacktraceModule` if the instance was uninitialized, regardless of the `skipIfClientUndefined` setting.