### PR TITLE
electron: fix potential loop with gpu-info-update

### DIFF
--- a/packages/electron/src/main/attributes/GpuAttributeProvider.ts
+++ b/packages/electron/src/main/attributes/GpuAttributeProvider.ts
@@ -49,11 +49,16 @@ export class GpuAttributeProvider implements BacktraceAttributeProvider {
     private _attributes?: Record<string, unknown>;
 
     constructor() {
+        // getGPUInfo may not be supported on earlier versions of Electron
         if (!app.getGPUInfo) {
             return;
         }
 
-        app.on('gpu-info-update', () =>
+        // Collect this information only once
+        // getGPUInfo causes 'gpu-info-update' to be emitted again essentially causing a loop
+        // https://github.com/electron/electron/issues/30827
+        // It is unlikely to change again within runtime of the application
+        app.once('gpu-info-update', () =>
             app
                 .getGPUInfo('complete')
                 .then((info) => {


### PR DESCRIPTION
This fixes an issue with `gpu-info-update` being emitted repeatedly after `getGPUInfo` is called, causing a loop.
We now only listen on this event once. It is unlikely that the GPU info will change within the app runtime.

https://github.com/electron/electron/issues/30827