### PR TITLE
electron: version 0.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23995,7 +23995,7 @@
         },
         "packages/electron": {
             "name": "@backtrace/electron",
-            "version": "0.6.1",
+            "version": "0.6.2",
             "license": "MIT",
             "dependencies": {
                 "@backtrace/node": "^0.6.2"

--- a/packages/electron/CHANGELOG.md
+++ b/packages/electron/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.6.2
+
+-   update `@backtrace/node` to `0.6.2`
+-   fix potential loop with gpu-info-update (#330)
+
 # Version 0.6.1
 
 -   update `@backtrace/node` to `0.6.1`

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/electron",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "description": "Backtrace-JavaScript Electron integration",
     "main": "./main/index.cjs",
     "module": "./main/index.mjs",


### PR DESCRIPTION
-   update `@backtrace/node` to `0.6.2`
-   fix potential loop with gpu-info-update (#330)