### PR TITLE
browser: add BrowserBacktraceStorage implementation [INT-355]

### DIFF
--- a/examples/sdk/browser/package-lock.json
+++ b/examples/sdk/browser/package-lock.json
@@ -22,34 +22,52 @@
             }
         },
         "../../../packages/browser": {
-            "version": "0.3.1",
+            "name": "@backtrace/browser",
+            "version": "0.5.0",
             "license": "MIT",
             "dependencies": {
-                "@backtrace/sdk-core": "^0.3.2",
-                "ua-parser-js": "^1.0.35"
+                "@backtrace/sdk-core": "0.7.0"
             },
             "devDependencies": {
                 "@reduxjs/toolkit": "^1.9.5",
+                "@rollup/plugin-commonjs": "^26.0.1",
+                "@rollup/plugin-json": "^6.1.0",
+                "@rollup/plugin-node-resolve": "^15.2.3",
+                "@rollup/plugin-replace": "^5.0.7",
+                "@rollup/plugin-terser": "^0.4.4",
                 "@types/jest": "^29.5.1",
                 "@types/ua-parser-js": "^0.7.36",
+                "concurrently": "^8.2.2",
                 "jest": "^29.5.0",
                 "jest-environment-jsdom": "^29.5.0",
+                "rollup": "^4.21.0",
                 "ts-jest": "^29.1.0",
-                "ts-loader": "^9.4.3",
                 "typescript": "^5.0.4",
-                "webpack": "^5.87.0",
-                "webpack-cli": "^5.1.4"
+                "ua-parser-js": "^1.0.35"
             }
         },
         "../../../packages/session-replay": {
             "name": "@backtrace/session-replay",
-            "version": "0.0.1",
+            "version": "0.2.0",
             "license": "MIT",
             "dependencies": {
+                "@backtrace/sdk-core": "0.7.0",
                 "rrweb": "^2.0.0-alpha.15"
             },
-            "peerDependencies": {
-                "@backtrace/sdk-core": "^0.3.2"
+            "devDependencies": {
+                "@rollup/plugin-commonjs": "^26.0.1",
+                "@rollup/plugin-json": "^6.1.0",
+                "@rollup/plugin-node-resolve": "^15.2.3",
+                "@rollup/plugin-terser": "^0.4.4",
+                "@rollup/plugin-typescript": "^11.1.6",
+                "@types/jest": "^29.5.1",
+                "@types/ua-parser-js": "^0.7.36",
+                "concurrently": "^8.2.2",
+                "jest": "^29.5.0",
+                "jest-environment-jsdom": "^29.7.0",
+                "rollup": "^4.21.0",
+                "ts-jest": "^29.1.0",
+                "typescript": "^5.0.4"
             }
         },
         "node_modules/@babel/runtime": {
@@ -2463,24 +2481,42 @@
         "@backtrace/browser": {
             "version": "file:../../../packages/browser",
             "requires": {
-                "@backtrace/sdk-core": "^0.3.2",
+                "@backtrace/sdk-core": "0.7.0",
                 "@reduxjs/toolkit": "^1.9.5",
+                "@rollup/plugin-commonjs": "^26.0.1",
+                "@rollup/plugin-json": "^6.1.0",
+                "@rollup/plugin-node-resolve": "^15.2.3",
+                "@rollup/plugin-replace": "^5.0.7",
+                "@rollup/plugin-terser": "^0.4.4",
                 "@types/jest": "^29.5.1",
                 "@types/ua-parser-js": "^0.7.36",
+                "concurrently": "^8.2.2",
                 "jest": "^29.5.0",
                 "jest-environment-jsdom": "^29.5.0",
+                "rollup": "^4.21.0",
                 "ts-jest": "^29.1.0",
-                "ts-loader": "^9.4.3",
                 "typescript": "^5.0.4",
-                "ua-parser-js": "^1.0.35",
-                "webpack": "^5.87.0",
-                "webpack-cli": "^5.1.4"
+                "ua-parser-js": "^1.0.35"
             }
         },
         "@backtrace/session-replay": {
             "version": "file:../../../packages/session-replay",
             "requires": {
-                "rrweb": "^2.0.0-alpha.15"
+                "@backtrace/sdk-core": "0.7.0",
+                "@rollup/plugin-commonjs": "^26.0.1",
+                "@rollup/plugin-json": "^6.1.0",
+                "@rollup/plugin-node-resolve": "^15.2.3",
+                "@rollup/plugin-terser": "^0.4.4",
+                "@rollup/plugin-typescript": "^11.1.6",
+                "@types/jest": "^29.5.1",
+                "@types/ua-parser-js": "^0.7.36",
+                "concurrently": "^8.2.2",
+                "jest": "^29.5.0",
+                "jest-environment-jsdom": "^29.7.0",
+                "rollup": "^4.21.0",
+                "rrweb": "^2.0.0-alpha.15",
+                "ts-jest": "^29.1.0",
+                "typescript": "^5.0.4"
             }
         },
         "@discoveryjs/json-ext": {

--- a/examples/sdk/browser/src/index.ts
+++ b/examples/sdk/browser/src/index.ts
@@ -14,6 +14,9 @@ const client = BacktraceClient.builder({
             prop2: 123,
         },
     },
+    database: {
+        enable: true,
+    },
 })
     .useModule(
         new BacktraceSessionReplayModule({

--- a/packages/browser/src/BacktraceClient.ts
+++ b/packages/browser/src/BacktraceClient.ts
@@ -11,6 +11,7 @@ import { BacktraceConfiguration } from './BacktraceConfiguration.js';
 import { BacktraceClientBuilder } from './builder/BacktraceClientBuilder.js';
 import { BacktraceClientSetup } from './builder/BacktraceClientSetup.js';
 import { getStackTraceConverter } from './converters/getStackTraceConverter.js';
+import { BrowserBacktraceStorage } from './storage/BrowserBacktraceStorage.js';
 
 export class BacktraceClient<O extends BacktraceConfiguration = BacktraceConfiguration> extends BacktraceCoreClient<O> {
     private readonly _disposeController: AbortController = new AbortController();
@@ -23,6 +24,10 @@ export class BacktraceClient<O extends BacktraceConfiguration = BacktraceConfigu
             debugIdMapProvider: new VariableDebugIdMapProvider(window as DebugIdContainer),
             sessionProvider: new BacktraceBrowserSessionProvider(),
             ...clientSetup,
+            database: {
+                storage: new BrowserBacktraceStorage(),
+                ...clientSetup.database,
+            },
         });
 
         this.captureUnhandledErrors(

--- a/packages/browser/src/storage/BrowserBacktraceStorage.ts
+++ b/packages/browser/src/storage/BrowserBacktraceStorage.ts
@@ -1,0 +1,63 @@
+import { BacktraceStorageModule } from '@backtrace/sdk-core';
+
+export class BrowserBacktraceStorage implements BacktraceStorageModule {
+    constructor(private readonly _storage = window.localStorage) {}
+
+    public async set(key: string, value: string): Promise<boolean> {
+        return this.setSync(key, value);
+    }
+
+    public async remove(key: string): Promise<boolean> {
+        return this.removeSync(key);
+    }
+
+    public async get(key: string): Promise<string | undefined> {
+        return this.getSync(key);
+    }
+
+    public async has(key: string): Promise<boolean> {
+        return this.hasSync(key);
+    }
+
+    public setSync(key: string, value: string): boolean {
+        try {
+            this._storage.setItem(key, value);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    public removeSync(key: string): boolean {
+        try {
+            this._storage.removeItem(key);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    public getSync(key: string): string | undefined {
+        try {
+            return this._storage.getItem(key) ?? undefined;
+        } catch {
+            return undefined;
+        }
+    }
+
+    public hasSync(key: string): boolean {
+        return key in this._storage;
+    }
+
+    public async *keys(): AsyncGenerator<string> {
+        for (const key of Object.keys(this._storage)) {
+            yield key;
+        }
+    }
+
+    public *keysSync(): Generator<string> {
+        for (const key of Object.keys(this._storage)) {
+            yield key;
+        }
+    }
+}


### PR DESCRIPTION
Follow up to https://github.com/backtrace-labs/backtrace-javascript/pull/341.

This MR adds `BrowserBacktraceStorage` implementation, which allows the database to be used in the browser SDK.