### PR TITLE
browser, react, session-replay: add api-extractor (NFC)

### DIFF
--- a/build/api-extractor.json
+++ b/build/api-extractor.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+    "compiler": {
+        "tsconfigFilePath": "<projectFolder>/tsconfig.build.json"
+    },
+    "apiReport": {
+        "enabled": false
+    },
+    "docModel": {
+        "enabled": false
+    },
+    "tsdocMetadata": {
+        "enabled": false
+    }
+}

--- a/build/rollup/apiExtractorPlugin.mjs
+++ b/build/rollup/apiExtractorPlugin.mjs
@@ -1,0 +1,23 @@
+import { Extractor, ExtractorConfig } from '@microsoft/api-extractor';
+
+/**
+ * Runs `@microsoft/api-extractor` with provided config file.
+ * @param {string} configPath - path to api-extractor.json.
+ * @returns
+ */
+export function apiExtractor(configPath = './api-extractor.json') {
+    return {
+        name: 'apiExtractor',
+        async closeBundle() {
+            const extractorConfig = ExtractorConfig.loadFileAndPrepare(configPath);
+            const extractorResult = Extractor.invoke(extractorConfig);
+
+            if (!extractorResult.succeeded) {
+                this.warn(
+                    `API Extractor completed with ${extractorResult.errorCount} errors` +
+                        ` and ${extractorResult.warningCount} warnings`,
+                );
+            }
+        },
+    };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2945,6 +2945,139 @@
                 "node": ">=8"
             }
         },
+        "node_modules/@microsoft/api-extractor": {
+            "version": "7.47.11",
+            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.47.11.tgz",
+            "integrity": "sha512-lrudfbPub5wzBhymfFtgZKuBvXxoSIAdrvS2UbHjoMT2TjIEddq6Z13pcve7A03BAouw0x8sW8G4txdgfiSwpQ==",
+            "dev": true,
+            "dependencies": {
+                "@microsoft/api-extractor-model": "7.29.8",
+                "@microsoft/tsdoc": "~0.15.0",
+                "@microsoft/tsdoc-config": "~0.17.0",
+                "@rushstack/node-core-library": "5.9.0",
+                "@rushstack/rig-package": "0.5.3",
+                "@rushstack/terminal": "0.14.2",
+                "@rushstack/ts-command-line": "4.23.0",
+                "lodash": "~4.17.15",
+                "minimatch": "~3.0.3",
+                "resolve": "~1.22.1",
+                "semver": "~7.5.4",
+                "source-map": "~0.6.1",
+                "typescript": "5.4.2"
+            },
+            "bin": {
+                "api-extractor": "bin/api-extractor"
+            }
+        },
+        "node_modules/@microsoft/api-extractor-model": {
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.29.8.tgz",
+            "integrity": "sha512-t3Z/xcO6TRbMcnKGVMs4uMzv/gd5j0NhMiJIGjD4cJMeFJ1Hf8wnLSx37vxlRlL0GWlGJhnFgxvnaL6JlS+73g==",
+            "dev": true,
+            "dependencies": {
+                "@microsoft/tsdoc": "~0.15.0",
+                "@microsoft/tsdoc-config": "~0.17.0",
+                "@rushstack/node-core-library": "5.9.0"
+            }
+        },
+        "node_modules/@microsoft/api-extractor/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@microsoft/api-extractor/node_modules/minimatch": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+            "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/@microsoft/api-extractor/node_modules/semver": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@microsoft/api-extractor/node_modules/typescript": {
+            "version": "5.4.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+            "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/@microsoft/api-extractor/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true
+        },
+        "node_modules/@microsoft/tsdoc": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.0.tgz",
+            "integrity": "sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==",
+            "dev": true
+        },
+        "node_modules/@microsoft/tsdoc-config": {
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.17.0.tgz",
+            "integrity": "sha512-v/EYRXnCAIHxOHW+Plb6OWuUoMotxTN0GLatnpOb1xq0KuTNw/WI3pamJx/UbsoJP5k9MCw1QxvvhPcF9pH3Zg==",
+            "dev": true,
+            "dependencies": {
+                "@microsoft/tsdoc": "0.15.0",
+                "ajv": "~8.12.0",
+                "jju": "~1.4.0",
+                "resolve": "~1.22.2"
+            }
+        },
+        "node_modules/@microsoft/tsdoc-config/node_modules/ajv": {
+            "version": "8.12.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/@microsoft/tsdoc-config/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true
+        },
         "node_modules/@nestjs/common": {
             "version": "10.4.1",
             "license": "MIT",
@@ -4157,6 +4290,210 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@rushstack/node-core-library": {
+            "version": "5.9.0",
+            "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.9.0.tgz",
+            "integrity": "sha512-MMsshEWkTbXqxqFxD4gcIUWQOCeBChlGczdZbHfqmNZQFLHB3yWxDFSMHFUdu2/OB9NUk7Awn5qRL+rws4HQNg==",
+            "dev": true,
+            "dependencies": {
+                "ajv": "~8.13.0",
+                "ajv-draft-04": "~1.0.0",
+                "ajv-formats": "~3.0.1",
+                "fs-extra": "~7.0.1",
+                "import-lazy": "~4.0.0",
+                "jju": "~1.4.0",
+                "resolve": "~1.22.1",
+                "semver": "~7.5.4"
+            },
+            "peerDependencies": {
+                "@types/node": "*"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/ajv": {
+            "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+            "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
+                "uri-js": "^4.4.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/ajv-draft-04": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+            "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+            "dev": true,
+            "peerDependencies": {
+                "ajv": "^8.5.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/fs-extra": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=6 <7 || >=8"
+            }
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+            "dev": true,
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/semver": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true
+        },
+        "node_modules/@rushstack/rig-package": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.5.3.tgz",
+            "integrity": "sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==",
+            "dev": true,
+            "dependencies": {
+                "resolve": "~1.22.1",
+                "strip-json-comments": "~3.1.1"
+            }
+        },
+        "node_modules/@rushstack/terminal": {
+            "version": "0.14.2",
+            "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.14.2.tgz",
+            "integrity": "sha512-2fC1wqu1VCExKC0/L+0noVcFQEXEnoBOtCIex1TOjBzEDWcw8KzJjjj7aTP6mLxepG0XIyn9OufeFb6SFsa+sg==",
+            "dev": true,
+            "dependencies": {
+                "@rushstack/node-core-library": "5.9.0",
+                "supports-color": "~8.1.1"
+            },
+            "peerDependencies": {
+                "@types/node": "*"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rushstack/terminal/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@rushstack/terminal/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/@rushstack/ts-command-line": {
+            "version": "4.23.0",
+            "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.23.0.tgz",
+            "integrity": "sha512-jYREBtsxduPV6ptNq8jOKp9+yx0ld1Tb/Tkdnlj8gTjazl1sF3DwX2VbluyYrNd0meWIL0bNeer7WDf5tKFjaQ==",
+            "dev": true,
+            "dependencies": {
+                "@rushstack/terminal": "0.14.2",
+                "@types/argparse": "1.0.38",
+                "argparse": "~1.0.9",
+                "string-argv": "~0.3.1"
+            }
+        },
+        "node_modules/@rushstack/ts-command-line/node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/@rushstack/ts-command-line/node_modules/sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+            "dev": true
+        },
         "node_modules/@sideway/address": {
             "version": "4.1.5",
             "dev": true,
@@ -4296,6 +4633,12 @@
             "version": "1.0.4",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/argparse": {
+            "version": "1.0.38",
+            "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
+            "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
+            "dev": true
         },
         "node_modules/@types/aria-query": {
             "version": "5.0.4",
@@ -5658,6 +6001,45 @@
             "peerDependencies": {
                 "ajv": ">=5.0.0"
             }
+        },
+        "node_modules/ajv-formats": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+            "dev": true,
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ajv-formats/node_modules/ajv": {
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true
         },
         "node_modules/ajv-keywords": {
             "version": "3.5.2",
@@ -11466,6 +11848,12 @@
             "version": "2.1.1",
             "license": "MIT"
         },
+        "node_modules/fast-uri": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
+            "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
+            "dev": true
+        },
         "node_modules/fast-xml-parser": {
             "version": "4.5.0",
             "dev": true,
@@ -13075,6 +13463,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/import-lazy": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+            "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/import-local": {
             "version": "3.2.0",
             "dev": true,
@@ -14653,6 +15050,12 @@
                 "jetifier-standalone": "bin/jetifier-standalone",
                 "jetify": "bin/jetify"
             }
+        },
+        "node_modules/jju": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+            "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+            "dev": true
         },
         "node_modules/joi": {
             "version": "17.13.3",
@@ -19123,6 +19526,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/require-main-filename": {
             "version": "2.0.0",
             "dev": true,
@@ -19391,6 +19803,28 @@
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/rollup-plugin-dts": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-6.1.1.tgz",
+            "integrity": "sha512-aSHRcJ6KG2IHIioYlvAOcEq6U99sVtqDDKVhnwt70rW6tsz3tv5OSjEiWcgzfsHdLyGXZ/3b/7b/+Za3Y6r1XA==",
+            "dev": true,
+            "dependencies": {
+                "magic-string": "^0.30.10"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/Swatinem"
+            },
+            "optionalDependencies": {
+                "@babel/code-frame": "^7.24.2"
+            },
+            "peerDependencies": {
+                "rollup": "^3.29.4 || ^4",
+                "typescript": "^4.5 || ^5.0"
             }
         },
         "node_modules/rrdom": {
@@ -20514,6 +20948,15 @@
                 }
             ],
             "license": "MIT"
+        },
+        "node_modules/string-argv": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+            "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.6.19"
+            }
         },
         "node_modules/string-length": {
             "version": "4.0.2",
@@ -23916,6 +24359,7 @@
             "license": "MIT",
             "devDependencies": {
                 "@backtrace/sdk-core": "^0.6.0",
+                "@microsoft/api-extractor": "^7.47.11",
                 "@reduxjs/toolkit": "^1.9.5",
                 "@rollup/plugin-commonjs": "^26.0.1",
                 "@rollup/plugin-json": "^6.1.0",
@@ -23928,6 +24372,7 @@
                 "jest": "^29.5.0",
                 "jest-environment-jsdom": "^29.5.0",
                 "rollup": "^4.21.0",
+                "rollup-plugin-dts": "^6.1.1",
                 "ts-jest": "^29.1.0",
                 "typescript": "^5.0.4",
                 "ua-parser-js": "^1.0.35"
@@ -24184,6 +24629,7 @@
             "devDependencies": {
                 "@backtrace/browser": "^0.4.1",
                 "@backtrace/sdk-core": "^0.6.0",
+                "@microsoft/api-extractor": "^7.47.11",
                 "@rollup/plugin-commonjs": "^26.0.1",
                 "@rollup/plugin-json": "^6.1.0",
                 "@rollup/plugin-node-resolve": "^15.2.3",
@@ -24386,6 +24832,7 @@
             },
             "devDependencies": {
                 "@backtrace/sdk-core": "^0.6.0",
+                "@microsoft/api-extractor": "^7.47.11",
                 "@rollup/plugin-commonjs": "^26.0.1",
                 "@rollup/plugin-json": "^6.1.0",
                 "@rollup/plugin-node-resolve": "^15.2.3",

--- a/packages/browser/api-extractor.json
+++ b/packages/browser/api-extractor.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+    "extends": "../../build/api-extractor.json",
+
+    "mainEntryPointFilePath": "<projectFolder>/lib/types/index.d.ts",
+    "bundledPackages": ["@backtrace/*"],
+    "dtsRollup": {
+        "enabled": true,
+        "untrimmedFilePath": "<projectFolder>/lib/bundle.d.ts"
+    }
+}

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -5,7 +5,7 @@
     "main": "lib/bundle.cjs",
     "module": "lib/bundle.mjs",
     "browser": "lib/bundle.mjs",
-    "types": "lib/index.d.ts",
+    "types": "lib/bundle.d.ts",
     "type": "module",
     "scripts": {
         "build": "tsc -p tsconfig.build.json --noEmit && rollup -c rollup.config.mjs",
@@ -36,10 +36,12 @@
     },
     "homepage": "https://github.com/backtrace-labs/backtrace-javascript#readme",
     "files": [
-        "/lib"
+        "/lib",
+        "!/lib/types"
     ],
     "devDependencies": {
         "@backtrace/sdk-core": "^0.6.0",
+        "@microsoft/api-extractor": "^7.47.11",
         "@reduxjs/toolkit": "^1.9.5",
         "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-json": "^6.1.0",
@@ -52,6 +54,7 @@
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "rollup": "^4.21.0",
+        "rollup-plugin-dts": "^6.1.1",
         "ts-jest": "^29.1.0",
         "typescript": "^5.0.4",
         "ua-parser-js": "^1.0.35"

--- a/packages/browser/rollup.config.mjs
+++ b/packages/browser/rollup.config.mjs
@@ -4,46 +4,50 @@ import nodeResolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
+import { apiExtractor } from '../../build/rollup/apiExtractorPlugin.mjs';
 import packageJson from './package.json' with { type: 'json' };
 
 const extensions = ['.js', '.ts'];
 
 /** @type {import('rollup').RollupOptions} */
-export default {
-    input: './src/index.ts',
-    output: [
-        {
-            file: 'lib/bundle.mjs',
-            format: 'esm',
-            sourcemap: true,
-        },
-        {
-            file: 'lib/bundle.min.mjs',
-            format: 'esm',
-            sourcemap: true,
-            plugins: [terser()],
-        },
-        {
-            file: 'lib/bundle.cjs',
-            format: 'cjs',
-            sourcemap: true,
-        },
-        {
-            file: 'lib/bundle.min.cjs',
-            format: 'cjs',
-            sourcemap: true,
-            plugins: [terser()],
-        },
-    ],
-    plugins: [
-        typescript({ tsconfig: './tsconfig.build.json' }),
-        nodeResolve({ extensions, preferBuiltins: true }),
-        commonjs({ defaultIsModuleExports: true }),
-        replace({
-            BACKTRACE_AGENT_NAME: packageJson.name,
-            BACKTRACE_AGENT_VERSION: packageJson.version,
-            preventAssignment: true,
-        }),
-        json(),
-    ],
-};
+export default [
+    {
+        input: './src/index.ts',
+        output: [
+            {
+                file: 'lib/bundle.mjs',
+                format: 'esm',
+                sourcemap: true,
+            },
+            {
+                file: 'lib/bundle.min.mjs',
+                format: 'esm',
+                sourcemap: true,
+                plugins: [terser()],
+            },
+            {
+                file: 'lib/bundle.cjs',
+                format: 'cjs',
+                sourcemap: true,
+            },
+            {
+                file: 'lib/bundle.min.cjs',
+                format: 'cjs',
+                sourcemap: true,
+                plugins: [terser()],
+            },
+        ],
+        plugins: [
+            typescript({ tsconfig: './tsconfig.build.json' }),
+            nodeResolve({ extensions, preferBuiltins: true }),
+            commonjs({ defaultIsModuleExports: true }),
+            replace({
+                BACKTRACE_AGENT_NAME: packageJson.name,
+                BACKTRACE_AGENT_VERSION: packageJson.version,
+                preventAssignment: true,
+            }),
+            json(),
+            apiExtractor(),
+        ],
+    },
+];

--- a/packages/browser/tsconfig.build.json
+++ b/packages/browser/tsconfig.build.json
@@ -5,6 +5,7 @@
         "rootDir": "./src",
         "outDir": "./lib",
         "module": "NodeNext",
-        "moduleResolution": "NodeNext"
+        "moduleResolution": "NodeNext",
+        "declarationDir": "./lib/types"
     }
 }

--- a/packages/react/api-extractor.json
+++ b/packages/react/api-extractor.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+    "extends": "../../build/api-extractor.json",
+
+    "mainEntryPointFilePath": "<projectFolder>/lib/types/index.d.ts",
+    "bundledPackages": ["@backtrace/*"],
+    "dtsRollup": {
+        "enabled": true,
+        "untrimmedFilePath": "<projectFolder>/lib/bundle.d.ts"
+    }
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -5,7 +5,7 @@
     "main": "lib/bundle.cjs",
     "module": "lib/bundle.mjs",
     "browser": "lib/bundle.mjs",
-    "types": "lib/index.d.ts",
+    "types": "lib/bundle.d.ts",
     "type": "module",
     "scripts": {
         "build": "tsc -p tsconfig.build.json --noEmit && rollup -c rollup.config.mjs",
@@ -37,11 +37,13 @@
     },
     "homepage": "https://github.com/backtrace-labs/backtrace-javascript#readme",
     "files": [
-        "/lib"
+        "/lib",
+        "!/lib/types"
     ],
     "devDependencies": {
         "@backtrace/browser": "^0.4.1",
         "@backtrace/sdk-core": "^0.6.0",
+        "@microsoft/api-extractor": "^7.47.11",
         "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^15.2.3",

--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -5,6 +5,7 @@ import replace from '@rollup/plugin-replace';
 import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
 import path from 'path';
+import { apiExtractor } from '../../build/rollup/apiExtractorPlugin.mjs';
 import packageJson from './package.json' with { type: 'json' };
 
 const extensions = ['.js', '.ts', '.tsx'];
@@ -50,5 +51,6 @@ export default {
             preventAssignment: true,
         }),
         json(),
+        apiExtractor(),
     ],
 };

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -4,6 +4,7 @@
     "compilerOptions": {
         "rootDir": "./src",
         "outDir": "./lib",
+        "declarationDir": "./lib/types",
         "module": "NodeNext",
         "moduleResolution": "NodeNext"
     }

--- a/packages/session-replay/api-extractor.json
+++ b/packages/session-replay/api-extractor.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+    "extends": "../../build/api-extractor.json",
+
+    "mainEntryPointFilePath": "<projectFolder>/lib/types/index.d.ts",
+    "dtsRollup": {
+        "enabled": true,
+        "untrimmedFilePath": "<projectFolder>/lib/bundle.d.ts"
+    }
+}

--- a/packages/session-replay/package.json
+++ b/packages/session-replay/package.json
@@ -5,7 +5,7 @@
     "main": "lib/bundle.cjs",
     "module": "lib/bundle.mjs",
     "browser": "lib/bundle.mjs",
-    "types": "lib/index.d.ts",
+    "types": "lib/bundle.d.ts",
     "type": "module",
     "scripts": {
         "build": "tsc -p tsconfig.build.json --noEmit && rollup -c rollup.config.mjs",
@@ -26,7 +26,8 @@
         "url": "https://github.com/backtrace-labs/backtrace-javascript/issues"
     },
     "files": [
-        "/lib"
+        "/lib",
+        "!/lib/types"
     ],
     "homepage": "https://github.com/backtrace-labs/backtrace-javascript#readme",
     "dependencies": {
@@ -34,6 +35,7 @@
     },
     "devDependencies": {
         "@backtrace/sdk-core": "^0.6.0",
+        "@microsoft/api-extractor": "^7.47.11",
         "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^15.2.3",

--- a/packages/session-replay/rollup.config.mjs
+++ b/packages/session-replay/rollup.config.mjs
@@ -4,6 +4,7 @@ import nodeResolve from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
 import path from 'path';
+import { apiExtractor } from '../../build/rollup/apiExtractorPlugin.mjs';
 
 const extensions = ['.js', '.ts'];
 
@@ -43,5 +44,6 @@ export default {
         }),
         commonjs({ defaultIsModuleExports: true }),
         json(),
+        apiExtractor(),
     ],
 };

--- a/packages/session-replay/tsconfig.build.json
+++ b/packages/session-replay/tsconfig.build.json
@@ -4,6 +4,7 @@
     "compilerOptions": {
         "rootDir": "./src",
         "outDir": "./lib",
+        "declarationDir": "./lib/types",
         "module": "NodeNext",
         "moduleResolution": "NodeNext"
     }


### PR DESCRIPTION
This PR adds `@microsoft/api-extractor` to web packages to bundle declaration files.

For these packages, declaration files are built in `lib/types`, and from then, bundled to `lib/bundle.d.ts`. `lib/types` is NOT included in the NPM package.

This should fix TypeScript build errors in packages that use browser SDK.