### PR TITLE
electron: version 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23995,7 +23995,7 @@
         },
         "packages/electron": {
             "name": "@backtrace/electron",
-            "version": "0.6.2",
+            "version": "0.7.0",
             "license": "MIT",
             "dependencies": {
                 "@backtrace/node": "^0.8.0"

--- a/packages/electron/CHANGELOG.md
+++ b/packages/electron/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 0.7.0
+
+-   update `@backtrace/node` to `0.8.0`
+-   fix endless loop when loading SessionFiles (#347)
+-   suppress stream errors when uploading (#346)
+
 # Version 0.6.2
 
 -   update `@backtrace/node` to `0.6.2`

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/electron",
-    "version": "0.6.2",
+    "version": "0.7.0",
     "description": "Backtrace-JavaScript Electron integration",
     "main": "./main/index.cjs",
     "module": "./main/index.mjs",


### PR DESCRIPTION
-   update `@backtrace/node` to `0.8.0`
-   fix endless loop when loading SessionFiles (#347)
-   suppress stream errors when uploading (#346)