### PR TITLE
Backtrace-node version 0.8.1

### DIFF
--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -89,7 +89,7 @@
         "/renderer"
     ],
     "dependencies": {
-        "@backtrace/node": "^0.8.0"
+        "@backtrace/node": "^0.8.1"
     },
     "peerDependencies": {
         "electron": ">=12"

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -62,7 +62,7 @@
         "typescript": "^5.0.4"
     },
     "dependencies": {
-        "@backtrace/node": "^0.8.0"
+        "@backtrace/node": "^0.8.1"
     },
     "peerDependencies": {
         "@nestjs/common": "^9 || ^10"

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.8.1
+
+-   Added support for error.cause serialization (#360)
+
 # Version 0.8.0
 
 -   update `@backtrace/sdk-core` to `0.8.0`

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/node",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "description": "Backtrace-JavaScript Node.JS integration",
     "main": "lib/bundle.cjs",
     "module": "lib/bundle.mjs",


### PR DESCRIPTION
```
# Version 0.8.1

-   Added support for error.cause serialization (#360)

```