### PR TITLE
browser: version 0.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23912,7 +23912,7 @@
         },
         "packages/browser": {
             "name": "@backtrace/browser",
-            "version": "0.4.1",
+            "version": "0.4.2",
             "license": "MIT",
             "dependencies": {
                 "@backtrace/sdk-core": "0.6.0"
@@ -24184,7 +24184,7 @@
             "version": "0.4.0",
             "license": "MIT",
             "dependencies": {
-                "@backtrace/browser": "0.4.1"
+                "@backtrace/browser": "0.4.2"
             },
             "devDependencies": {
                 "@rollup/plugin-commonjs": "^26.0.1",

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.4.2
+
+-   add `@backtrace/sdk-core` as normal dependency to fix typings
+
 # Version 0.4.1
 
 -   fix old `@backtrace/sdk-core` bundled with the package

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/browser",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "description": "Backtrace-JavaScript web browser integration",
     "main": "lib/bundle.cjs",
     "module": "lib/bundle.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,7 +40,7 @@
         "/lib"
     ],
     "dependencies": {
-        "@backtrace/browser": "0.4.1"
+        "@backtrace/browser": "0.4.2"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^26.0.1",


### PR DESCRIPTION
-   add `@backtrace/sdk-core` as normal dependency to fix typings