### PR TITLE
backtrace-browser 0.6.1

### DIFF
--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.6.1
+
+-   Added support for error.cause serialization (#360)
+
 # Version 0.6.0
 
 -   update `@backtrace/sdk-core` to `0.8.0`

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/browser",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "Backtrace-JavaScript web browser integration",
     "main": "lib/bundle.cjs",
     "module": "lib/bundle.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,7 +40,7 @@
         "/lib"
     ],
     "dependencies": {
-        "@backtrace/browser": "0.6.0"
+        "@backtrace/browser": "0.6.1"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^26.0.1",


### PR DESCRIPTION
# Version 0.6.1

-   Added support for error.cause serialization (#360)