### PR TITLE
sdk-core, node: In memory proper attribute filtering

### DIFF
--- a/packages/node/src/breadcrumbs/FileBreadcrumbsStorage.ts
+++ b/packages/node/src/breadcrumbs/FileBreadcrumbsStorage.ts
@@ -1,5 +1,4 @@
 import {
-    AttributeType,
     BacktraceAttachment,
     BacktraceAttachmentProvider,
     Breadcrumb,
@@ -108,7 +107,7 @@ export class FileBreadcrumbsStorage implements BreadcrumbsStorage {
             timestamp: TimeHelper.now(),
             type: BreadcrumbType[rawBreadcrumb.type].toLowerCase(),
             level: BreadcrumbLogLevel[rawBreadcrumb.level].toLowerCase(),
-            attributes: this.prepareAttributes(rawBreadcrumb.attributes),
+            attributes: rawBreadcrumb.attributes,
         };
         const breadcrumbJson = JSON.stringify(breadcrumb, jsonEscaper());
         const jsonLength = breadcrumbJson.length + 1; // newline
@@ -121,46 +120,6 @@ export class FileBreadcrumbsStorage implements BreadcrumbsStorage {
 
         this._dest.write(breadcrumbJson + '\n');
         return id;
-    }
-
-    private prepareAttributes(attributes?: Record<string, AttributeType>): Record<string, AttributeType> | undefined {
-        const result: Record<string, AttributeType> = {};
-        if (!attributes) {
-            return undefined;
-        }
-        for (const key in attributes) {
-            const value = attributes[key];
-            switch (typeof value) {
-                case 'number':
-                case 'boolean':
-                case 'string':
-                case 'undefined':
-                    result[key] = value;
-                    break;
-                case 'bigint':
-                    result[key] = (value as bigint).toString();
-                    break;
-                case 'object': {
-                    if (!value) {
-                        result[key] = value;
-                        break;
-                    }
-                    const unknownValue = value as unknown;
-                    try {
-                        if (unknownValue instanceof Date) {
-                            result[key] = unknownValue.toISOString();
-                        } else if (unknownValue instanceof URL) {
-                            result[key] = unknownValue.toString();
-                        }
-                    } catch {
-                        // revoked proxy or broken object — drop it
-                    }
-                    // drop all other objects
-                    break;
-                }
-            }
-        }
-        return result;
     }
 
     private static getFileName(index: number) {

--- a/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
+++ b/packages/sdk-core/src/modules/breadcrumbs/BreadcrumbsManager.ts
@@ -185,6 +185,13 @@ export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule
             rawBreadcrumb.message = rawBreadcrumb.message.substring(0, this._limits.maximumBreadcrumbMessageLength);
         }
 
+        if (rawBreadcrumb.attributes) {
+            rawBreadcrumb = {
+                ...rawBreadcrumb,
+                attributes: this.prepareAttributes(rawBreadcrumb.attributes),
+            };
+        }
+
         let limitedBreadcrumb: RawBreadcrumb | LimitedRawBreadcrumb;
         if (this._limits.maximumAttributesDepth !== undefined && rawBreadcrumb.attributes) {
             limitedBreadcrumb = {
@@ -205,6 +212,43 @@ export class BreadcrumbsManager implements BacktraceBreadcrumbs, BacktraceModule
 
         const id = this._storage.add(limitedBreadcrumb);
         return id !== undefined;
+    }
+
+    private prepareAttributes(attributes: Record<string, AttributeType>): Record<string, AttributeType> {
+        const result: Record<string, AttributeType> = {};
+        for (const key in attributes) {
+            const value = attributes[key];
+            switch (typeof value) {
+                case 'number':
+                case 'boolean':
+                case 'string':
+                case 'undefined':
+                    result[key] = value;
+                    break;
+                case 'bigint':
+                    result[key] = (value as bigint).toString();
+                    break;
+                case 'object': {
+                    if (!value) {
+                        result[key] = value;
+                        break;
+                    }
+                    const unknownValue = value as unknown;
+                    try {
+                        if (unknownValue instanceof Date) {
+                            result[key] = unknownValue.toISOString();
+                        } else if (unknownValue instanceof URL) {
+                            result[key] = unknownValue.toString();
+                        }
+                    } catch {
+                        // revoked proxy or broken object — drop it
+                    }
+                    // drop all other objects
+                    break;
+                }
+            }
+        }
+        return result;
     }
 
     /**


### PR DESCRIPTION
**Why**

Per @GT1990 comment, InMemoryAttributes are not covered. Therefore, I decided to move the implementation to the BreacrumbManager and always pass prepared attributes to the storage.