### PR TITLE
all: clean and build dependencies in prepublishOnly scripts (NFC)

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -12,7 +12,7 @@
         "clean": "rimraf \"lib\"",
         "format": "prettier --write '**/*.ts'",
         "lint": "eslint . --ext .ts",
-        "prepublishOnly": "cross-env NODE_ENV=production npm run build",
+        "prepublishOnly": "npm -w ../sdk-core run prepublishOnly && npm run clean && cross-env NODE_ENV=production npm run build",
         "watch": "concurrently \"tsc -p tsconfig.build.json --noEmit --watch\" \"rollup -c rollup.config.mjs --watch\"",
         "test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" NODE_NO_WARNINGS=1 NODE_ENV=test jest"
     },

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -64,7 +64,7 @@
         "clean": "rimraf main renderer common",
         "format": "prettier --write '**/*.ts'",
         "lint": "eslint src --ext .ts",
-        "prepublishOnly": "cross-env NODE_ENV=production npm run build",
+        "prepublishOnly": "npm run clean && cross-env NODE_ENV=production npm run build",
         "watch": "concurrently \"tsc -p tsconfig.main.json --noEmit --watch\" \"tsc -p tsconfig.renderer.json --noEmit --watch\" \"rollup -c rollup.config.mjs --watch\""
     },
     "keywords": [

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -11,7 +11,7 @@
         "clean": "rimraf \"lib\"",
         "format": "prettier --write '**/*.ts'",
         "lint": "eslint . --ext .ts",
-        "prepublishOnly": "cross-env NODE_ENV=production npm run build",
+        "prepublishOnly": "npm run clean && cross-env NODE_ENV=production npm run build",
         "watch": "concurrently \"tsc -p tsconfig.build.json --noEmit --watch\" \"rollup -c rollup.config.mjs --watch\"",
         "test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" NODE_NO_WARNINGS=1 NODE_ENV=test jest"
     },

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -11,7 +11,7 @@
         "clean": "rimraf lib tsconfig.tsbuildinfo",
         "format": "prettier --write '**/*.ts'",
         "lint": "eslint . --ext .ts",
-        "prepublishOnly": "cross-env NODE_ENV=production npm run build",
+        "prepublishOnly": "npm run clean && cross-env NODE_ENV=production npm run build",
         "watch": "concurrently \"tsc -p tsconfig.build.json --noEmit --watch\" \"rollup -c rollup.config.mjs --watch\"",
         "test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" NODE_NO_WARNINGS=1 NODE_ENV=test jest"
     },

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -30,7 +30,7 @@
         "build": "bob build",
         "clean": "rimraf \"lib\"",
         "format:check": "eslint \"**/*.{js,ts,tsx}\"",
-        "prepublishOnly": "bob build",
+        "prepublishOnly": "npm run clean && cross-env NODE_ENV=production bob build",
         "test": "cross-env NODE_ENV=test jest"
     },
     "keywords": [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,7 +12,7 @@
         "clean": "rimraf \"lib\"",
         "format": "prettier --write '**/*.ts'",
         "lint": "eslint . --ext .ts",
-        "prepublishOnly": "cross-env NODE_ENV=production npm run build",
+        "prepublishOnly": "npm -w ../browser run prepublishOnly && npm run clean && cross-env NODE_ENV=production npm run build",
         "watch": "concurrently \"tsc -p tsconfig.build.json --noEmit --watch\" \"rollup -c rollup.config.mjs --watch\"",
         "test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" NODE_NO_WARNINGS=1 NODE_ENV=test jest"
     },

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -12,7 +12,8 @@
         "format": "prettier --write '**/*.ts'",
         "lint": "eslint . --ext .ts",
         "watch": "concurrently \"tsc -p tsconfig.build.json --noEmit --watch\" \"rollup -c rollup.config.mjs --watch\"",
-        "test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" NODE_NO_WARNINGS=1 NODE_ENV=test jest"
+        "test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" NODE_NO_WARNINGS=1 NODE_ENV=test jest",
+        "prepublishOnly": "npm run clean && cross-env NODE_ENV=production npm run build"
     },
     "repository": {
         "type": "git",

--- a/packages/session-replay/package.json
+++ b/packages/session-replay/package.json
@@ -13,7 +13,7 @@
         "format": "prettier --write '**/*.ts'",
         "lint": "eslint . --ext .ts",
         "watch": "concurrently \"tsc -p tsconfig.build.json --noEmit --watch\" \"rollup -c rollup.config.mjs --watch\"",
-        "prepublishOnly": "cross-env NODE_ENV=production npm run clean && npm run build",
+        "prepublishOnly": "npm -w ../sdk-core run prepublishOnly && npm run clean && cross-env NODE_ENV=production npm run build",
         "test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" NODE_NO_WARNINGS=1 NODE_ENV=test jest"
     },
     "repository": {

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -15,7 +15,7 @@
         "clean": "tsc -b --clean && rimraf \"lib\"",
         "format": "prettier --write '**/*.ts'",
         "lint": "eslint . --ext .ts",
-        "prepublishOnly": "cross-env NODE_ENV=production npm run build",
+        "prepublishOnly": "npm run clean && cross-env NODE_ENV=production npm run build",
         "watch": "tsc -w",
         "start": "node lib/index.js",
         "test": "cross-env NODE_ENV=test jest"

--- a/tools/rollup-plugin/package.json
+++ b/tools/rollup-plugin/package.json
@@ -12,7 +12,7 @@
         "build:rollup": "rollup --config rollup.config.js",
         "clean": "tsc -b ./tsconfig.build.json --clean && rimraf \"lib\"",
         "format": "prettier --write '**/*.ts'",
-        "prepublishOnly": "cross-env NODE_ENV=production npm run build",
+        "prepublishOnly": "npm run clean && cross-env NODE_ENV=production npm run build",
         "lint": "eslint . --ext .ts",
         "watch": "tsc -b ./tsconfig.build.json -w"
     },

--- a/tools/sourcemap-tools/package.json
+++ b/tools/sourcemap-tools/package.json
@@ -13,7 +13,8 @@
         "format": "prettier --write '**/*.ts'",
         "lint": "eslint . --ext .ts",
         "watch": "tsc -w",
-        "test": "cross-env NODE_ENV=test jest"
+        "test": "cross-env NODE_ENV=test jest",
+        "prepublishOnly": "npm run clean && cross-env NODE_ENV=production npm run build"
     },
     "repository": {
         "type": "git",

--- a/tools/vite-plugin/package.json
+++ b/tools/vite-plugin/package.json
@@ -12,7 +12,7 @@
         "build:vite": "vite build --config vite.config.js",
         "clean": "tsc -b ./tsconfig.build.json --clean && rimraf \"lib\"",
         "format": "prettier --write '**/*.ts'",
-        "prepublishOnly": "cross-env NODE_ENV=production npm run build",
+        "prepublishOnly": "npm run clean && cross-env NODE_ENV=production npm run build",
         "lint": "eslint . --ext .ts",
         "watch": "tsc -b ./tsconfig.build.json -w"
     },

--- a/tools/webpack-plugin/package.json
+++ b/tools/webpack-plugin/package.json
@@ -13,7 +13,7 @@
         "clean": "tsc -b ./tsconfig.build.json --clean && rimraf \"lib\"",
         "format": "prettier --write '**/*.ts'",
         "lint": "eslint . --ext .ts",
-        "prepublishOnly": "cross-env NODE_ENV=production npm run build",
+        "prepublishOnly": "npm run clean && cross-env NODE_ENV=production npm run build",
         "watch": "tsc -b ./tsconfig.build.json -w",
         "test:e2e": "npm run test:e2e:webpackv5 && npm run test:e2e:webpackv4",
         "test:e2e:webpackv4": "cross-env NODE_ENV=test jest --config ./webpack4.e2e.jest.config.js",


### PR DESCRIPTION
This PR makes sure that all our packages have valid `prepublishOnly` scripts that:
1. build dependencies (run dependencies' `prepublishOnly` scripts),
2. clean package,
3. build package.
