### PR TITLE
electron: version 0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26768,7 +26768,7 @@
         },
         "packages/electron": {
             "name": "@backtrace/electron",
-            "version": "0.6.0",
+            "version": "0.6.1",
             "license": "MIT",
             "dependencies": {
                 "@backtrace/node": "^0.6.1"
@@ -26787,7 +26787,7 @@
                 "typescript": "^5.0.4"
             },
             "peerDependencies": {
-                "electron": "12 - 28"
+                "electron": ">=12"
             }
         },
         "packages/electron/node_modules/rollup": {

--- a/packages/electron/CHANGELOG.md
+++ b/packages/electron/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Version 0.6.1
 
 -   update `@backtrace/node` to `0.6.1`
--   change default electron version to the latest (#309)
+-   change the default electron version to the latest (#311)
 
 # Version 0.6.0
 

--- a/packages/electron/CHANGELOG.md
+++ b/packages/electron/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.6.1
+
+-   update `@backtrace/node` to `0.6.1`
+-   change default electron version to the latest (#309)
+
 # Version 0.6.0
 
 -   update `@backtrace/node` to `0.6.0`

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/electron",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "Backtrace-JavaScript Electron integration",
     "main": "./main/index.cjs",
     "module": "./main/index.mjs",


### PR DESCRIPTION
# Version 0.6.1

-   update `@backtrace/node` to `0.6.1`
-   change the default electron version to the latest (#311)