### PR TITLE
node: Provide fallback for MachineIdentifier, in case shell is not available

### DIFF
--- a/packages/node/src/attributes/MachineIdentitfierAttributeProvider.ts
+++ b/packages/node/src/attributes/MachineIdentitfierAttributeProvider.ts
@@ -24,31 +24,35 @@ export class MachineIdentitfierAttributeProvider implements BacktraceAttributePr
     }
 
     public generateGuid() {
-        switch (process.platform) {
-            case 'win32': {
-                return execSync(this.COMMANDS['win32'])
-                    .toString()
-                    .match(/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/i)?.[0]
-                    .toLowerCase();
+        try {
+            switch (process.platform) {
+                case 'win32': {
+                    return execSync(this.COMMANDS['win32'])
+                        .toString()
+                        .match(/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/i)?.[0]
+                        .toLowerCase();
+                }
+                case 'darwin': {
+                    return execSync(this.COMMANDS[process.platform])
+                        .toString()
+                        .split('IOPlatformUUID')[1]
+                        .split('\n')[0]
+                        .replace(/=|\s+|"/gi, '')
+                        .toLowerCase();
+                }
+                case 'linux':
+                case 'freebsd': {
+                    return execSync(this.COMMANDS[process.platform])
+                        .toString()
+                        .replace(/\r+|\n+|\s+/gi, '')
+                        .toLowerCase();
+                }
+                default: {
+                    return null;
+                }
             }
-            case 'darwin': {
-                return execSync(this.COMMANDS[process.platform])
-                    .toString()
-                    .split('IOPlatformUUID')[1]
-                    .split('\n')[0]
-                    .replace(/=|\s+|"/gi, '')
-                    .toLowerCase();
-            }
-            case 'linux':
-            case 'freebsd': {
-                return execSync(this.COMMANDS[process.platform])
-                    .toString()
-                    .replace(/\r+|\n+|\s+/gi, '')
-                    .toLowerCase();
-            }
-            default: {
-                return null;
-            }
+        } catch {
+            return null
         }
     }
 }


### PR DESCRIPTION
In a hardened environment, where shell access has been restricted, spinning up Backtrace leads to an unhandled exception:
```
node:internal/child_process:1120
    at new AttributeManager (/usr/local/lib/node_modules/icloud-photos-sync/node_modules/@backtrace/sdk-core/lib/bundle.cjs:572:18)
    result.error = new ErrnoException(result.error, 'spawnSync ' + options.file);
                   ^
<ref *1> Error: spawnSync /bin/sh ENOENT
    at Object.spawnSync (node:internal/child_process:1120:20)
    at spawnSync (node:child_process:902:24)
    at Object.execSync (node:child_process:983:15)
    at MachineIdentitfierAttributeProvider.get (/usr/local/lib/node_modules/icloud-photos-sync/node_modules/@backtrace/node/lib/bundle.cjs:878:33)
    at MachineIdentitfierAttributeProvider.generateGuid (/usr/local/lib/node_modules/icloud-photos-sync/node_modules/@backtrace/node/lib/bundle.cjs:901:38)
    at AttributeManager.addProvider (/usr/local/lib/node_modules/icloud-photos-sync/node_modules/@backtrace/sdk-core/lib/bundle.cjs:598:50)
    at new BacktraceCoreClient (/usr/local/lib/node_modules/icloud-photos-sync/node_modules/@backtrace/sdk-core/lib/bundle.cjs:3042:33)
    at new BacktraceClient (/usr/local/lib/node_modules/icloud-photos-sync/node_modules/@backtrace/node/lib/bundle.cjs:1162:9)
    at BacktraceClientBuilder.build (/usr/local/lib/node_modules/icloud-photos-sync/node_modules/@backtrace/node/lib/bundle.cjs:977:26) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'spawnSync /bin/sh',
    '-c',
  spawnargs: [
  path: '/bin/sh',
    '( cat /var/lib/dbus/machine-id /etc/machine-id 2> /dev/null || hostname ) | head -n 1 || :'
  error: [Circular *1],
  ],
  status: null,
  output: null,
  signal: null,
  pid: 0,
  stdout: undefined,
  stderr: undefined
}
Node.js v22.20.0
```

The proposed change handles any exception thrown, to return `null` and triggering the existing fallback case `const guid = this.generateGuid() ?? IdGenerator.uuid();`