### PR TITLE
electron: change default electron version to the latest

### DIFF
--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -92,7 +92,7 @@
         "@backtrace/node": "^0.6.1"
     },
     "peerDependencies": {
-        "electron": "12 - 28"
+        "electron": ">=12"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^26.0.1",


### PR DESCRIPTION
# Why

Our customers keep asking us to bump the electron version. This pull request requires a minimal electron version instead of us manually updating the maximum electron version.