### PR TITLE
node: version 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23998,7 +23998,7 @@
             "version": "0.6.2",
             "license": "MIT",
             "dependencies": {
-                "@backtrace/node": "^0.7.0"
+                "@backtrace/node": "^0.8.0"
             },
             "devDependencies": {
                 "@rollup/plugin-commonjs": "^26.0.1",
@@ -24056,7 +24056,7 @@
             "version": "0.5.1",
             "license": "MIT",
             "dependencies": {
-                "@backtrace/node": "^0.7.0"
+                "@backtrace/node": "^0.8.0"
             },
             "devDependencies": {
                 "@nestjs/core": "^10",
@@ -24121,7 +24121,7 @@
         },
         "packages/node": {
             "name": "@backtrace/node",
-            "version": "0.7.0",
+            "version": "0.8.0",
             "license": "MIT",
             "dependencies": {
                 "@backtrace/sdk-core": "^0.8.0",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -89,7 +89,7 @@
         "/renderer"
     ],
     "dependencies": {
-        "@backtrace/node": "^0.7.0"
+        "@backtrace/node": "^0.8.0"
     },
     "peerDependencies": {
         "electron": ">=12"

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -62,7 +62,7 @@
         "typescript": "^5.0.4"
     },
     "dependencies": {
-        "@backtrace/node": "^0.7.0"
+        "@backtrace/node": "^0.8.0"
     },
     "peerDependencies": {
         "@nestjs/common": "^9 || ^10"

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.8.0
+
+-   update `@backtrace/sdk-core` to `0.8.0`
+-   suppress stream errors when uploading (#346)
+
 # Version 0.7.0
 
 -   update `@backtrace/sdk-core` to `0.7.0`

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/node",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "description": "Backtrace-JavaScript Node.JS integration",
     "main": "lib/bundle.cjs",
     "module": "lib/bundle.mjs",


### PR DESCRIPTION
-   update `@backtrace/sdk-core` to `0.8.0`
-   suppress stream errors when uploading (#346)