### PR TITLE
react-native: version 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24209,7 +24209,7 @@
         },
         "packages/react-native": {
             "name": "@backtrace/react-native",
-            "version": "0.1.1",
+            "version": "0.2.0",
             "license": "MIT",
             "dependencies": {
                 "@backtrace/sdk-core": "^0.6.0",

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Version 0.2.0
+
+-   update `@backtrace/sdk-core` to `0.6.0`
+-   android crash handler upgrade (#301)
+-   fix previous sessions not being cleared (#306)
+-   fix invalid RN object returned from iOS BacktraceReactNative.initialize function (#308)
+-   remove invalid imports from iOS headers (#307)
+-   replace AlternatingFileWriter with WritableStream and ChunkifierSink for breadcrumbs (#315)
+-   reduce breadcrumb size (#320)
+
 # Version 0.1.1
 
 -   update @backtrace/sdk-core to `0.3.2`

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   remove invalid imports from iOS headers (#307)
 -   replace AlternatingFileWriter with WritableStream and ChunkifierSink for breadcrumbs (#315)
 -   reduce breadcrumb size (#320)
+-   fixed debugger detection in the bridgeless mode (#325)
 
 # Version 0.1.1
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/react-native",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "description": "Backtrace-Javascript React-Native integration",
     "main": "lib/commonjs/index",
     "module": "lib/module/index",


### PR DESCRIPTION
-   update `@backtrace/sdk-core` to `0.6.0`
-   android crash handler upgrade (#301)
-   fix previous sessions not being cleared (#306)
-   fix invalid RN object returned from iOS BacktraceReactNative.initialize function (#308)
-   remove invalid imports from iOS headers (#307)
-   replace AlternatingFileWriter with WritableStream and ChunkifierSink for breadcrumbs (#315)
-   reduce breadcrumb size (#320)
-   fixed debugger detection in the bridgeless mode (#325)