### PR TITLE
browser, react, session-replay: move @backtrace/* dependencies to normal dependencies (NFC)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23914,8 +23914,10 @@
             "name": "@backtrace/browser",
             "version": "0.4.1",
             "license": "MIT",
+            "dependencies": {
+                "@backtrace/sdk-core": "0.6.0"
+            },
             "devDependencies": {
-                "@backtrace/sdk-core": "^0.6.0",
                 "@reduxjs/toolkit": "^1.9.5",
                 "@rollup/plugin-commonjs": "^26.0.1",
                 "@rollup/plugin-json": "^6.1.0",
@@ -24181,9 +24183,10 @@
             "name": "@backtrace/react",
             "version": "0.4.0",
             "license": "MIT",
+            "dependencies": {
+                "@backtrace/browser": "0.4.1"
+            },
             "devDependencies": {
-                "@backtrace/browser": "^0.4.1",
-                "@backtrace/sdk-core": "^0.6.0",
                 "@rollup/plugin-commonjs": "^26.0.1",
                 "@rollup/plugin-json": "^6.1.0",
                 "@rollup/plugin-node-resolve": "^15.2.3",
@@ -24382,10 +24385,10 @@
             "version": "0.2.0",
             "license": "MIT",
             "dependencies": {
+                "@backtrace/sdk-core": "0.6.0",
                 "rrweb": "^2.0.0-alpha.15"
             },
             "devDependencies": {
-                "@backtrace/sdk-core": "^0.6.0",
                 "@rollup/plugin-commonjs": "^26.0.1",
                 "@rollup/plugin-json": "^6.1.0",
                 "@rollup/plugin-node-resolve": "^15.2.3",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -38,8 +38,10 @@
     "files": [
         "/lib"
     ],
+    "dependencies": {
+        "@backtrace/sdk-core": "0.6.0"
+    },
     "devDependencies": {
-        "@backtrace/sdk-core": "^0.6.0",
         "@reduxjs/toolkit": "^1.9.5",
         "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-json": "^6.1.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -39,9 +39,10 @@
     "files": [
         "/lib"
     ],
+    "dependencies": {
+        "@backtrace/browser": "0.4.1"
+    },
     "devDependencies": {
-        "@backtrace/browser": "^0.4.1",
-        "@backtrace/sdk-core": "^0.6.0",
         "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^15.2.3",

--- a/packages/session-replay/package.json
+++ b/packages/session-replay/package.json
@@ -30,10 +30,10 @@
     ],
     "homepage": "https://github.com/backtrace-labs/backtrace-javascript#readme",
     "dependencies": {
-        "rrweb": "^2.0.0-alpha.15"
+        "rrweb": "^2.0.0-alpha.15",
+        "@backtrace/sdk-core": "0.6.0"
     },
     "devDependencies": {
-        "@backtrace/sdk-core": "^0.6.0",
         "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^15.2.3",


### PR DESCRIPTION
As bundling removed the requirement of installing `@backtrace/*` dependencies, they have been moved to dev deps. However, this broke typings in packages that do not install dependent packages.

To mitigate this, these packages have been moved to normal dependencies. As the bundle will have a specific version, this specific is used in `package.json`. `syncVersions.ts` script has also been updated to not include `^` caret in version range by default, but rather preserve the operator, whatever it may be.