### PR TITLE
node: fix machine id not being a UUID in some cases

### DIFF
--- a/packages/node/tests/attributes/machineIdAttributeProviderTests.spec.ts
+++ b/packages/node/tests/attributes/machineIdAttributeProviderTests.spec.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import { MachineIdentitfierAttributeProvider } from '../../src/attributes/MachineIdentitfierAttributeProvider.js';
 
 describe('Machine id attribute provider test', () => {
@@ -6,7 +7,7 @@ describe('Machine id attribute provider test', () => {
             const machineIdentifier1 = new MachineIdentitfierAttributeProvider();
             const machineIdentifier2 = new MachineIdentitfierAttributeProvider();
 
-            expect(machineIdentifier1.generateGuid()).toBe(machineIdentifier2.generateGuid());
+            expect(machineIdentifier1.getMachineId()).toBe(machineIdentifier2.getMachineId());
         });
     }
 
@@ -14,5 +15,37 @@ describe('Machine id attribute provider test', () => {
         const machineIdentifier = new MachineIdentitfierAttributeProvider();
 
         expect(machineIdentifier.get()['guid']).toBeDefined();
+    });
+
+    it(`Should return a guid unchanged if it's a valid guid`, () => {
+        const machineIdentifier = new MachineIdentitfierAttributeProvider();
+        const uuid = crypto.randomUUID();
+
+        jest.spyOn(machineIdentifier, 'getMachineId').mockReturnValue(uuid);
+
+        expect(machineIdentifier.get()['guid']).toEqual(uuid);
+    });
+
+    it(`Should convert guid to a guid with dashes`, () => {
+        const machineIdentifier = new MachineIdentitfierAttributeProvider();
+        const uuid = crypto.randomUUID();
+
+        jest.spyOn(machineIdentifier, 'getMachineId').mockReturnValue(uuid.replace(/-/g, ''));
+
+        expect(machineIdentifier.get()['guid']).toEqual(uuid);
+    });
+
+    it(`Should create a hash of guid if it is not a proper guid`, () => {
+        const machineIdentifier = new MachineIdentitfierAttributeProvider();
+        const guidResult = 'foo';
+        const sha = crypto.createHash('sha1').update(guidResult).digest('hex').substring(0, 32);
+        const expected = `${sha.substring(0, 8)}-${sha.substring(8, 12)}-${sha.substring(12, 16)}-${sha.substring(16, 20)}-${sha.substring(20, 32)}`;
+
+        // Sanity check for creating a dashed guid
+        expect(expected.replace(/-/g, '')).toEqual(sha);
+
+        jest.spyOn(machineIdentifier, 'getMachineId').mockReturnValue(guidResult);
+
+        expect(machineIdentifier.get()['guid']).toEqual(expected);
     });
 });


### PR DESCRIPTION
In some cases, like on Linux, the returned machine ID may not be a GUID, but a hostname:

```sh
( cat /var/lib/dbus/machine-id /etc/machine-id 2> /dev/null || hostname ) | head -n 1 || :
```

This change makes sure that non-GUID results are hashed and returned as GUIDs.