### PR TITLE
node: version 0.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23997,7 +23997,7 @@
             "version": "0.6.1",
             "license": "MIT",
             "dependencies": {
-                "@backtrace/node": "^0.6.1"
+                "@backtrace/node": "^0.6.2"
             },
             "devDependencies": {
                 "@rollup/plugin-commonjs": "^26.0.1",
@@ -24055,7 +24055,7 @@
             "version": "0.5.1",
             "license": "MIT",
             "dependencies": {
-                "@backtrace/node": "^0.6.1"
+                "@backtrace/node": "^0.6.2"
             },
             "devDependencies": {
                 "@nestjs/core": "^10",
@@ -24120,7 +24120,7 @@
         },
         "packages/node": {
             "name": "@backtrace/node",
-            "version": "0.6.1",
+            "version": "0.6.2",
             "license": "MIT",
             "dependencies": {
                 "@backtrace/sdk-core": "^0.6.0",
@@ -24222,6 +24222,7 @@
                 "jest": "^29.7.0",
                 "pod-install": "^0.1.0",
                 "prettier": "^2.0.5",
+                "random-seed": "^0.3.0",
                 "react": "18.2.0",
                 "react-native": "^0.72.4",
                 "react-native-builder-bob": "^0.21.3",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -89,7 +89,7 @@
         "/renderer"
     ],
     "dependencies": {
-        "@backtrace/node": "^0.6.1"
+        "@backtrace/node": "^0.6.2"
     },
     "peerDependencies": {
         "electron": ">=12"

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -62,7 +62,7 @@
         "typescript": "^5.0.4"
     },
     "dependencies": {
-        "@backtrace/node": "^0.6.1"
+        "@backtrace/node": "^0.6.2"
     },
     "peerDependencies": {
         "@nestjs/common": "^9 || ^10"

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.6.2
+
+-   fix invalid error handler in `fileChunkSink` (#322)
+
 # Version 0.6.1
 
 -   fix invalid breadcrumb name in `FileBreadcrumbsStorage` (#303)

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/node",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "description": "Backtrace-JavaScript Node.JS integration",
     "main": "lib/bundle.cjs",
     "module": "lib/bundle.mjs",


### PR DESCRIPTION
-   fix invalid error handler in `fileChunkSink` (#322)