### PR TITLE
sdk-core Version 0.8.2

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -39,7 +39,7 @@
         "/lib"
     ],
     "dependencies": {
-        "@backtrace/sdk-core": "0.8.1"
+        "@backtrace/sdk-core": "0.8.2"
     },
     "devDependencies": {
         "@reduxjs/toolkit": "^1.9.5",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -56,7 +56,7 @@
         "typescript": "^5.0.4"
     },
     "dependencies": {
-        "@backtrace/sdk-core": "^0.8.1",
+        "@backtrace/sdk-core": "^0.8.2",
         "form-data": "^4.0.0"
     }
 }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -92,7 +92,7 @@
     },
     "dependencies": {
         "@backtrace/react-native": "^0.2.1",
-        "@backtrace/sdk-core": "^0.8.1",
+        "@backtrace/sdk-core": "^0.8.2",
         "web-streams-polyfill": "^4.0.0"
     }
 }

--- a/packages/sdk-core/CHANGELOG.md
+++ b/packages/sdk-core/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.8.2
+
+-   Fixed crash when report attributes contain non-serializable objects such as revoked Proxies, broken toJSON, or spread class instances (#365)
+
 # Version 0.8.1
 
 -   Added support for error.cause serialization (#360)

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/sdk-core",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "description": "Backtrace-JavaScript SDK core library",
     "main": "lib/bundle.cjs",
     "module": "lib/bundle.mjs",

--- a/packages/session-replay/package.json
+++ b/packages/session-replay/package.json
@@ -31,7 +31,7 @@
     "homepage": "https://github.com/backtrace-labs/backtrace-javascript#readme",
     "dependencies": {
         "rrweb": "^2.0.0-alpha.15",
-        "@backtrace/sdk-core": "0.8.1"
+        "@backtrace/sdk-core": "0.8.2"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^26.0.1",


### PR DESCRIPTION
```
# Version 0.8.2

-   Fixed crash when report attributes contain non-serializable objects such as revoked Proxies, broken toJSON, or spread class instances (#365)
```