### PR TITLE
sdk-core: Limit object depth

### DIFF
--- a/packages/sdk-core/src/common/limitObjectDepth.ts
+++ b/packages/sdk-core/src/common/limitObjectDepth.ts
@@ -19,7 +19,7 @@ export function limitObjectDepth<T>(val: T, depth: number): Limited<T> {
 
     try {
         if ('toJSON' in val && typeof val.toJSON === 'function') {
-            return limitObjectDepth(val.toJSON(), depth);
+            return limitObjectDepth(val.toJSON(), depth - 1);
         }
     } catch (err) {
         if (err instanceof TypeError) {


### PR DESCRIPTION
**Why**

@melekr pointed out that a potential infinity loop can happen because of not decrementing object depth during recursion #365. This pull request properly decrease object depth