### PR TITLE
browser: add browser file system based on localStorage

### DIFF
--- a/examples/sdk/browser/src/index.ts
+++ b/examples/sdk/browser/src/index.ts
@@ -14,6 +14,10 @@ const client = BacktraceClient.builder({
             prop2: 123,
         },
     },
+    database: {
+        enable: true,
+        path: '/',
+    },
 })
     .useModule(
         new BacktraceSessionReplayModule({

--- a/packages/browser/src/BacktraceClient.ts
+++ b/packages/browser/src/BacktraceClient.ts
@@ -11,6 +11,7 @@ import { BacktraceConfiguration } from './BacktraceConfiguration.js';
 import { BacktraceClientBuilder } from './builder/BacktraceClientBuilder.js';
 import { BacktraceClientSetup } from './builder/BacktraceClientSetup.js';
 import { getStackTraceConverter } from './converters/getStackTraceConverter.js';
+import { BrowserFileSystem } from './storage/BrowserFileSystem.js';
 
 export class BacktraceClient<O extends BacktraceConfiguration = BacktraceConfiguration> extends BacktraceCoreClient<O> {
     private readonly _disposeController: AbortController = new AbortController();
@@ -22,6 +23,7 @@ export class BacktraceClient<O extends BacktraceConfiguration = BacktraceConfigu
             requestHandler: new BacktraceBrowserRequestHandler(clientSetup.options),
             debugIdMapProvider: new VariableDebugIdMapProvider(window as DebugIdContainer),
             sessionProvider: new BacktraceBrowserSessionProvider(),
+            fileSystem: new BrowserFileSystem(),
             ...clientSetup,
         });
 

--- a/packages/browser/src/storage/BrowserFileSystem.ts
+++ b/packages/browser/src/storage/BrowserFileSystem.ts
@@ -1,0 +1,90 @@
+import { BacktraceAttachment, BacktraceStringAttachment, FileSystem } from '@backtrace/sdk-core';
+
+const PREFIX = 'backtrace__';
+
+export class BrowserFileSystem implements FileSystem {
+    constructor(private readonly _storage = window.localStorage) {}
+
+    public async readDir(dir: string): Promise<string[]> {
+        return this.readDirSync(dir);
+    }
+
+    public readDirSync(dir: string): string[] {
+        dir = this.resolvePath(this.ensureTrailingSlash(dir));
+
+        const result: string[] = [];
+        for (const key in this._storage) {
+            if (key.startsWith(dir)) {
+                result.push(key.substring(dir.length));
+            }
+        }
+
+        return result;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    public async createDir(_dir: string): Promise<void> {
+        return;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    public createDirSync(_dir: string): void {
+        return;
+    }
+
+    public async readFile(path: string): Promise<string> {
+        return this.readFileSync(path);
+    }
+
+    public readFileSync(path: string): string {
+        const result = this._storage.getItem(this.resolvePath(path));
+        if (!result) {
+            throw new Error('path does not exist');
+        }
+        return result;
+    }
+
+    public async writeFile(path: string, content: string): Promise<void> {
+        return this.writeFileSync(path, content);
+    }
+
+    public writeFileSync(path: string, content: string): void {
+        this._storage.setItem(this.resolvePath(path), content);
+    }
+
+    public async unlink(path: string): Promise<void> {
+        return this.unlinkSync(path);
+    }
+
+    public unlinkSync(path: string): void {
+        this._storage.removeItem(this.resolvePath(path));
+    }
+
+    public async exists(path: string): Promise<boolean> {
+        return this.existsSync(path);
+    }
+
+    public existsSync(path: string): boolean {
+        return this.resolvePath(path) in this._storage;
+    }
+
+    public createAttachment(path: string, name?: string): BacktraceAttachment {
+        return new BacktraceStringAttachment(name ?? path, this.readFileSync(path));
+    }
+
+    private resolvePath(key: string) {
+        return PREFIX + key;
+    }
+
+    private ensureTrailingSlash(path: string) {
+        if (path === '/') {
+            return '//';
+        }
+
+        while (path.endsWith('/')) {
+            path = path.substring(0, path.length - 1);
+        }
+
+        return path + '/';
+    }
+}


### PR DESCRIPTION
A simple implementation of `BrowserFileSystem` based on `localStorage` that enables usage of `BacktraceDatabase` in the browser.

Requires https://github.com/backtrace-labs/backtrace-javascript/pull/347, as browsers have a single session ID and this causes endless loops.