### PR TITLE
react-native: Remove unused prettier devDependency

### DIFF
--- a/examples/sdk/reactNative/package-lock.json
+++ b/examples/sdk/reactNative/package-lock.json
@@ -31,11 +31,11 @@
         },
         "../../../packages/react-native": {
             "name": "@backtrace/react-native",
-            "version": "0.2.2",
+            "version": "0.2.0",
             "license": "MIT",
             "dependencies": {
-                "@backtrace/react-native": "^0.2.2",
-                "@backtrace/sdk-core": "^0.8.3",
+                "@backtrace/react-native": "^0.2.0",
+                "@backtrace/sdk-core": "^0.8.0",
                 "web-streams-polyfill": "^4.0.0"
             },
             "devDependencies": {
@@ -88,7 +88,7 @@
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@backtrace/sourcemap-tools": "^0.2.5",
+                "@backtrace/sourcemap-tools": "^0.2.4",
                 "command-line-args": "^5.2.1",
                 "command-line-usage": "^7.0.1",
                 "glob": "^10.3.3",
@@ -113,7 +113,7 @@
         },
         "../../../tools/sourcemap-tools": {
             "name": "@backtrace/sourcemap-tools",
-            "version": "0.2.5",
+            "version": "0.2.4",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1975,6 +1975,13 @@
             "resolved": "../../../tools/sourcemap-tools",
             "link": true
         },
+        "node_modules/@bcoe/v8-coverage": {
+            "version": "0.2.3",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true
+        },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.4.0",
             "dev": true,
@@ -2162,6 +2169,72 @@
                 "node": ">=8"
             }
         },
+        "node_modules/@jest/console": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "jest-message-util": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/core": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@jest/console": "^29.7.0",
+                "@jest/reporters": "^29.7.0",
+                "@jest/test-result": "^29.7.0",
+                "@jest/transform": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.0.0",
+                "ci-info": "^3.2.0",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.2.9",
+                "jest-changed-files": "^29.7.0",
+                "jest-config": "^29.7.0",
+                "jest-haste-map": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-regex-util": "^29.6.3",
+                "jest-resolve": "^29.7.0",
+                "jest-resolve-dependencies": "^29.7.0",
+                "jest-runner": "^29.7.0",
+                "jest-runtime": "^29.7.0",
+                "jest-snapshot": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "jest-validate": "^29.7.0",
+                "jest-watcher": "^29.7.0",
+                "micromatch": "^4.0.4",
+                "pretty-format": "^29.7.0",
+                "slash": "^3.0.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "node-notifier": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@jest/create-cache-key-function": {
             "version": "29.7.0",
             "license": "MIT",
@@ -2185,6 +2258,33 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/@jest/expect": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "expect": "^29.7.0",
+                "jest-snapshot": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/expect-utils": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "jest-get-type": "^29.6.3"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
         "node_modules/@jest/fake-timers": {
             "version": "29.7.0",
             "license": "MIT",
@@ -2200,11 +2300,135 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/@jest/globals": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@jest/environment": "^29.7.0",
+                "@jest/expect": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "jest-mock": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/reporters": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@bcoe/v8-coverage": "^0.2.3",
+                "@jest/console": "^29.7.0",
+                "@jest/test-result": "^29.7.0",
+                "@jest/transform": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@jridgewell/trace-mapping": "^0.3.18",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "collect-v8-coverage": "^1.0.0",
+                "exit": "^0.1.2",
+                "glob": "^7.1.3",
+                "graceful-fs": "^4.2.9",
+                "istanbul-lib-coverage": "^3.0.0",
+                "istanbul-lib-instrument": "^6.0.0",
+                "istanbul-lib-report": "^3.0.0",
+                "istanbul-lib-source-maps": "^4.0.0",
+                "istanbul-reports": "^3.1.3",
+                "jest-message-util": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "jest-worker": "^29.7.0",
+                "slash": "^3.0.0",
+                "string-length": "^4.0.1",
+                "strip-ansi": "^6.0.0",
+                "v8-to-istanbul": "^9.0.1"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "node-notifier": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@jest/reporters/node_modules/istanbul-lib-instrument": {
+            "version": "6.0.3",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@babel/core": "^7.23.9",
+                "@babel/parser": "^7.23.9",
+                "@istanbuljs/schema": "^0.1.3",
+                "istanbul-lib-coverage": "^3.2.0",
+                "semver": "^7.5.4"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/@jest/schemas": {
             "version": "29.6.3",
             "license": "MIT",
             "dependencies": {
                 "@sinclair/typebox": "^0.27.8"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/source-map": {
+            "version": "29.6.3",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.18",
+                "callsites": "^3.0.0",
+                "graceful-fs": "^4.2.9"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/test-result": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@jest/console": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "collect-v8-coverage": "^1.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@jest/test-sequencer": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@jest/test-result": "^29.7.0",
+                "graceful-fs": "^4.2.9",
+                "jest-haste-map": "^29.7.0",
+                "slash": "^3.0.0"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -3060,6 +3284,35 @@
             "version": "1.4.10",
             "license": "MIT"
         },
+        "node_modules/ansi-escapes": {
+            "version": "4.3.2",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "type-fest": "^0.21.3"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ansi-escapes/node_modules/type-fest": {
+            "version": "0.21.3",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
             "license": "MIT",
@@ -3601,6 +3854,16 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
+        "node_modules/char-regex": {
+            "version": "1.0.2",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/chrome-launcher": {
             "version": "0.15.2",
             "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.2.tgz",
@@ -3646,6 +3909,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/cjs-module-lexer": {
+            "version": "1.4.1",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true
+        },
         "node_modules/cliui": {
             "version": "8.0.1",
             "license": "ISC",
@@ -3671,6 +3941,24 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/co": {
+            "version": "4.6.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "iojs": ">= 1.0.0",
+                "node": ">= 0.12.0"
+            }
+        },
+        "node_modules/collect-v8-coverage": {
+            "version": "1.0.2",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/commander": {
             "version": "12.1.0",
@@ -3799,6 +4087,28 @@
                 "node": ">=4"
             }
         },
+        "node_modules/create-jest": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@jest/types": "^29.6.3",
+                "chalk": "^4.0.0",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.2.9",
+                "jest-config": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "prompts": "^2.0.1"
+            },
+            "bin": {
+                "create-jest": "bin/create-jest.js"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
             "dev": true,
@@ -3881,11 +4191,36 @@
                 }
             }
         },
+        "node_modules/dedent": {
+            "version": "1.5.3",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "peerDependencies": {
+                "babel-plugin-macros": "^3.1.0"
+            },
+            "peerDependenciesMeta": {
+                "babel-plugin-macros": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "dev": true,
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/deepmerge": {
+            "version": "4.3.1",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/define-data-property": {
             "version": "1.1.4",
@@ -3938,6 +4273,26 @@
                 "npm": "1.2.8000 || >= 1.4.16"
             }
         },
+        "node_modules/detect-newline": {
+            "version": "3.1.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/diff-sequences": {
+            "version": "29.6.3",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
         "node_modules/dir-glob": {
             "version": "3.0.1",
             "dev": true,
@@ -3970,6 +4325,19 @@
         "node_modules/electron-to-chromium": {
             "version": "1.5.29",
             "license": "ISC"
+        },
+        "node_modules/emittery": {
+            "version": "0.13.1",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+            }
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -4637,6 +5005,56 @@
                 "node": ">=6"
             }
         },
+        "node_modules/execa": {
+            "version": "5.1.1",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/exit": {
+            "version": "0.1.2",
+            "dev": true,
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/expect": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@jest/expect-utils": "^29.7.0",
+                "jest-get-type": "^29.6.3",
+                "jest-matcher-utils": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-util": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
         "node_modules/exponential-backoff": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
@@ -4953,6 +5371,19 @@
                 "node": ">=8.0.0"
             }
         },
+        "node_modules/get-stream": {
+            "version": "6.0.1",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/get-symbol-description": {
             "version": "1.0.2",
             "dev": true,
@@ -5147,6 +5578,13 @@
                 "hermes-estree": "0.25.1"
             }
         },
+        "node_modules/html-escaper": {
+            "version": "2.0.2",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true
+        },
         "node_modules/http-errors": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -5170,6 +5608,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/human-signals": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=10.17.0"
             }
         },
         "node_modules/ignore": {
@@ -5218,6 +5666,95 @@
             "peer": true,
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/import-local": {
+            "version": "3.2.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "pkg-dir": "^4.2.0",
+                "resolve-cwd": "^3.0.0"
+            },
+            "bin": {
+                "import-local-fixture": "fixtures/cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/import-local/node_modules/find-up": {
+            "version": "4.1.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/import-local/node_modules/locate-path": {
+            "version": "5.0.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "p-locate": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/import-local/node_modules/p-limit": {
+            "version": "2.3.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/import-local/node_modules/p-locate": {
+            "version": "4.1.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "p-limit": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/import-local/node_modules/pkg-dir": {
+            "version": "4.2.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "find-up": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/imurmurhash": {
@@ -5422,6 +5959,16 @@
                 "node": ">=8"
             }
         },
+        "node_modules/is-generator-fn": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/is-generator-function": {
             "version": "1.0.10",
             "dev": true,
@@ -5549,6 +6096,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-stream": {
+            "version": "2.0.1",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-string": {
@@ -5690,6 +6250,66 @@
                 "semver": "bin/semver.js"
             }
         },
+        "node_modules/istanbul-lib-report": {
+            "version": "3.0.1",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "istanbul-lib-coverage": "^3.0.0",
+                "make-dir": "^4.0.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/istanbul-lib-report/node_modules/make-dir": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "semver": "^7.5.3"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/istanbul-lib-source-maps": {
+            "version": "4.0.1",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^3.0.0",
+                "source-map": "^0.6.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/istanbul-reports": {
+            "version": "3.1.7",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "html-escaper": "^2.0.0",
+                "istanbul-lib-report": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/iterator.prototype": {
             "version": "1.1.2",
             "dev": true,
@@ -5700,6 +6320,206 @@
                 "has-symbols": "^1.0.3",
                 "reflect.getprototypeof": "^1.0.4",
                 "set-function-name": "^2.0.1"
+            }
+        },
+        "node_modules/jest": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@jest/core": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "import-local": "^3.0.2",
+                "jest-cli": "^29.7.0"
+            },
+            "bin": {
+                "jest": "bin/jest.js"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "node-notifier": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jest-changed-files": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "execa": "^5.0.0",
+                "jest-util": "^29.7.0",
+                "p-limit": "^3.1.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-circus": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@jest/environment": "^29.7.0",
+                "@jest/expect": "^29.7.0",
+                "@jest/test-result": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "co": "^4.6.0",
+                "dedent": "^1.0.0",
+                "is-generator-fn": "^2.0.0",
+                "jest-each": "^29.7.0",
+                "jest-matcher-utils": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-runtime": "^29.7.0",
+                "jest-snapshot": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "p-limit": "^3.1.0",
+                "pretty-format": "^29.7.0",
+                "pure-rand": "^6.0.0",
+                "slash": "^3.0.0",
+                "stack-utils": "^2.0.3"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-cli": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@jest/core": "^29.7.0",
+                "@jest/test-result": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "chalk": "^4.0.0",
+                "create-jest": "^29.7.0",
+                "exit": "^0.1.2",
+                "import-local": "^3.0.2",
+                "jest-config": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "jest-validate": "^29.7.0",
+                "yargs": "^17.3.1"
+            },
+            "bin": {
+                "jest": "bin/jest.js"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "node-notifier": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jest-config": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@babel/core": "^7.11.6",
+                "@jest/test-sequencer": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "babel-jest": "^29.7.0",
+                "chalk": "^4.0.0",
+                "ci-info": "^3.2.0",
+                "deepmerge": "^4.2.2",
+                "glob": "^7.1.3",
+                "graceful-fs": "^4.2.9",
+                "jest-circus": "^29.7.0",
+                "jest-environment-node": "^29.7.0",
+                "jest-get-type": "^29.6.3",
+                "jest-regex-util": "^29.6.3",
+                "jest-resolve": "^29.7.0",
+                "jest-runner": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "jest-validate": "^29.7.0",
+                "micromatch": "^4.0.4",
+                "parse-json": "^5.2.0",
+                "pretty-format": "^29.7.0",
+                "slash": "^3.0.0",
+                "strip-json-comments": "^3.1.1"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            },
+            "peerDependencies": {
+                "@types/node": "*",
+                "ts-node": ">=9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "ts-node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jest-diff": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "chalk": "^4.0.0",
+                "diff-sequences": "^29.6.3",
+                "jest-get-type": "^29.6.3",
+                "pretty-format": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-docblock": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "detect-newline": "^3.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-each": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@jest/types": "^29.6.3",
+                "chalk": "^4.0.0",
+                "jest-get-type": "^29.6.3",
+                "jest-util": "^29.7.0",
+                "pretty-format": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-environment-node": {
@@ -5747,6 +6567,36 @@
                 "fsevents": "^2.3.2"
             }
         },
+        "node_modules/jest-leak-detector": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "jest-get-type": "^29.6.3",
+                "pretty-format": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-matcher-utils": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "chalk": "^4.0.0",
+                "jest-diff": "^29.7.0",
+                "jest-get-type": "^29.6.3",
+                "pretty-format": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
         "node_modules/jest-message-util": {
             "version": "29.7.0",
             "license": "MIT",
@@ -5777,9 +6627,172 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/jest-pnp-resolver": {
+            "version": "1.2.3",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=6"
+            },
+            "peerDependencies": {
+                "jest-resolve": "*"
+            },
+            "peerDependenciesMeta": {
+                "jest-resolve": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/jest-regex-util": {
             "version": "29.6.3",
             "license": "MIT",
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-resolve": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.9",
+                "jest-haste-map": "^29.7.0",
+                "jest-pnp-resolver": "^1.2.2",
+                "jest-util": "^29.7.0",
+                "jest-validate": "^29.7.0",
+                "resolve": "^1.20.0",
+                "resolve.exports": "^2.0.0",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-resolve-dependencies": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "jest-regex-util": "^29.6.3",
+                "jest-snapshot": "^29.7.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-runner": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@jest/console": "^29.7.0",
+                "@jest/environment": "^29.7.0",
+                "@jest/test-result": "^29.7.0",
+                "@jest/transform": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "emittery": "^0.13.1",
+                "graceful-fs": "^4.2.9",
+                "jest-docblock": "^29.7.0",
+                "jest-environment-node": "^29.7.0",
+                "jest-haste-map": "^29.7.0",
+                "jest-leak-detector": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-resolve": "^29.7.0",
+                "jest-runtime": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "jest-watcher": "^29.7.0",
+                "jest-worker": "^29.7.0",
+                "p-limit": "^3.1.0",
+                "source-map-support": "0.5.13"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-runner/node_modules/source-map-support": {
+            "version": "0.5.13",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "node_modules/jest-runtime": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@jest/environment": "^29.7.0",
+                "@jest/fake-timers": "^29.7.0",
+                "@jest/globals": "^29.7.0",
+                "@jest/source-map": "^29.6.3",
+                "@jest/test-result": "^29.7.0",
+                "@jest/transform": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "cjs-module-lexer": "^1.0.0",
+                "collect-v8-coverage": "^1.0.0",
+                "glob": "^7.1.3",
+                "graceful-fs": "^4.2.9",
+                "jest-haste-map": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-mock": "^29.7.0",
+                "jest-regex-util": "^29.6.3",
+                "jest-resolve": "^29.7.0",
+                "jest-snapshot": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "slash": "^3.0.0",
+                "strip-bom": "^4.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-snapshot": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@babel/core": "^7.11.6",
+                "@babel/generator": "^7.7.2",
+                "@babel/plugin-syntax-jsx": "^7.7.2",
+                "@babel/plugin-syntax-typescript": "^7.7.2",
+                "@babel/types": "^7.3.3",
+                "@jest/expect-utils": "^29.7.0",
+                "@jest/transform": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "babel-preset-current-node-syntax": "^1.0.0",
+                "chalk": "^4.0.0",
+                "expect": "^29.7.0",
+                "graceful-fs": "^4.2.9",
+                "jest-diff": "^29.7.0",
+                "jest-get-type": "^29.6.3",
+                "jest-matcher-utils": "^29.7.0",
+                "jest-message-util": "^29.7.0",
+                "jest-util": "^29.7.0",
+                "natural-compare": "^1.4.0",
+                "pretty-format": "^29.7.0",
+                "semver": "^7.5.3"
+            },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
@@ -5822,6 +6835,26 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/jest-watcher": {
+            "version": "29.7.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@jest/test-result": "^29.7.0",
+                "@jest/types": "^29.6.3",
+                "@types/node": "*",
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.0.0",
+                "emittery": "^0.13.1",
+                "jest-util": "^29.7.0",
+                "string-length": "^4.0.1"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-worker": {
@@ -5946,6 +6979,13 @@
             "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
             "license": "MIT"
         },
+        "node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true
+        },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "dev": true,
@@ -6000,6 +7040,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/kleur": {
+            "version": "3.0.3",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/leven": {
             "version": "3.1.0",
             "license": "MIT",
@@ -6044,6 +7094,13 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "license": "MIT"
+        },
+        "node_modules/lines-and-columns": {
+            "version": "1.2.4",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/locate-path": {
             "version": "3.0.0",
@@ -6524,6 +7581,16 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/minimatch": {
             "version": "3.1.2",
             "license": "ISC",
@@ -6600,6 +7667,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm-run-path": {
+            "version": "4.0.1",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "path-key": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/nullthrows": {
@@ -6729,6 +7809,22 @@
                 "wrappy": "1"
             }
         },
+        "node_modules/onetime": {
+            "version": "5.1.2",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/open": {
             "version": "7.4.2",
             "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
@@ -6821,6 +7917,25 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/parse-json": {
+            "version": "5.2.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/parseurl": {
@@ -6984,6 +8099,20 @@
                 "asap": "~2.0.6"
             }
         },
+        "node_modules/prompts": {
+            "version": "2.4.2",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "kleur": "^3.0.3",
+                "sisteransi": "^1.0.5"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/prop-types": {
             "version": "15.8.1",
             "dev": true,
@@ -7007,6 +8136,23 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/pure-rand": {
+            "version": "6.1.0",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/dubzzz"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fast-check"
+                }
+            ],
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/queue": {
             "version": "6.0.2",
@@ -7286,11 +8432,34 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/resolve-cwd": {
+            "version": "3.0.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "resolve-from": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/resolve-from": {
             "version": "5.0.0",
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/resolve.exports": {
+            "version": "2.0.2",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/reusify": {
@@ -7595,6 +8764,13 @@
             "version": "3.0.7",
             "license": "ISC"
         },
+        "node_modules/sisteransi": {
+            "version": "1.0.5",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true
+        },
         "node_modules/slash": {
             "version": "3.0.0",
             "license": "MIT",
@@ -7670,6 +8846,20 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/string-length": {
+            "version": "4.0.2",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "char-regex": "^1.0.2",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/string-natural-compare": {
@@ -7777,6 +8967,26 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/strip-bom": {
+            "version": "4.0.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-final-newline": {
+            "version": "2.0.0",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/strip-json-comments": {
@@ -8148,6 +9358,21 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/v8-to-istanbul": {
+            "version": "9.3.0",
+            "dev": true,
+            "license": "ISC",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.12",
+                "@types/istanbul-lib-coverage": "^2.0.1",
+                "convert-source-map": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.12.0"
             }
         },
         "node_modules/vlq": {

--- a/examples/sdk/reactNative/package-lock.json
+++ b/examples/sdk/reactNative/package-lock.json
@@ -31,11 +31,11 @@
         },
         "../../../packages/react-native": {
             "name": "@backtrace/react-native",
-            "version": "0.2.0",
+            "version": "0.2.2",
             "license": "MIT",
             "dependencies": {
-                "@backtrace/react-native": "^0.2.0",
-                "@backtrace/sdk-core": "^0.8.0",
+                "@backtrace/react-native": "^0.2.2",
+                "@backtrace/sdk-core": "^0.8.3",
                 "web-streams-polyfill": "^4.0.0"
             },
             "devDependencies": {
@@ -88,7 +88,7 @@
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@backtrace/sourcemap-tools": "^0.2.4",
+                "@backtrace/sourcemap-tools": "^0.2.5",
                 "command-line-args": "^5.2.1",
                 "command-line-usage": "^7.0.1",
                 "glob": "^10.3.3",
@@ -113,7 +113,7 @@
         },
         "../../../tools/sourcemap-tools": {
             "name": "@backtrace/sourcemap-tools",
-            "version": "0.2.4",
+            "version": "0.2.5",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1975,13 +1975,6 @@
             "resolved": "../../../tools/sourcemap-tools",
             "link": true
         },
-        "node_modules/@bcoe/v8-coverage": {
-            "version": "0.2.3",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.4.0",
             "dev": true,
@@ -2169,72 +2162,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@jest/console": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "jest-message-util": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/core": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/console": "^29.7.0",
-                "@jest/reporters": "^29.7.0",
-                "@jest/test-result": "^29.7.0",
-                "@jest/transform": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "ansi-escapes": "^4.2.1",
-                "chalk": "^4.0.0",
-                "ci-info": "^3.2.0",
-                "exit": "^0.1.2",
-                "graceful-fs": "^4.2.9",
-                "jest-changed-files": "^29.7.0",
-                "jest-config": "^29.7.0",
-                "jest-haste-map": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-regex-util": "^29.6.3",
-                "jest-resolve": "^29.7.0",
-                "jest-resolve-dependencies": "^29.7.0",
-                "jest-runner": "^29.7.0",
-                "jest-runtime": "^29.7.0",
-                "jest-snapshot": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "jest-validate": "^29.7.0",
-                "jest-watcher": "^29.7.0",
-                "micromatch": "^4.0.4",
-                "pretty-format": "^29.7.0",
-                "slash": "^3.0.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-            },
-            "peerDependenciesMeta": {
-                "node-notifier": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@jest/create-cache-key-function": {
             "version": "29.7.0",
             "license": "MIT",
@@ -2258,33 +2185,6 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/@jest/expect": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "expect": "^29.7.0",
-                "jest-snapshot": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/expect-utils": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "jest-get-type": "^29.6.3"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
         "node_modules/@jest/fake-timers": {
             "version": "29.7.0",
             "license": "MIT",
@@ -2300,135 +2200,11 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/@jest/globals": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/environment": "^29.7.0",
-                "@jest/expect": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "jest-mock": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/reporters": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@bcoe/v8-coverage": "^0.2.3",
-                "@jest/console": "^29.7.0",
-                "@jest/test-result": "^29.7.0",
-                "@jest/transform": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@jridgewell/trace-mapping": "^0.3.18",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "collect-v8-coverage": "^1.0.0",
-                "exit": "^0.1.2",
-                "glob": "^7.1.3",
-                "graceful-fs": "^4.2.9",
-                "istanbul-lib-coverage": "^3.0.0",
-                "istanbul-lib-instrument": "^6.0.0",
-                "istanbul-lib-report": "^3.0.0",
-                "istanbul-lib-source-maps": "^4.0.0",
-                "istanbul-reports": "^3.1.3",
-                "jest-message-util": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "jest-worker": "^29.7.0",
-                "slash": "^3.0.0",
-                "string-length": "^4.0.1",
-                "strip-ansi": "^6.0.0",
-                "v8-to-istanbul": "^9.0.1"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-            },
-            "peerDependenciesMeta": {
-                "node-notifier": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@jest/reporters/node_modules/istanbul-lib-instrument": {
-            "version": "6.0.3",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@babel/core": "^7.23.9",
-                "@babel/parser": "^7.23.9",
-                "@istanbuljs/schema": "^0.1.3",
-                "istanbul-lib-coverage": "^3.2.0",
-                "semver": "^7.5.4"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@jest/schemas": {
             "version": "29.6.3",
             "license": "MIT",
             "dependencies": {
                 "@sinclair/typebox": "^0.27.8"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/source-map": {
-            "version": "29.6.3",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.18",
-                "callsites": "^3.0.0",
-                "graceful-fs": "^4.2.9"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/test-result": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/console": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "collect-v8-coverage": "^1.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/test-sequencer": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/test-result": "^29.7.0",
-                "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.7.0",
-                "slash": "^3.0.0"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -3284,35 +3060,6 @@
             "version": "1.4.10",
             "license": "MIT"
         },
-        "node_modules/ansi-escapes": {
-            "version": "4.3.2",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "type-fest": "^0.21.3"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/ansi-escapes/node_modules/type-fest": {
-            "version": "0.21.3",
-            "dev": true,
-            "license": "(MIT OR CC0-1.0)",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
             "license": "MIT",
@@ -3854,16 +3601,6 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
-        "node_modules/char-regex": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/chrome-launcher": {
             "version": "0.15.2",
             "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.2.tgz",
@@ -3909,13 +3646,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/cjs-module-lexer": {
-            "version": "1.4.1",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/cliui": {
             "version": "8.0.1",
             "license": "ISC",
@@ -3941,24 +3671,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/co": {
-            "version": "4.6.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "iojs": ">= 1.0.0",
-                "node": ">= 0.12.0"
-            }
-        },
-        "node_modules/collect-v8-coverage": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/commander": {
             "version": "12.1.0",
@@ -4087,28 +3799,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/create-jest": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "chalk": "^4.0.0",
-                "exit": "^0.1.2",
-                "graceful-fs": "^4.2.9",
-                "jest-config": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "prompts": "^2.0.1"
-            },
-            "bin": {
-                "create-jest": "bin/create-jest.js"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
             "dev": true,
@@ -4191,36 +3881,11 @@
                 }
             }
         },
-        "node_modules/dedent": {
-            "version": "1.5.3",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "peerDependencies": {
-                "babel-plugin-macros": "^3.1.0"
-            },
-            "peerDependenciesMeta": {
-                "babel-plugin-macros": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "dev": true,
             "license": "MIT",
             "peer": true
-        },
-        "node_modules/deepmerge": {
-            "version": "4.3.1",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/define-data-property": {
             "version": "1.1.4",
@@ -4273,26 +3938,6 @@
                 "npm": "1.2.8000 || >= 1.4.16"
             }
         },
-        "node_modules/detect-newline": {
-            "version": "3.1.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/diff-sequences": {
-            "version": "29.6.3",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
         "node_modules/dir-glob": {
             "version": "3.0.1",
             "dev": true,
@@ -4325,19 +3970,6 @@
         "node_modules/electron-to-chromium": {
             "version": "1.5.29",
             "license": "ISC"
-        },
-        "node_modules/emittery": {
-            "version": "0.13.1",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/emittery?sponsor=1"
-            }
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -5005,56 +4637,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/execa": {
-            "version": "5.1.1",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.0",
-                "human-signals": "^2.1.0",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.1",
-                "onetime": "^5.1.2",
-                "signal-exit": "^3.0.3",
-                "strip-final-newline": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/exit": {
-            "version": "0.1.2",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/expect": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/expect-utils": "^29.7.0",
-                "jest-get-type": "^29.6.3",
-                "jest-matcher-utils": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-util": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
         "node_modules/exponential-backoff": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
@@ -5371,19 +4953,6 @@
                 "node": ">=8.0.0"
             }
         },
-        "node_modules/get-stream": {
-            "version": "6.0.1",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/get-symbol-description": {
             "version": "1.0.2",
             "dev": true,
@@ -5578,13 +5147,6 @@
                 "hermes-estree": "0.25.1"
             }
         },
-        "node_modules/html-escaper": {
-            "version": "2.0.2",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/http-errors": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -5608,16 +5170,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/human-signals": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10.17.0"
             }
         },
         "node_modules/ignore": {
@@ -5666,95 +5218,6 @@
             "peer": true,
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/import-local": {
-            "version": "3.2.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "pkg-dir": "^4.2.0",
-                "resolve-cwd": "^3.0.0"
-            },
-            "bin": {
-                "import-local-fixture": "fixtures/cli.js"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/import-local/node_modules/find-up": {
-            "version": "4.1.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/import-local/node_modules/locate-path": {
-            "version": "5.0.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "p-locate": "^4.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/import-local/node_modules/p-limit": {
-            "version": "2.3.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "p-try": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/import-local/node_modules/p-locate": {
-            "version": "4.1.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "p-limit": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/import-local/node_modules/pkg-dir": {
-            "version": "4.2.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "find-up": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/imurmurhash": {
@@ -5959,16 +5422,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/is-generator-fn": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/is-generator-function": {
             "version": "1.0.10",
             "dev": true,
@@ -6096,19 +5549,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-stream": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-string": {
@@ -6250,66 +5690,6 @@
                 "semver": "bin/semver.js"
             }
         },
-        "node_modules/istanbul-lib-report": {
-            "version": "3.0.1",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "istanbul-lib-coverage": "^3.0.0",
-                "make-dir": "^4.0.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/istanbul-lib-report/node_modules/make-dir": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "semver": "^7.5.3"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/istanbul-lib-source-maps": {
-            "version": "4.0.1",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "debug": "^4.1.1",
-                "istanbul-lib-coverage": "^3.0.0",
-                "source-map": "^0.6.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/istanbul-reports": {
-            "version": "3.1.7",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "html-escaper": "^2.0.0",
-                "istanbul-lib-report": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/iterator.prototype": {
             "version": "1.1.2",
             "dev": true,
@@ -6320,206 +5700,6 @@
                 "has-symbols": "^1.0.3",
                 "reflect.getprototypeof": "^1.0.4",
                 "set-function-name": "^2.0.1"
-            }
-        },
-        "node_modules/jest": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/core": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "import-local": "^3.0.2",
-                "jest-cli": "^29.7.0"
-            },
-            "bin": {
-                "jest": "bin/jest.js"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-            },
-            "peerDependenciesMeta": {
-                "node-notifier": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/jest-changed-files": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "execa": "^5.0.0",
-                "jest-util": "^29.7.0",
-                "p-limit": "^3.1.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-circus": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/environment": "^29.7.0",
-                "@jest/expect": "^29.7.0",
-                "@jest/test-result": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "co": "^4.6.0",
-                "dedent": "^1.0.0",
-                "is-generator-fn": "^2.0.0",
-                "jest-each": "^29.7.0",
-                "jest-matcher-utils": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-runtime": "^29.7.0",
-                "jest-snapshot": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "p-limit": "^3.1.0",
-                "pretty-format": "^29.7.0",
-                "pure-rand": "^6.0.0",
-                "slash": "^3.0.0",
-                "stack-utils": "^2.0.3"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-cli": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/core": "^29.7.0",
-                "@jest/test-result": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "chalk": "^4.0.0",
-                "create-jest": "^29.7.0",
-                "exit": "^0.1.2",
-                "import-local": "^3.0.2",
-                "jest-config": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "jest-validate": "^29.7.0",
-                "yargs": "^17.3.1"
-            },
-            "bin": {
-                "jest": "bin/jest.js"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-            },
-            "peerDependenciesMeta": {
-                "node-notifier": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/jest-config": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@babel/core": "^7.11.6",
-                "@jest/test-sequencer": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "babel-jest": "^29.7.0",
-                "chalk": "^4.0.0",
-                "ci-info": "^3.2.0",
-                "deepmerge": "^4.2.2",
-                "glob": "^7.1.3",
-                "graceful-fs": "^4.2.9",
-                "jest-circus": "^29.7.0",
-                "jest-environment-node": "^29.7.0",
-                "jest-get-type": "^29.6.3",
-                "jest-regex-util": "^29.6.3",
-                "jest-resolve": "^29.7.0",
-                "jest-runner": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "jest-validate": "^29.7.0",
-                "micromatch": "^4.0.4",
-                "parse-json": "^5.2.0",
-                "pretty-format": "^29.7.0",
-                "slash": "^3.0.0",
-                "strip-json-comments": "^3.1.1"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "@types/node": "*",
-                "ts-node": ">=9.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "ts-node": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/jest-diff": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "chalk": "^4.0.0",
-                "diff-sequences": "^29.6.3",
-                "jest-get-type": "^29.6.3",
-                "pretty-format": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-docblock": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "detect-newline": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-each": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "chalk": "^4.0.0",
-                "jest-get-type": "^29.6.3",
-                "jest-util": "^29.7.0",
-                "pretty-format": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-environment-node": {
@@ -6567,36 +5747,6 @@
                 "fsevents": "^2.3.2"
             }
         },
-        "node_modules/jest-leak-detector": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "jest-get-type": "^29.6.3",
-                "pretty-format": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-matcher-utils": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "chalk": "^4.0.0",
-                "jest-diff": "^29.7.0",
-                "jest-get-type": "^29.6.3",
-                "pretty-format": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
         "node_modules/jest-message-util": {
             "version": "29.7.0",
             "license": "MIT",
@@ -6627,172 +5777,9 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/jest-pnp-resolver": {
-            "version": "1.2.3",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=6"
-            },
-            "peerDependencies": {
-                "jest-resolve": "*"
-            },
-            "peerDependenciesMeta": {
-                "jest-resolve": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/jest-regex-util": {
             "version": "29.6.3",
             "license": "MIT",
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-resolve": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "chalk": "^4.0.0",
-                "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.7.0",
-                "jest-pnp-resolver": "^1.2.2",
-                "jest-util": "^29.7.0",
-                "jest-validate": "^29.7.0",
-                "resolve": "^1.20.0",
-                "resolve.exports": "^2.0.0",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-resolve-dependencies": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "jest-regex-util": "^29.6.3",
-                "jest-snapshot": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-runner": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/console": "^29.7.0",
-                "@jest/environment": "^29.7.0",
-                "@jest/test-result": "^29.7.0",
-                "@jest/transform": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "emittery": "^0.13.1",
-                "graceful-fs": "^4.2.9",
-                "jest-docblock": "^29.7.0",
-                "jest-environment-node": "^29.7.0",
-                "jest-haste-map": "^29.7.0",
-                "jest-leak-detector": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-resolve": "^29.7.0",
-                "jest-runtime": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "jest-watcher": "^29.7.0",
-                "jest-worker": "^29.7.0",
-                "p-limit": "^3.1.0",
-                "source-map-support": "0.5.13"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-runner/node_modules/source-map-support": {
-            "version": "0.5.13",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
-            }
-        },
-        "node_modules/jest-runtime": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/environment": "^29.7.0",
-                "@jest/fake-timers": "^29.7.0",
-                "@jest/globals": "^29.7.0",
-                "@jest/source-map": "^29.6.3",
-                "@jest/test-result": "^29.7.0",
-                "@jest/transform": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "cjs-module-lexer": "^1.0.0",
-                "collect-v8-coverage": "^1.0.0",
-                "glob": "^7.1.3",
-                "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-mock": "^29.7.0",
-                "jest-regex-util": "^29.6.3",
-                "jest-resolve": "^29.7.0",
-                "jest-snapshot": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "slash": "^3.0.0",
-                "strip-bom": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-snapshot": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@babel/core": "^7.11.6",
-                "@babel/generator": "^7.7.2",
-                "@babel/plugin-syntax-jsx": "^7.7.2",
-                "@babel/plugin-syntax-typescript": "^7.7.2",
-                "@babel/types": "^7.3.3",
-                "@jest/expect-utils": "^29.7.0",
-                "@jest/transform": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "babel-preset-current-node-syntax": "^1.0.0",
-                "chalk": "^4.0.0",
-                "expect": "^29.7.0",
-                "graceful-fs": "^4.2.9",
-                "jest-diff": "^29.7.0",
-                "jest-get-type": "^29.6.3",
-                "jest-matcher-utils": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "natural-compare": "^1.4.0",
-                "pretty-format": "^29.7.0",
-                "semver": "^7.5.3"
-            },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
@@ -6835,26 +5822,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/jest-watcher": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/test-result": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "ansi-escapes": "^4.2.1",
-                "chalk": "^4.0.0",
-                "emittery": "^0.13.1",
-                "jest-util": "^29.7.0",
-                "string-length": "^4.0.1"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-worker": {
@@ -6979,13 +5946,6 @@
             "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
             "license": "MIT"
         },
-        "node_modules/json-parse-even-better-errors": {
-            "version": "2.3.1",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "dev": true,
@@ -7040,16 +6000,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/kleur": {
-            "version": "3.0.3",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/leven": {
             "version": "3.1.0",
             "license": "MIT",
@@ -7094,13 +6044,6 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "license": "MIT"
-        },
-        "node_modules/lines-and-columns": {
-            "version": "1.2.4",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/locate-path": {
             "version": "3.0.0",
@@ -7581,16 +6524,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/minimatch": {
             "version": "3.1.2",
             "license": "ISC",
@@ -7667,19 +6600,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/npm-run-path": {
-            "version": "4.0.1",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "path-key": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/nullthrows": {
@@ -7809,22 +6729,6 @@
                 "wrappy": "1"
             }
         },
-        "node_modules/onetime": {
-            "version": "5.1.2",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/open": {
             "version": "7.4.2",
             "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
@@ -7917,25 +6821,6 @@
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/parse-json": {
-            "version": "5.2.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@babel/code-frame": "^7.0.0",
-                "error-ex": "^1.3.1",
-                "json-parse-even-better-errors": "^2.3.0",
-                "lines-and-columns": "^1.1.6"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/parseurl": {
@@ -8099,20 +6984,6 @@
                 "asap": "~2.0.6"
             }
         },
-        "node_modules/prompts": {
-            "version": "2.4.2",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "kleur": "^3.0.3",
-                "sisteransi": "^1.0.5"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/prop-types": {
             "version": "15.8.1",
             "dev": true,
@@ -8136,23 +7007,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/pure-rand": {
-            "version": "6.1.0",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/dubzzz"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fast-check"
-                }
-            ],
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/queue": {
             "version": "6.0.2",
@@ -8432,34 +7286,11 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/resolve-cwd": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "resolve-from": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/resolve-from": {
             "version": "5.0.0",
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/resolve.exports": {
-            "version": "2.0.2",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/reusify": {
@@ -8764,13 +7595,6 @@
             "version": "3.0.7",
             "license": "ISC"
         },
-        "node_modules/sisteransi": {
-            "version": "1.0.5",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/slash": {
             "version": "3.0.0",
             "license": "MIT",
@@ -8846,20 +7670,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/string-length": {
-            "version": "4.0.2",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "char-regex": "^1.0.2",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/string-natural-compare": {
@@ -8967,26 +7777,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/strip-bom": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/strip-final-newline": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/strip-json-comments": {
@@ -9358,21 +8148,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4.0"
-            }
-        },
-        "node_modules/v8-to-istanbul": {
-            "version": "9.3.0",
-            "dev": true,
-            "license": "ISC",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.12",
-                "@types/istanbul-lib-coverage": "^2.0.1",
-                "convert-source-map": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.12.0"
             }
         },
         "node_modules/vlq": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7501,22 +7501,6 @@
                 "node": ">=6.0"
             }
         },
-        "node_modules/chromium-bidi": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.3.tgz",
-            "integrity": "sha512-qXlsCmpCZJAnoTYI83Iu6EdYQpMYdVkCfq08KDh2pmlVqK5t5IA9mGs4/LwCwp4fqisSOMXZxP3HIh8w8aRn0A==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "mitt": "3.0.1",
-                "urlpattern-polyfill": "10.0.0",
-                "zod": "3.23.8"
-            },
-            "peerDependencies": {
-                "devtools-protocol": "*"
-            }
-        },
         "node_modules/ci-info": {
             "version": "3.9.0",
             "dev": true,
@@ -18230,56 +18214,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/puppeteer-core": {
-            "version": "22.15.0",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.15.0.tgz",
-            "integrity": "sha512-cHArnywCiAAVXa3t4GGL2vttNxh7GqXtIYGym99egkNJ3oG//wL9LkvO4WE8W1TJe95t1F1ocu9X4xWaGsOKOA==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@puppeteer/browsers": "2.3.0",
-                "chromium-bidi": "0.6.3",
-                "debug": "^4.3.6",
-                "devtools-protocol": "0.0.1312386",
-                "ws": "^8.18.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/@puppeteer/browsers": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.3.0.tgz",
-            "integrity": "sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "debug": "^4.3.5",
-                "extract-zip": "^2.0.1",
-                "progress": "^2.0.3",
-                "proxy-agent": "^6.4.0",
-                "semver": "^7.6.3",
-                "tar-fs": "^3.0.6",
-                "unbzip2-stream": "^1.4.3",
-                "yargs": "^17.7.2"
-            },
-            "bin": {
-                "browsers": "lib/cjs/main-cli.js"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/devtools-protocol": {
-            "version": "0.0.1312386",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
-            "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
-            "dev": true,
-            "optional": true,
-            "peer": true
-        },
         "node_modules/pure-rand": {
             "version": "6.1.0",
             "dev": true,
@@ -23892,17 +23826,6 @@
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
-        "node_modules/zod": {
-            "version": "3.23.8",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-            "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
-            }
-        },
         "packages/browser": {
             "name": "@backtrace/browser",
             "version": "0.6.2",
@@ -23987,7 +23910,7 @@
         },
         "packages/electron": {
             "name": "@backtrace/electron",
-            "version": "0.7.0",
+            "version": "0.7.1",
             "license": "MIT",
             "dependencies": {
                 "@backtrace/node": "^0.8.3"
@@ -24045,7 +23968,7 @@
         },
         "packages/nestjs": {
             "name": "@backtrace/nestjs",
-            "version": "0.6.0",
+            "version": "0.6.1",
             "license": "MIT",
             "dependencies": {
                 "@backtrace/node": "^0.8.3"
@@ -24174,7 +24097,7 @@
         },
         "packages/react": {
             "name": "@backtrace/react",
-            "version": "0.5.0",
+            "version": "0.5.1",
             "license": "MIT",
             "dependencies": {
                 "@backtrace/browser": "0.6.2"
@@ -24214,7 +24137,6 @@
                 "@types/react": "~17.0.21",
                 "jest": "^29.7.0",
                 "pod-install": "^0.1.0",
-                "prettier": "^2.0.5",
                 "random-seed": "^0.3.0",
                 "react": "18.2.0",
                 "react-native": "^0.72.4",
@@ -24229,20 +24151,6 @@
             "peerDependencies": {
                 "react": "*",
                 "react-native": "*"
-            }
-        },
-        "packages/react-native/node_modules/prettier": {
-            "version": "2.8.8",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "prettier": "bin-prettier.js"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            },
-            "funding": {
-                "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
         "packages/react-native/node_modules/web-streams-polyfill": {
@@ -24385,7 +24293,7 @@
         },
         "packages/session-replay": {
             "name": "@backtrace/session-replay",
-            "version": "0.2.0",
+            "version": "0.2.1",
             "license": "MIT",
             "dependencies": {
                 "@backtrace/sdk-core": "0.8.3",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -84,7 +84,6 @@
         "@types/react": "~17.0.21",
         "jest": "^29.7.0",
         "pod-install": "^0.1.0",
-        "prettier": "^3.3.2",
         "random-seed": "^0.3.0",
         "react": "18.2.0",
         "react-native": "^0.72.4",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -84,7 +84,7 @@
         "@types/react": "~17.0.21",
         "jest": "^29.7.0",
         "pod-install": "^0.1.0",
-        "prettier": "^2.0.5",
+        "prettier": "^3.3.2",
         "random-seed": "^0.3.0",
         "react": "18.2.0",
         "react-native": "^0.72.4",


### PR DESCRIPTION
Removed the unused `prettier` devDependency from `@backtrace/react-native`'s package.json (it had no prettier script or config and formatting is handled by the root-level prettier setup), and updated the lockfile accordingly.