### PR TITLE
nestjs: version 0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26826,7 +26826,7 @@
         },
         "packages/nestjs": {
             "name": "@backtrace/nestjs",
-            "version": "0.5.0",
+            "version": "0.5.1",
             "license": "MIT",
             "dependencies": {
                 "@backtrace/node": "^0.6.1"

--- a/packages/nestjs/CHANGELOG.md
+++ b/packages/nestjs/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.5.1
+
+-   fix `skipIfClientUndefined` not working in `BacktraceModule` (#309)
+
 # Version 0.5.0
 
 -   update `@backtrace/node` to `0.6.0`

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/nestjs",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "description": "Backtrace-JavaScript NestJS integration",
     "main": "lib/bundle.cjs",
     "module": "lib/bundle.mjs",


### PR DESCRIPTION
-   fix `skipIfClientUndefined` not working in `BacktraceModule` (#309)