### PR TITLE
sourcemap-tools: add processSource to SourceProcessor

### DIFF
--- a/tools/sourcemap-tools/src/SourceProcessor.ts
+++ b/tools/sourcemap-tools/src/SourceProcessor.ts
@@ -125,19 +125,19 @@ export class SourceProcessor {
      * @param force Force adding changes.
      * @returns Used debug ID, new source and new sourcemap.
      */
-    public async processSourceAndAvailableSourceMap(
+    private async processSourceAndAvailableSourceMap(
         source: string,
         sourceMap: RawSourceMap,
         debugId?: string,
         force?: boolean,
     ): Promise<ProcessResultWithSourceMaps>;
-    public async processSourceAndAvailableSourceMap(
+    private async processSourceAndAvailableSourceMap(
         source: string,
         sourceMap?: undefined,
         debugId?: string,
         force?: boolean,
     ): Promise<ProcessResultWithoutSourceMap>;
-    public async processSourceAndAvailableSourceMap(
+    private async processSourceAndAvailableSourceMap(
         source: string,
         sourceMap?: RawSourceMap,
         debugId?: string,


### PR DESCRIPTION
# Why

This change exposes an option in the sourcemap-tools to process source maps via translation process (for example: via metro in react-native) 

ref: BT-5175