### PR TITLE
smoketest: Downgrade react types in smoketests to the version in the sdk

### DIFF
--- a/smoketests/packages/react-ts-esm/package.json
+++ b/smoketests/packages/react-ts-esm/package.json
@@ -13,8 +13,8 @@
     "author": "Backtrace <team@backtrace.io>",
     "license": "MIT",
     "devDependencies": {
-        "@types/react": "^18.2.14",
-        "@types/react-dom": "^18.2.6",
+        "@types/react": "^16.14.0",
+        "@types/react-dom": "^16.8.0",
         "@backtrace/browser": "file:../../../packages/react",
         "@backtrace/session-replay": "file:../../../packages/session-replay",
         "http-server": "^14.1.1",

--- a/smoketests/packages/react-ts-esm/package.json
+++ b/smoketests/packages/react-ts-esm/package.json
@@ -13,7 +13,7 @@
     "author": "Backtrace <team@backtrace.io>",
     "license": "MIT",
     "devDependencies": {
-        "@types/react": "^16.14.0",
+        "@types/react": "^18.2.14",
         "@types/react-dom": "^18.2.6",
         "@backtrace/browser": "file:../../../packages/react",
         "@backtrace/session-replay": "file:../../../packages/session-replay",


### PR DESCRIPTION
# Why

This pull request downgrades the react-dom types library to the one, that we use in the SDK package.json