### PR TITLE
sdk-core: Serialize error.cause

### DIFF
--- a/packages/sdk-core/src/model/report/BacktraceReport.ts
+++ b/packages/sdk-core/src/model/report/BacktraceReport.ts
@@ -120,7 +120,7 @@ export class BacktraceReport {
                 error.cause instanceof Error && !seen.has(error.cause)
                     ? this.unwrapErrorToAnnotation(error.cause, seen)
                     : error.cause != null
-                      ? { value: String(error.cause) }
+                      ? { ...error.cause }
                       : undefined,
         };
     }

--- a/packages/sdk-core/src/model/report/BacktraceReport.ts
+++ b/packages/sdk-core/src/model/report/BacktraceReport.ts
@@ -71,12 +71,7 @@ export class BacktraceReport {
         let errorType: BacktraceErrorType = 'Exception';
         if (data instanceof Error) {
             this.message = this.generateErrorMessage(data.message);
-            this.annotations['error'] = {
-                ...data,
-                message: this.message,
-                name: data.name,
-                stack: data.stack,
-            };
+            this.annotations['error'] = this.unwrapErrorToAnnotation(data);
             this.classifiers = [data.name];
             this.stackTrace['main'] = {
                 stack: data.stack ?? '',
@@ -109,6 +104,25 @@ export class BacktraceReport {
         if (options?.classifiers) {
             this.classifiers.unshift(...options.classifiers);
         }
+    }
+
+    private unwrapErrorToAnnotation(
+        error: Error,
+        seen = new WeakSet<object>(),
+    ): Record<string, string | undefined | object> {
+        seen.add(error);
+        return {
+            ...error,
+            message: this.generateErrorMessage(error.message),
+            name: error.name,
+            stack: error.stack,
+            cause:
+                error.cause instanceof Error && !seen.has(error.cause)
+                    ? this.unwrapErrorToAnnotation(error.cause, seen)
+                    : error.cause != null
+                      ? { value: String(error.cause) }
+                      : undefined,
+        };
     }
 
     private generateErrorMessage(data: unknown) {

--- a/packages/sdk-core/src/model/report/BacktraceReport.ts
+++ b/packages/sdk-core/src/model/report/BacktraceReport.ts
@@ -117,10 +117,14 @@ export class BacktraceReport {
             name: error.name,
             stack: error.stack,
             cause:
-                error.cause instanceof Error && !seen.has(error.cause)
-                    ? this.unwrapErrorToAnnotation(error.cause, seen)
-                    : error.cause != null
-                      ? { ...error.cause }
+                error.cause instanceof Error
+                    ? seen.has(error.cause)
+                        ? `[Circular] ${error.cause.message}`
+                        : this.unwrapErrorToAnnotation(error.cause, seen)
+                    : error.cause
+                      ? typeof error.cause === 'object'
+                          ? { ...error.cause }
+                          : String(error.cause)
                       : undefined,
         };
     }

--- a/packages/sdk-core/src/model/report/BacktraceReport.ts
+++ b/packages/sdk-core/src/model/report/BacktraceReport.ts
@@ -106,10 +106,7 @@ export class BacktraceReport {
         }
     }
 
-    private unwrapErrorToAnnotation(
-        error: Error,
-        seen = new WeakSet<object>(),
-    ): Record<string, string | undefined | object> {
+    private unwrapErrorToAnnotation(error: Error, seen = new WeakSet<object>()): Record<string, unknown> {
         seen.add(error);
         return {
             ...error,
@@ -121,11 +118,7 @@ export class BacktraceReport {
                     ? seen.has(error.cause)
                         ? `[Circular] ${error.cause.message}`
                         : this.unwrapErrorToAnnotation(error.cause, seen)
-                    : error.cause
-                      ? typeof error.cause === 'object'
-                          ? { ...error.cause }
-                          : String(error.cause)
-                      : undefined,
+                    : error.cause,
         };
     }
 

--- a/packages/sdk-core/tests/report/reportTests.spec.ts
+++ b/packages/sdk-core/tests/report/reportTests.spec.ts
@@ -151,8 +151,8 @@ describe('Backtrace report generation tests', () => {
             const annotation = report.annotations['error'] as ErrorWithCause;
             const causeAnnotation = annotation.cause as ErrorWithCause;
             expect(causeAnnotation.message).toBe(cause.message);
-            // circular reference back to `a` — not recursed, falls through to string fallback
-            expect(causeAnnotation.cause).toEqual({ value: 'Error: error a' });
+            // circular reference back to `topLevelError` — not recursed, produces circular placeholder
+            expect(causeAnnotation.cause).toEqual(`[Circular] ${topLevelError.message}`);
         });
 
         it('should handle self-referencing cause without stack overflow', () => {
@@ -162,8 +162,8 @@ describe('Backtrace report generation tests', () => {
             const report = new BacktraceReport(error);
 
             const annotation = report.annotations['error'] as ErrorWithCause;
-            // cause points to itself — not recursed, falls through to string fallback
-            expect(annotation.cause).toEqual({ value: 'Error: self' });
+            // cause points to itself — not recursed, produces circular placeholder
+            expect(annotation.cause).toEqual(`[Circular] ${error.message}`);
         });
 
         it('should handle non-Error cause as string value', () => {
@@ -171,7 +171,7 @@ describe('Backtrace report generation tests', () => {
             const report = new BacktraceReport(error);
 
             const annotation = report.annotations['error'] as ErrorWithCause;
-            expect(annotation.cause).toEqual({ value: 'timeout' });
+            expect(annotation.cause).toEqual('timeout');
         });
 
         it('should handle non-Error object cause as string value', () => {

--- a/packages/sdk-core/tests/report/reportTests.spec.ts
+++ b/packages/sdk-core/tests/report/reportTests.spec.ts
@@ -102,7 +102,7 @@ describe('Backtrace report generation tests', () => {
     });
 
     describe('error annotation cause unwrapping', () => {
-        type ErrorWithCause = Error & { cause?: ErrorWithCause };
+        type ErrorWithCause = Error & { cause?: unknown };
 
         /**
          * This function is a helper to fix a potential type issue between different

--- a/packages/sdk-core/tests/report/reportTests.spec.ts
+++ b/packages/sdk-core/tests/report/reportTests.spec.ts
@@ -102,7 +102,7 @@ describe('Backtrace report generation tests', () => {
     });
 
     describe('error annotation cause unwrapping', () => {
-        type ErrorWithCause = Error & { cause?: unknown };
+        type ErrorWithCause = Error & { cause?: ErrorWithCause };
 
         /**
          * This function is a helper to fix a potential type issue between different
@@ -115,13 +115,14 @@ describe('Backtrace report generation tests', () => {
         }
 
         it('should include cause in error annotation', () => {
-            const cause = new Error('root cause');
+            const causeMessage = 'cause';
+            const cause = new Error(causeMessage);
             const error = createError('top level', cause);
             const report = new BacktraceReport(error);
 
-            const annotation = report.annotations['error'] as Record<string, unknown>;
-            const causeAnnotation = annotation.cause as Record<string, unknown>;
-            expect(causeAnnotation.message).toBe('root cause');
+            const annotation = report.annotations['error'] as ErrorWithCause;
+            const causeAnnotation = annotation.cause as ErrorWithCause;
+            expect(causeAnnotation.message).toBe(causeMessage);
             expect(causeAnnotation.name).toBe('Error');
         });
 
@@ -131,25 +132,25 @@ describe('Backtrace report generation tests', () => {
             const top = createError('top', mid);
             const report = new BacktraceReport(top);
 
-            const annotation = report.annotations['error'] as Record<string, unknown>;
-            const midAnnotation = annotation.cause as Record<string, unknown>;
-            const rootAnnotation = midAnnotation.cause as Record<string, unknown>;
-            expect(midAnnotation.message).toBe('mid');
-            expect(rootAnnotation.message).toBe('root');
+            const annotation = report.annotations['error'] as ErrorWithCause;
+            const midAnnotation = annotation.cause as ErrorWithCause;
+            const rootAnnotation = midAnnotation.cause as ErrorWithCause;
+            expect(midAnnotation.message).toBe(mid.message);
+            expect(rootAnnotation.message).toBe(root.message);
             expect(rootAnnotation.cause).toBeUndefined();
         });
 
         it('should handle circular cause without stack overflow', () => {
-            const a = createError('error a');
-            const b = createError('error b');
-            a.cause = b;
-            b.cause = a;
+            const topLevelError = createError('error a');
+            const cause = createError('error b');
+            topLevelError.cause = cause;
+            cause.cause = topLevelError;
 
-            const report = new BacktraceReport(a);
+            const report = new BacktraceReport(topLevelError);
 
-            const annotation = report.annotations['error'] as Record<string, unknown>;
-            const causeAnnotation = annotation.cause as Record<string, unknown>;
-            expect(causeAnnotation.message).toBe('error b');
+            const annotation = report.annotations['error'] as ErrorWithCause;
+            const causeAnnotation = annotation.cause as ErrorWithCause;
+            expect(causeAnnotation.message).toBe(cause.message);
             // circular reference back to `a` — not recursed, falls through to string fallback
             expect(causeAnnotation.cause).toEqual({ value: 'Error: error a' });
         });
@@ -160,7 +161,7 @@ describe('Backtrace report generation tests', () => {
 
             const report = new BacktraceReport(error);
 
-            const annotation = report.annotations['error'] as Record<string, unknown>;
+            const annotation = report.annotations['error'] as ErrorWithCause;
             // cause points to itself — not recursed, falls through to string fallback
             expect(annotation.cause).toEqual({ value: 'Error: self' });
         });
@@ -169,7 +170,7 @@ describe('Backtrace report generation tests', () => {
             const error = createError('fail', 'timeout');
             const report = new BacktraceReport(error);
 
-            const annotation = report.annotations['error'] as Record<string, unknown>;
+            const annotation = report.annotations['error'] as ErrorWithCause;
             expect(annotation.cause).toEqual({ value: 'timeout' });
         });
 
@@ -177,15 +178,15 @@ describe('Backtrace report generation tests', () => {
             const error = createError('fail', { code: 'ENOENT' });
             const report = new BacktraceReport(error);
 
-            const annotation = report.annotations['error'] as Record<string, unknown>;
-            expect(annotation.cause).toEqual({ value: '[object Object]' });
+            const annotation = report.annotations['error'] as ErrorWithCause;
+            expect(annotation.cause).toEqual({ code: 'ENOENT' });
         });
 
         it('should set cause to undefined when no cause exists', () => {
             const error = new Error('no cause');
             const report = new BacktraceReport(error);
 
-            const annotation = report.annotations['error'] as Record<string, unknown>;
+            const annotation = report.annotations['error'] as ErrorWithCause;
             expect(annotation.cause).toBeUndefined();
         });
     });

--- a/packages/sdk-core/tests/report/reportTests.spec.ts
+++ b/packages/sdk-core/tests/report/reportTests.spec.ts
@@ -100,4 +100,93 @@ describe('Backtrace report generation tests', () => {
             expect(messageReport.stackTrace[name]).toEqual(expect.objectContaining(expected));
         });
     });
+
+    describe('error annotation cause unwrapping', () => {
+        type ErrorWithCause = Error & { cause?: unknown };
+
+        /**
+         * This function is a helper to fix a potential type issue between different
+         * version of TypeScript's built-in Error type, which may or may not include the `cause` property.
+         */
+        function createError(message: string, cause?: unknown): ErrorWithCause {
+            const error: ErrorWithCause = new Error(message);
+            error.cause = cause;
+            return error;
+        }
+
+        it('should include cause in error annotation', () => {
+            const cause = new Error('root cause');
+            const error = createError('top level', cause);
+            const report = new BacktraceReport(error);
+
+            const annotation = report.annotations['error'] as Record<string, unknown>;
+            const causeAnnotation = annotation.cause as Record<string, unknown>;
+            expect(causeAnnotation.message).toBe('root cause');
+            expect(causeAnnotation.name).toBe('Error');
+        });
+
+        it('should unwrap nested cause chain', () => {
+            const root = new Error('root');
+            const mid = createError('mid', root);
+            const top = createError('top', mid);
+            const report = new BacktraceReport(top);
+
+            const annotation = report.annotations['error'] as Record<string, unknown>;
+            const midAnnotation = annotation.cause as Record<string, unknown>;
+            const rootAnnotation = midAnnotation.cause as Record<string, unknown>;
+            expect(midAnnotation.message).toBe('mid');
+            expect(rootAnnotation.message).toBe('root');
+            expect(rootAnnotation.cause).toBeUndefined();
+        });
+
+        it('should handle circular cause without stack overflow', () => {
+            const a = createError('error a');
+            const b = createError('error b');
+            a.cause = b;
+            b.cause = a;
+
+            const report = new BacktraceReport(a);
+
+            const annotation = report.annotations['error'] as Record<string, unknown>;
+            const causeAnnotation = annotation.cause as Record<string, unknown>;
+            expect(causeAnnotation.message).toBe('error b');
+            // circular reference back to `a` — not recursed, falls through to string fallback
+            expect(causeAnnotation.cause).toEqual({ value: 'Error: error a' });
+        });
+
+        it('should handle self-referencing cause without stack overflow', () => {
+            const error = createError('self');
+            error.cause = error;
+
+            const report = new BacktraceReport(error);
+
+            const annotation = report.annotations['error'] as Record<string, unknown>;
+            // cause points to itself — not recursed, falls through to string fallback
+            expect(annotation.cause).toEqual({ value: 'Error: self' });
+        });
+
+        it('should handle non-Error cause as string value', () => {
+            const error = createError('fail', 'timeout');
+            const report = new BacktraceReport(error);
+
+            const annotation = report.annotations['error'] as Record<string, unknown>;
+            expect(annotation.cause).toEqual({ value: 'timeout' });
+        });
+
+        it('should handle non-Error object cause as string value', () => {
+            const error = createError('fail', { code: 'ENOENT' });
+            const report = new BacktraceReport(error);
+
+            const annotation = report.annotations['error'] as Record<string, unknown>;
+            expect(annotation.cause).toEqual({ value: '[object Object]' });
+        });
+
+        it('should set cause to undefined when no cause exists', () => {
+            const error = new Error('no cause');
+            const report = new BacktraceReport(error);
+
+            const annotation = report.annotations['error'] as Record<string, unknown>;
+            expect(annotation.cause).toBeUndefined();
+        });
+    });
 });


### PR DESCRIPTION
**Why**
This pull request allows for serializing errors.cause. Currently, if the cause exists, it's not visible in the annotation