### PR TITLE
browser: version 0.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26688,7 +26688,7 @@
         },
         "packages/browser": {
             "name": "@backtrace/browser",
-            "version": "0.4.0",
+            "version": "0.4.1",
             "license": "MIT",
             "devDependencies": {
                 "@backtrace/sdk-core": "^0.6.0",
@@ -26958,7 +26958,7 @@
             "version": "0.4.0",
             "license": "MIT",
             "devDependencies": {
-                "@backtrace/browser": "^0.4.0",
+                "@backtrace/browser": "^0.4.1",
                 "@backtrace/sdk-core": "^0.6.0",
                 "@rollup/plugin-commonjs": "^26.0.1",
                 "@rollup/plugin-json": "^6.1.0",

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.4.1
+
+-   fix old `@backtrace/sdk-core` bundled with the package
+
 # Version 0.4.0
 
 -   update `@backtrace/sdk-core` to `0.5.0`

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/browser",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "Backtrace-JavaScript web browser integration",
     "main": "lib/bundle.cjs",
     "module": "lib/bundle.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,7 +40,7 @@
         "/lib"
     ],
     "devDependencies": {
-        "@backtrace/browser": "^0.4.0",
+        "@backtrace/browser": "^0.4.1",
         "@backtrace/sdk-core": "^0.6.0",
         "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-json": "^6.1.0",


### PR DESCRIPTION
-   fix old `@backtrace/sdk-core` bundled with the package