### PR TITLE
react-native: add support for bridgeless mode in the android example

### DIFF
--- a/examples/sdk/reactNative/android/app/src/main/java/com/reactnative/MainApplication.java
+++ b/examples/sdk/reactNative/android/app/src/main/java/com/reactnative/MainApplication.java
@@ -1,59 +1,71 @@
 package com.reactnative;
 
 import android.app.Application;
+
+import androidx.annotation.NonNull;
+
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactHost;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
+import com.facebook.react.defaults.DefaultReactHost;
 import com.facebook.react.defaults.DefaultReactNativeHost;
 import com.facebook.soloader.SoLoader;
+
 import java.util.List;
 
 public class MainApplication extends Application implements ReactApplication {
 
-  private final ReactNativeHost mReactNativeHost = new DefaultReactNativeHost(this) {
+    private final ReactNativeHost mReactNativeHost = new DefaultReactNativeHost(this) {
+        @Override
+        public List<ReactPackage> getPackages() {
+            List<ReactPackage> packages = new PackageList(this).getPackages();
+            packages.add(new BacktraceDemoPackage());
+            return packages;
+        }
+
+        @Override
+        public String getJSMainModuleName() {
+            return "index";
+        }
+
+        @Override
+        public boolean getUseDeveloperSupport() {
+            return BuildConfig.DEBUG;
+        }
+
+        @Override
+        public boolean isNewArchEnabled() {
+            return BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
+        }
+
+        @Override
+        public Boolean isHermesEnabled() {
+            return BuildConfig.IS_HERMES_ENABLED;
+        }
+    };
+
+    @NonNull
     @Override
-    public boolean getUseDeveloperSupport() {
-      return BuildConfig.DEBUG;
+    public ReactNativeHost getReactNativeHost() {
+        return mReactNativeHost;
     }
 
     @Override
-    protected List<ReactPackage> getPackages() {
-      List<ReactPackage> packages = new PackageList(this).getPackages();
-      packages.add(new BacktraceDemoPackage());
-      return packages;
+    public ReactHost getReactHost() {
+        return DefaultReactHost.getDefaultReactHost(getApplicationContext(), mReactNativeHost);
     }
 
     @Override
-    protected String getJSMainModuleName() {
-      return "index";
+    public void onCreate() {
+        super.onCreate();
+        SoLoader.init(this, false);
+        if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+            // If you opted-in for the New Architecture, we load the native entry point for
+            // this app.
+            DefaultNewArchitectureEntryPoint.load();
+        }
     }
-
-    @Override
-    protected boolean isNewArchEnabled() {
-      return BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
-    }
-
-    @Override
-    protected Boolean isHermesEnabled() {
-      return BuildConfig.IS_HERMES_ENABLED;
-    }
-  };
-
-  @Override
-  public ReactNativeHost getReactNativeHost() {
-    return mReactNativeHost;
-  }
-
-  @Override
-  public void onCreate() {
-    super.onCreate();
-    SoLoader.init(this, /* native exopackage */ false);
-    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-      // If you opted-in for the New Architecture, we load the native entry point for
-      // this app.
-      DefaultNewArchitectureEntryPoint.load();
-    }
-  }
 }

--- a/examples/sdk/reactNative/index.js
+++ b/examples/sdk/reactNative/index.js
@@ -15,14 +15,12 @@ BacktraceClient.initialize({
             prop2: 123,
         },
     },
-    database: __DEV__
-        ? undefined
-        : {
-              enable: true,
-              captureNativeCrashes: true,
-              createDatabaseDirectory: true,
-              path: `${BacktraceClient.applicationDataPath}/backtrace`,
-          },
+    database: {
+        enable: true,
+        captureNativeCrashes: true,
+        createDatabaseDirectory: true,
+        path: `${BacktraceClient.applicationDataPath}/backtrace`,
+    },
 });
 
 AppRegistry.registerComponent(appName, () => App);


### PR DESCRIPTION
# Why

Changing gradle.properties to run the app in the bridgeless mode, crashed the example app. This pull request:
- fix mainapplication in the bridgeless mode,
- Formats Android file with Android studio formatter