### PR TITLE
node Version 0.8.2

### DIFF
--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -89,7 +89,7 @@
         "/renderer"
     ],
     "dependencies": {
-        "@backtrace/node": "^0.8.1"
+        "@backtrace/node": "^0.8.2"
     },
     "peerDependencies": {
         "electron": ">=12"

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -62,7 +62,7 @@
         "typescript": "^5.0.4"
     },
     "dependencies": {
-        "@backtrace/node": "^0.8.1"
+        "@backtrace/node": "^0.8.2"
     },
     "peerDependencies": {
         "@nestjs/common": "^9 || ^10"

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.8.2
+
+-   Fixed crash when report attributes contain non-serializable objects such as revoked Proxies, broken toJSON, or spread class instances (#365)
+
 # Version 0.8.1
 
 -   Added support for error.cause serialization (#360)

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@backtrace/node",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "description": "Backtrace-JavaScript Node.JS integration",
     "main": "lib/bundle.cjs",
     "module": "lib/bundle.mjs",


### PR DESCRIPTION
```
# Version 0.8.2

-   Fixed crash when report attributes contain non-serializable objects such as revoked Proxies, broken toJSON, or spread class instances (#365)
```