### PR TITLE
cicd: cancel previous workflow on commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
         branches: [main, dev]
     pull_request:
 
+    concurrency:
+        group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+        cancel-in-progress: true
+
 jobs:
     test_linux_all:
         runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,9 @@ on:
         branches: [main, dev]
     pull_request:
 
-    concurrency:
-        group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-        cancel-in-progress: true
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
 
 jobs:
     test_linux_all:


### PR DESCRIPTION
# Why

We keep running the cicd pipeline after we commit more changes. Some pipelines are already long - so canceling them makes a lot of sense. This pull request cancels a cicd pipeline on a new change added to the pull request 