### PR TITLE
react-native: Remove self-dependency in package.json

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -91,7 +91,6 @@
         "typescript": "^5.0.2"
     },
     "dependencies": {
-        "@backtrace/react-native": "^0.2.2",
         "@backtrace/sdk-core": "^0.8.3",
         "web-streams-polyfill": "^4.0.0"
     }


### PR DESCRIPTION
Remove self dependency to `@backtrace/react-native` in react-native library.