### PR TITLE
sourcemap-tools: version 0.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25798,7 +25798,7 @@
             "version": "0.3.2",
             "license": "MIT",
             "dependencies": {
-                "@backtrace/sourcemap-tools": "^0.2.3",
+                "@backtrace/sourcemap-tools": "^0.2.4",
                 "command-line-args": "^5.2.1",
                 "command-line-usage": "^7.0.1",
                 "glob": "^10.3.3",
@@ -25895,7 +25895,7 @@
             "version": "0.1.0",
             "license": "MIT",
             "dependencies": {
-                "@backtrace/sourcemap-tools": "^0.2.3"
+                "@backtrace/sourcemap-tools": "^0.2.4"
             },
             "devDependencies": {
                 "@rollup/plugin-typescript": "^11.1.2",
@@ -25913,7 +25913,7 @@
         },
         "tools/sourcemap-tools": {
             "name": "@backtrace/sourcemap-tools",
-            "version": "0.2.3",
+            "version": "0.2.4",
             "license": "MIT",
             "dependencies": {
                 "tar-stream": "^3.1.6"
@@ -25963,7 +25963,7 @@
             "version": "0.1.0",
             "license": "MIT",
             "dependencies": {
-                "@backtrace/sourcemap-tools": "^0.2.3"
+                "@backtrace/sourcemap-tools": "^0.2.4"
             },
             "devDependencies": {
                 "@types/jest": "^29.5.1",

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -45,7 +45,7 @@
         "/lib"
     ],
     "dependencies": {
-        "@backtrace/sourcemap-tools": "^0.2.3",
+        "@backtrace/sourcemap-tools": "^0.2.4",
         "command-line-args": "^5.2.1",
         "command-line-usage": "^7.0.1",
         "glob": "^10.3.3",

--- a/tools/rollup-plugin/package.json
+++ b/tools/rollup-plugin/package.json
@@ -49,7 +49,7 @@
         "typescript": "^5.0.4"
     },
     "dependencies": {
-        "@backtrace/sourcemap-tools": "^0.2.3"
+        "@backtrace/sourcemap-tools": "^0.2.4"
     },
     "peerDependencies": {
         "rollup": "^3.26.3"

--- a/tools/sourcemap-tools/CHANGELOG.md
+++ b/tools/sourcemap-tools/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Version 0.2.4
+
+-   expose processSource for CLI tools (#332)

--- a/tools/sourcemap-tools/package.json
+++ b/tools/sourcemap-tools/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/sourcemap-tools",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "description": "Backtrace-JavaScript sourcemap tools",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/tools/webpack-plugin/package.json
+++ b/tools/webpack-plugin/package.json
@@ -58,7 +58,7 @@
         "webpack-sources-webpack-4": "npm:webpack-sources@^1.4.1"
     },
     "dependencies": {
-        "@backtrace/sourcemap-tools": "^0.2.3"
+        "@backtrace/sourcemap-tools": "^0.2.4"
     },
     "peerDependencies": {
         "webpack": "^5.85.0 || ^4.46.0"


### PR DESCRIPTION
-   expose processSource for CLI tools (#332)
