### PR TITLE
react-native: Enable native functions for Bridgeless react-native setup

### DIFF
--- a/packages/react-native/src/builder/BacktraceClientBuilder.ts
+++ b/packages/react-native/src/builder/BacktraceClientBuilder.ts
@@ -14,9 +14,8 @@ export class BacktraceClientBuilder extends BacktraceCoreClientBuilder<Backtrace
     constructor(clientSetup: BacktraceClientSetup) {
         super(clientSetup);
 
-        const debuggerAvailable = DebuggerHelper.isConnected();
         this.addAttributeProvider(new ReactNativeAttributeProvider());
-        if (debuggerAvailable) {
+        if (!DebuggerHelper.isNativeBridgeEnabled()) {
             return;
         }
 

--- a/packages/react-native/src/common/DebuggerHelper.ts
+++ b/packages/react-native/src/common/DebuggerHelper.ts
@@ -1,5 +1,18 @@
+import { NativeModules } from 'react-native';
+
 export class DebuggerHelper {
-    public static isConnected(): boolean {
-        return !(global as unknown as { nativeCallSyncHook: boolean }).nativeCallSyncHook;
+    /**
+     * Detects if the native bridge between JavaScript and native is available.
+     * @returns true if the native bridge is available. Otherwise false.
+     */
+    public static isNativeBridgeEnabled(): boolean {
+        // in the bridgeless mode, we always have access to the native layer - there is no risk
+        // on returning true.
+        const isBridgeless = !NativeModules.UIManager;
+        if (isBridgeless) {
+            return true;
+        }
+
+        return !!(global as unknown as { nativeCallSyncHook: boolean }).nativeCallSyncHook;
     }
 }

--- a/packages/react-native/src/crashReporter/CrashReporter.ts
+++ b/packages/react-native/src/crashReporter/CrashReporter.ts
@@ -29,7 +29,7 @@ export class CrashReporter {
             return false;
         }
 
-        if (DebuggerHelper.isConnected()) {
+        if (!DebuggerHelper.isNativeBridgeEnabled()) {
             return false;
         }
 

--- a/packages/react-native/src/handlers/android/AndroidUnhandledExceptionHandler.ts
+++ b/packages/react-native/src/handlers/android/AndroidUnhandledExceptionHandler.ts
@@ -13,7 +13,7 @@ export class AndroidUnhandledExceptionHandler extends UnhandledExceptionHandler 
         if (!this._unhandledExceptionHandler) {
             return;
         }
-        if (DebuggerHelper.isConnected()) {
+        if (!DebuggerHelper.isNativeBridgeEnabled()) {
             return;
         }
 


### PR DESCRIPTION
# Why

This pull request enables native functions for bridgeless react-native setup. In the bridgeless setup, we know we can run native functions.  

Now all native functions such us unhandled exceptions/crashes are working in the bridgeless mode.

ref: BT-5152,  BT-5174