### PR TITLE
browser: version 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23913,7 +23913,7 @@
         },
         "packages/browser": {
             "name": "@backtrace/browser",
-            "version": "0.4.2",
+            "version": "0.5.0",
             "license": "MIT",
             "dependencies": {
                 "@backtrace/sdk-core": "0.7.0"
@@ -24185,7 +24185,7 @@
             "version": "0.4.1",
             "license": "MIT",
             "dependencies": {
-                "@backtrace/browser": "0.4.2"
+                "@backtrace/browser": "0.5.0"
             },
             "devDependencies": {
                 "@rollup/plugin-commonjs": "^26.0.1",

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.5.0
+
+-   update `@backtrace/sdk-core` to `0.7.0`
+-   add `BacktraceApi` (#335)
+
 # Version 0.4.2
 
 -   add `@backtrace/sdk-core` as normal dependency to fix typings

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/browser",
-    "version": "0.4.2",
+    "version": "0.5.0",
     "description": "Backtrace-JavaScript web browser integration",
     "main": "lib/bundle.cjs",
     "module": "lib/bundle.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,7 +40,7 @@
         "/lib"
     ],
     "dependencies": {
-        "@backtrace/browser": "0.4.2"
+        "@backtrace/browser": "0.5.0"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^26.0.1",


### PR DESCRIPTION
-   update `@backtrace/sdk-core` to `0.7.0`
-   add `BacktraceApi` (#335)