### PR TITLE
react-native: safe dependency upgrades (BT-7067)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [18.x]
+                node-version: [20.x]
 
         steps:
             - uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,32 +44,42 @@
                 "typescript": "^5.0.4"
             }
         },
-        "node_modules/@ampproject/remapping": {
-            "version": "2.3.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.24"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@babel/code-frame": {
-            "version": "7.24.7",
+        "node_modules/@ark/schema": {
+            "version": "0.56.1",
+            "resolved": "https://registry.npmjs.org/@ark/schema/-/schema-0.56.1.tgz",
+            "integrity": "sha512-1Cf2g9nKD8K/3JGRu+gCCfYw5d4qR8YLLjDs5W5kpmaButCYWAPFUJqSXyBATPjglzCd4tIkp398iPYVs8MjRA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/highlight": "^7.24.7",
-                "picocolors": "^1.0.0"
+                "@ark/util": "0.56.1"
+            }
+        },
+        "node_modules/@ark/util": {
+            "version": "0.56.1",
+            "resolved": "https://registry.npmjs.org/@ark/util/-/util-0.56.1.tgz",
+            "integrity": "sha512-Tp1rTik3q5Z+jAeeDxr5JZpmVIw0miti1ykSEHyZv5Pw3TIJl2xbN6KTacOxITp0l3s9ytlrWd30Zvqcy5vzoQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@babel/code-frame": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.25.4",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -77,20 +87,22 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.25.2",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.24.7",
-                "@babel/generator": "^7.25.0",
-                "@babel/helper-compilation-targets": "^7.25.2",
-                "@babel/helper-module-transforms": "^7.25.2",
-                "@babel/helpers": "^7.25.0",
-                "@babel/parser": "^7.25.0",
-                "@babel/template": "^7.25.0",
-                "@babel/traverse": "^7.25.2",
-                "@babel/types": "^7.25.2",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -139,50 +151,45 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.25.6",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+            "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.25.6",
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.25",
-                "jsesc": "^2.5.1"
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
+                "jsesc": "^3.0.2"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+            "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.24.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
-            "version": "7.24.7",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/traverse": "^7.24.7",
-                "@babel/types": "^7.24.7"
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.25.2",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.25.2",
-                "@babel/helper-validator-option": "^7.24.8",
-                "browserslist": "^4.23.1",
+                "@babel/compat-data": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
+                "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
             },
@@ -199,16 +206,18 @@
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.25.4",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
+            "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.24.7",
-                "@babel/helper-member-expression-to-functions": "^7.24.8",
-                "@babel/helper-optimise-call-expression": "^7.24.7",
-                "@babel/helper-replace-supers": "^7.25.0",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
-                "@babel/traverse": "^7.25.4",
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "@babel/helper-member-expression-to-functions": "^7.29.7",
+                "@babel/helper-optimise-call-expression": "^7.29.7",
+                "@babel/helper-replace-supers": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -227,12 +236,14 @@
             }
         },
         "node_modules/@babel/helper-create-regexp-features-plugin": {
-            "version": "7.25.2",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.29.7.tgz",
+            "integrity": "sha512-907Uymvqgg1dwUA+7IGwFAOSYzQOuzPXKNJ1yxzwPffzkYFg2q2eHi1fIOs6sXkG9NbIUMunnUlkYsfRFNvomg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.24.7",
-                "regexpu-core": "^5.3.1",
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "regexpu-core": "^6.3.1",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -251,15 +262,17 @@
             }
         },
         "node_modules/@babel/helper-define-polyfill-provider": {
-            "version": "0.6.2",
+            "version": "0.6.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
+            "integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-compilation-targets": "^7.22.6",
-                "@babel/helper-plugin-utils": "^7.22.5",
-                "debug": "^4.1.1",
+                "@babel/helper-compilation-targets": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "debug": "^4.4.3",
                 "lodash.debounce": "^4.0.8",
-                "resolve": "^1.14.2"
+                "resolve": "^1.22.11"
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -276,39 +289,54 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@babel/helper-globals": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/helper-member-expression-to-functions": {
-            "version": "7.24.8",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
+            "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.24.8",
-                "@babel/types": "^7.24.8"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.24.7",
-                "@babel/types": "^7.24.7"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.25.2",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.24.7",
-                "@babel/helper-simple-access": "^7.24.7",
-                "@babel/helper-validator-identifier": "^7.24.7",
-                "@babel/traverse": "^7.25.2"
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -318,18 +346,22 @@
             }
         },
         "node_modules/@babel/helper-optimise-call-expression": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
+            "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.24.7"
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.24.8",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+            "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -337,13 +369,15 @@
             }
         },
         "node_modules/@babel/helper-remap-async-to-generator": {
-            "version": "7.25.0",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.29.7.tgz",
+            "integrity": "sha512-16AMiW26DbXWBbr3B8wNozKM0ydMLB892vaOaJW/fPJdnT8vJk5sdkQcU/isqUxyCE0cEoa8wZOcbgDuC4b6Og==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.24.7",
-                "@babel/helper-wrap-function": "^7.25.0",
-                "@babel/traverse": "^7.25.0"
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "@babel/helper-wrap-function": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -353,13 +387,15 @@
             }
         },
         "node_modules/@babel/helper-replace-supers": {
-            "version": "7.25.0",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
+            "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-member-expression-to-functions": "^7.24.8",
-                "@babel/helper-optimise-call-expression": "^7.24.7",
-                "@babel/traverse": "^7.25.0"
+                "@babel/helper-member-expression-to-functions": "^7.29.7",
+                "@babel/helper-optimise-call-expression": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -368,32 +404,24 @@
                 "@babel/core": "^7.0.0"
             }
         },
-        "node_modules/@babel/helper-simple-access": {
-            "version": "7.24.7",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/traverse": "^7.24.7",
-                "@babel/types": "^7.24.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
+            "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.24.7",
-                "@babel/types": "^7.24.7"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.24.8",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -401,7 +429,9 @@
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -409,7 +439,9 @@
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.24.8",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -417,64 +449,42 @@
             }
         },
         "node_modules/@babel/helper-wrap-function": {
-            "version": "7.25.0",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.29.7.tgz",
+            "integrity": "sha512-iES0Skag9ERIF68aXadpO6dbXa03mNWK3sEqJaMnLNs/eC3l0lkImdfoy6Y09/SfkpawdAB4RjQ7PVA7TcVGdw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.25.0",
-                "@babel/traverse": "^7.25.0",
-                "@babel/types": "^7.25.0"
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.25.6",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.25.0",
-                "@babel/types": "^7.25.6"
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/highlight": {
-            "version": "7.24.7",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-validator-identifier": "^7.24.7",
-                "chalk": "^2.4.2",
-                "js-tokens": "^4.0.0",
-                "picocolors": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.25.6",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.25.6"
+                "@babel/types": "^7.29.7"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -484,12 +494,14 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-            "version": "7.25.3",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.29.7.tgz",
+            "integrity": "sha512-j8SrR0zLZrRsC09DlszEx8FpMiwukKffYXMK0d5LmOglO7vGG6sz/BR/20yHqWH+Lnn31JTt2PE3hIWNgM2J6w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.8",
-                "@babel/traverse": "^7.25.3"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -499,11 +511,13 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
-            "version": "7.25.0",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.29.7.tgz",
+            "integrity": "sha512-r8j8escF+U2FUHo0KOhPUdMzUO+jp9fInva6+ACVAF3Y97Ev+5iNZwiqTghmzNeWwDkOPlYuTcfb1vDaoZKmAQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.8"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -513,11 +527,30 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-            "version": "7.25.0",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.29.7.tgz",
+            "integrity": "sha512-GE1TFSiuFeGsCxmYXZl8HwoPrVlwe4rHPFE8weieGKZqnDORK+Ar3vgWMgW+AOxQ6/2TgLSKx9p6W7O4rC6qgQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.8"
+                "@babel/helper-plugin-utils": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-7.29.7.tgz",
+            "integrity": "sha512-oBNVCvnO5tND+xSopWvV8WNGfpTfgP4Zr/YXXSj8zfmcPktp5Ku/aZlsIowgSD4fjmgHn6sGmB9APVsU5zOdhA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -527,13 +560,15 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.29.7.tgz",
+            "integrity": "sha512-QQt9qKHZ2sg/kivaLr7lnQr8HVrQDdBNSfCsTjiDxRuX/K5ORyKq+Bu8Xr0cDE3Dfkv0cw28Ve0EKyKMvulkOw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
-                "@babel/plugin-transform-optional-chaining": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+                "@babel/plugin-transform-optional-chaining": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -543,12 +578,14 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-            "version": "7.25.0",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.29.7.tgz",
+            "integrity": "sha512-pn6QacGLgvCcwc+syUhKE/qSjV2D1IHDB84RNxWYSt1mW3K/SCtjinZ2p0cETJxAWBjPy3K/1lHwG5BjjPxNlw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.8",
-                "@babel/traverse": "^7.25.0"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -766,23 +803,14 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
-        "node_modules/@babel/plugin-syntax-export-namespace-from": {
-            "version": "7.8.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.3"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
         "node_modules/@babel/plugin-syntax-flow": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.29.7.tgz",
+            "integrity": "sha512-ajMX6QPcyomotqwpzhkYGxcK2i/us0rs1Qo9QvUpa+Fca0FTmqrzKrctoIYLMxcOhGZldGT/BAVkRGTWBiR8gQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -792,11 +820,13 @@
             }
         },
         "node_modules/@babel/plugin-syntax-import-assertions": {
-            "version": "7.25.6",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.29.7.tgz",
+            "integrity": "sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.8"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -806,11 +836,13 @@
             }
         },
         "node_modules/@babel/plugin-syntax-import-attributes": {
-            "version": "7.25.6",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+            "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.8"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -842,11 +874,13 @@
             }
         },
         "node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+            "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -950,11 +984,13 @@
             }
         },
         "node_modules/@babel/plugin-syntax-typescript": {
-            "version": "7.25.4",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+            "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.8"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -979,11 +1015,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-arrow-functions": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.29.7.tgz",
+            "integrity": "sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -993,14 +1031,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-async-generator-functions": {
-            "version": "7.25.4",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.7.tgz",
+            "integrity": "sha512-d98gXZkgswvkyohMBABkhm3GeXhYj8psWfwQ2C7gtfrKGTykQa/iOIi+JJhwMjPlZ6Vm2XN+DCf3Es1EoG4ZLA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.8",
-                "@babel/helper-remap-async-to-generator": "^7.25.0",
-                "@babel/plugin-syntax-async-generators": "^7.8.4",
-                "@babel/traverse": "^7.25.4"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-remap-async-to-generator": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1010,13 +1049,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-async-to-generator": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.29.7.tgz",
+            "integrity": "sha512-pcUb2SS+RMo9TWVBwKGI5ShtoG7R+zBsFmCKDa6fe8c+hPr3XJlZgoE5j6i8W7gDjhyvy+85vmYexanvXh3d1w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "@babel/helper-remap-async-to-generator": "^7.24.7"
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-remap-async-to-generator": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1026,11 +1067,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-block-scoped-functions": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.29.7.tgz",
+            "integrity": "sha512-cUSmjh72N+rN4PrkFlN1dJwNCwjVp5d38/CQrEsFggkD10UiFlBFgdH3tv5dNsLuHY+3S8db2xCHjhZcv5WgvA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1040,11 +1083,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-block-scoping": {
-            "version": "7.25.0",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.29.7.tgz",
+            "integrity": "sha512-ONyr4+AZhKh8yKWInVxU9AXA9EbsyeLcL6V0dJy6M2/62vuvpGm29zzuymbTpdc451GEpDIdAyPLP3r+P61yKQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.8"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1054,12 +1099,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-class-properties": {
-            "version": "7.25.4",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.29.7.tgz",
+            "integrity": "sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.25.4",
-                "@babel/helper-plugin-utils": "^7.24.8"
+                "@babel/helper-create-class-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1069,13 +1116,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-class-static-block": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.29.7.tgz",
+            "integrity": "sha512-kibJgmEdX2iMwsHY2tSZNDgj8PwIlCQz7FK9KuGKO8zsuoUwSEhoNnNVp/emKWrbY4HeO6kkXfdMqRKKKXBm2A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "@babel/plugin-syntax-class-static-block": "^7.14.5"
+                "@babel/helper-create-class-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1085,16 +1133,18 @@
             }
         },
         "node_modules/@babel/plugin-transform-classes": {
-            "version": "7.25.4",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.29.7.tgz",
+            "integrity": "sha512-qV0OGGBVacduzQHE649JyCneOFI/maT+YKsO+K4Yi3xv2wTPNjM/W2o2gdzMwEAZz7fXNTHAe0NcSg30bIN69g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.24.7",
-                "@babel/helper-compilation-targets": "^7.25.2",
-                "@babel/helper-plugin-utils": "^7.24.8",
-                "@babel/helper-replace-supers": "^7.25.0",
-                "@babel/traverse": "^7.25.4",
-                "globals": "^11.1.0"
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-replace-supers": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1104,12 +1154,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-computed-properties": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.29.7.tgz",
+            "integrity": "sha512-RK7/IyU5phpuCdBAuig5VkzG/EnbDaui5SQGdU9BFrHdV+mV4cUjLMQ9lJDjLNtWHsqtiefpGZUXQP2BiTYMsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "@babel/template": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/template": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1119,11 +1171,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-destructuring": {
-            "version": "7.24.8",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.29.7.tgz",
+            "integrity": "sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.8"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1133,12 +1188,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-dotall-regex": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.29.7.tgz",
+            "integrity": "sha512-3qc18hsD2RdZiyJNDNc7HQpv6xbncwh8FYtxNFFzclSyh/trPD9KkVR9BDECUjDLvb7yJVF15GfYUuC+LMkkiQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1148,11 +1205,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-duplicate-keys": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.29.7.tgz",
+            "integrity": "sha512-6IvRRriEMqnBwD6chtxdLpMYCHWEzN+oL5cyQtjykya19UgzbmKhxmhZgKC/LHxS2nYr9Q/qYPZ5Lr6jOL9+yQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1162,12 +1221,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-            "version": "7.25.0",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.7.tgz",
+            "integrity": "sha512-2wiIyo2BjtgU7HufSeDnL9L2O7zr8jmhFKuSr65VpRkUiRKRNpb0mdlk56+XPPKoIrfHqzbMuglDvZun0RISsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.25.0",
-                "@babel/helper-plugin-utils": "^7.24.8"
+                "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1177,12 +1238,30 @@
             }
         },
         "node_modules/@babel/plugin-transform-dynamic-import": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.29.7.tgz",
+            "integrity": "sha512-giOlEm/EFjfjr+te9NsdjkUo2v4f8rS/SXPumRVHAtbNcyNlvtREkU1dZzaIDclNpnaVhlCqRdFKhJBjBikzLg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "@babel/plugin-syntax-dynamic-import": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-explicit-resource-management": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.29.7.tgz",
+            "integrity": "sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/plugin-transform-destructuring": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1192,12 +1271,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-exponentiation-operator": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.29.7.tgz",
+            "integrity": "sha512-zFpMOTLZBdW5LfObqcSbL6kefg4R4eLdmvS0wbN9M6D5Mym/sKm9toOoWyVOa+xDjvCnuWcHls2YonXwHvH3CQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1207,12 +1287,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-export-namespace-from": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.29.7.tgz",
+            "integrity": "sha512-24B2nOy2TeJSMheqwPD4DDQOV/elLSIlKxjZt4i05H5AgdPdWR3n18HnNrcJ+j76WJd9gbwb9jPjNYUy6RautA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1222,12 +1303,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-flow-strip-types": {
-            "version": "7.25.2",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.29.7.tgz",
+            "integrity": "sha512-wRHeUjUjCZnMHmiO5bRgjFLcoEh7JyTdByOW11ahhwNa4V0bmeGEaIvt51yq0zQp2yWIpqfxXXPyUP6GFJZHOQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.8",
-                "@babel/plugin-syntax-flow": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/plugin-syntax-flow": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1237,12 +1320,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-for-of": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.29.7.tgz",
+            "integrity": "sha512-zeSIHh0+E1Um1WJRXCFlHQYu2ieJNdivLLjlBEp+dIBu3S51n+SZZmIXjxnItw6pz56Cn+KvK68BIBVsxq2JiQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1252,13 +1337,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-function-name": {
-            "version": "7.25.1",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.29.7.tgz",
+            "integrity": "sha512-otRWaHXE6fbAGkePvaj/kvs3HsqXfPhlnzwSOlnFgbqCPMd975dW+4wZ00WFBt+/YlBGcJwNrARQTOJOb4ZrIg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-compilation-targets": "^7.24.8",
-                "@babel/helper-plugin-utils": "^7.24.8",
-                "@babel/traverse": "^7.25.1"
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1268,12 +1355,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-json-strings": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.29.7.tgz",
+            "integrity": "sha512-RRnE2+eon1rJAq8MnoF1b5kTpY1vU88twHcvcKMrsqP/jxIRqDVs9iJB5fqPuqyeFAW0wJo4MlUIPpQCq/aRsg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "@babel/plugin-syntax-json-strings": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1283,11 +1371,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-literals": {
-            "version": "7.25.2",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.29.7.tgz",
+            "integrity": "sha512-DZ/oLP21ZuWx1vKqnoNv6/tvEK48AQOBRai40CX9dTjGluvT/YZCyY3rryDtyUqCEoyNroy5KKPwX2iQCiRvyw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.8"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1297,12 +1387,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-logical-assignment-operators": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.29.7.tgz",
+            "integrity": "sha512-A0H91hh6W8MFRkp5TqJmMr39jzGD1A1E1Ysiv2O06Sfbhkapm+XyIzxWCEh5kqwOZ1/8QZ0dY3SeQ7XBqfJd5Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1312,11 +1403,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-member-expression-literals": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.29.7.tgz",
+            "integrity": "sha512-hl1kwFZCCiDyfH25Xmco9jTrkPgnS9pmOzSG7W5I4SaGbLeqKv417hcU2RKmaxoPEgsoJh7ZPOrnPGq99bHoUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1326,12 +1419,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-amd": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.29.7.tgz",
+            "integrity": "sha512-fxtQoH3m5ywUSIfaH0FGCzWu4McsYon5bD3K4XnskC7f+OyQMj7rsOMi4NvvmJ83WwBAg4UCe+ov4VZlqEvyew==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1341,13 +1436,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-commonjs": {
-            "version": "7.24.8",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
+            "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.24.8",
-                "@babel/helper-plugin-utils": "^7.24.8",
-                "@babel/helper-simple-access": "^7.24.7"
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1357,14 +1453,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-systemjs": {
-            "version": "7.25.0",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
+            "integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.25.0",
-                "@babel/helper-plugin-utils": "^7.24.8",
-                "@babel/helper-validator-identifier": "^7.24.7",
-                "@babel/traverse": "^7.25.0"
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1374,12 +1472,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-umd": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.29.7.tgz",
+            "integrity": "sha512-B4UkaTK3QpgCwJnrxKfMPKdo92CN7OKXAlpAAnM3UPu0Q0lCCk57ylA9AJbRy2v8dDKOPAAWcoR6CMyeoHwRCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1389,12 +1489,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.7.tgz",
+            "integrity": "sha512-vuFoLwr4qnv2xbZ16SQd6uPcH5FNrLHhk/Jzo++0XJFcaDsr4gjJVg6j398oMHiC+83k/GiBzviwF5KBJkPUtQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1404,11 +1506,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-new-target": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.29.7.tgz",
+            "integrity": "sha512-fEo41GmsOUhOBlw8ioo6zvjX5Xc2Lqkzlyfqbpsk3eB6TReV18uhxZ0esfEokVbY2+PVJAQHNKxER6lGrzNd3A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1418,12 +1522,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.29.7.tgz",
+            "integrity": "sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1433,12 +1538,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-numeric-separator": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.29.7.tgz",
+            "integrity": "sha512-zR7fv/z14OjgHl4AgRtkDBvBMhIzCxqV/qN/2BCRC7LjFwvuzjYe7gDWxC4Wl/SNsLM6SE1IWvRPYMgSJaUvNw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1448,14 +1554,17 @@
             }
         },
         "node_modules/@babel/plugin-transform-object-rest-spread": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.29.7.tgz",
+            "integrity": "sha512-Ld98jn4c0smUywL57m7SgsHq3OpThOa6LqZJif3G6jYOovPleoFhVrBJ1WegRApSFB2wu4+RelAj9AC9G08Z4A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-compilation-targets": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-                "@babel/plugin-transform-parameters": "^7.24.7"
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/plugin-transform-destructuring": "^7.29.7",
+                "@babel/plugin-transform-parameters": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1465,12 +1574,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-object-super": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.29.7.tgz",
+            "integrity": "sha512-Ea/diGcw0twB5IlZPO5sgET6fJsLJqPABqTuFWIR+iMPGPZJkATEIWx0wa+aEQ5UY1CBQyP/gkAiLEqn1vBiQA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "@babel/helper-replace-supers": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-replace-supers": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1480,12 +1591,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-optional-catch-binding": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.29.7.tgz",
+            "integrity": "sha512-sLsyndxK2VwX6yNUOakMb7Sh553ZTe/vVM1XJ+9Z5aW1ytsc8xOIwmyk05NNjN60vkc5/KqoTH6hB4V41LJhng==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1495,13 +1607,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-optional-chaining": {
-            "version": "7.24.8",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.29.7.tgz",
+            "integrity": "sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.8",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
-                "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1511,11 +1624,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-parameters": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.29.7.tgz",
+            "integrity": "sha512-ZDOBqV/qLYJI0YElr8DcENEyARsFQeESqWXH6gZlghYXuPPjvweuDhP4VyEi4BlUBlLRFZVjxoZDMjxhLW766g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1525,12 +1640,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-private-methods": {
-            "version": "7.25.4",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.29.7.tgz",
+            "integrity": "sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.25.4",
-                "@babel/helper-plugin-utils": "^7.24.8"
+                "@babel/helper-create-class-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1540,14 +1657,15 @@
             }
         },
         "node_modules/@babel/plugin-transform-private-property-in-object": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.29.7.tgz",
+            "integrity": "sha512-+BNo06dnrzdNNqCm1X6YUaVv0DKk8Q+JYcoZfOkLhYWNCXzlwTSRq8zGWayT1csjcpNXV9CQTBRRbmTLZac5cA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.24.7",
-                "@babel/helper-create-class-features-plugin": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "@babel/helper-create-class-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1557,11 +1675,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-property-literals": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.29.7.tgz",
+            "integrity": "sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1571,11 +1691,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-display-name": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.29.7.tgz",
+            "integrity": "sha512-+1wdDMGNb4UPeY3Q4L5yLiYe6TXPXubs4NjrgRFw13hPRLJfEMw2Q5OXkee6/IfdqePIeW4Jjwe3aBh7SdKz4Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1585,15 +1707,17 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-jsx": {
-            "version": "7.25.2",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.29.7.tgz",
+            "integrity": "sha512-WsZulLVBUHXVj2cUcPVx6UE21TpalB6bHbSFErKT0Ib++ax24jjXe73FqlWvdylFOjiuPHYi6VCcgRad1ItN+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.24.7",
-                "@babel/helper-module-imports": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.8",
-                "@babel/plugin-syntax-jsx": "^7.24.7",
-                "@babel/types": "^7.25.2"
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/plugin-syntax-jsx": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1603,11 +1727,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-jsx-development": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.29.7.tgz",
+            "integrity": "sha512-Xfy3UVMF04+ypnFbkhvfqtmvwfe92qwQdbGZVonhE+6v35GzlofmOnA1szaZqzb9xYWr0nl1e5EMmzi0DNON1g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/plugin-transform-react-jsx": "^7.24.7"
+                "@babel/plugin-transform-react-jsx": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1645,12 +1771,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-pure-annotations": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.29.7.tgz",
+            "integrity": "sha512-H5E+HBgDpr6Q5t+Aj11tL7XkIui1jhbIoArVQnqjgXo5/3YxkN7ZEBcWF4RQlB0T4rrxJQbXS6kiFV6B7XTqUA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1660,12 +1788,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-regenerator": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.7.tgz",
+            "integrity": "sha512-rNNFV0DBAJp988xW2DOntfDoYn1eR8GGF5AT5vYc+rjyfaQkM242c9tZUHHPe7KYaiJizXPWhQTzzdbXySyhBw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "regenerator-transform": "^0.15.2"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1674,12 +1803,31 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
-        "node_modules/@babel/plugin-transform-reserved-words": {
-            "version": "7.24.7",
+        "node_modules/@babel/plugin-transform-regexp-modifiers": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.29.7.tgz",
+            "integrity": "sha512-mB5Fs0VWrJ42ZCmc8114v60qetdaUVNkj9PmSZRmanCZM3S9hm0CFRLjRmYIsuXav14l2jvZ+4T8iiCGnhj3nQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-reserved-words": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.29.7.tgz",
+            "integrity": "sha512-5+YhdpVgmfSmwZyLMftfaiffLRMHjzIRHFHHLdibcSyJm2pasMrKHrO3Ptrt2DRshjvpgjEJJ1zVW14WPq/6QA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1716,11 +1864,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-shorthand-properties": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.29.7.tgz",
+            "integrity": "sha512-I+WYbGBAiCn7nA6xBrlgPH+MB7HWb4u8pv5S0Pv7OtwNvIFvCCb24YlttKEeUFVurfBCEaOTnuhlqsb7f0Z5Dg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1730,12 +1880,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-spread": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.29.7.tgz",
+            "integrity": "sha512-/u5K1QWada7tbYNqTjMh96718g9NTwh9tfPJMsSmVsQwGT447FskV+KcfeXkXq2GWki4EM/MuTdmBec+hOuVTQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1745,11 +1897,29 @@
             }
         },
         "node_modules/@babel/plugin-transform-sticky-regex": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.29.7.tgz",
+            "integrity": "sha512-BCHzNYJGe9l7EpwwDBN/ztlL2NYFFq8hp9ddjtUEM9f2O7S7kKV/lL6Fwo7IF7NSkYhPK2vO+86nIGltA90MsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-strict-mode": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-strict-mode/-/plugin-transform-strict-mode-7.29.7.tgz",
+            "integrity": "sha512-YjFcy7S8kEndK6dsK4UBISrMZa2MHiitApdZ7hTxAyQpX+Ct+aKgKOZoTx/Kcz6drgKxe50TIPUvZq7V4HGGKg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1759,11 +1929,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-template-literals": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.29.7.tgz",
+            "integrity": "sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1773,11 +1945,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-typeof-symbol": {
-            "version": "7.24.8",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.29.7.tgz",
+            "integrity": "sha512-223mNGoTkBiTEWFoK+Q6Go3tueMRclO8vxxxxquNCYuNI4jWOofFKJRRDu6SDrB8Sgo1UEGW9T4GAQ8ZyRso1A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.8"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1787,15 +1961,17 @@
             }
         },
         "node_modules/@babel/plugin-transform-typescript": {
-            "version": "7.25.2",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
+            "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.24.7",
-                "@babel/helper-create-class-features-plugin": "^7.25.0",
-                "@babel/helper-plugin-utils": "^7.24.8",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
-                "@babel/plugin-syntax-typescript": "^7.24.7"
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "@babel/helper-create-class-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+                "@babel/plugin-syntax-typescript": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1805,11 +1981,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-escapes": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.29.7.tgz",
+            "integrity": "sha512-jCfXxSjf94lf4E0hKE0AByxF6F3/pVFqRdUUNkDJhsY0m1ZKjnN6ZYyMeHNpzflxb/0q5b7t3p+BE+SLF1WOtA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1819,12 +1997,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-property-regex": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.29.7.tgz",
+            "integrity": "sha512-OgZ+zoAJgZLUCunsTRQ5LAjOywDv5zzZ2/hQ5aMw1pGXyY2rtE8/chXYUmu3AlVHKpm10KEdG9aMwbI/K76ZGw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1834,12 +2014,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-regex": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.29.7.tgz",
+            "integrity": "sha512-7D/x/23/d/3VqZ0QA+LGbZMlGwZjztBygSWWWsfTPoQ1oQ6Q1P6Mr3d0kk42XabyUVw+fha3LqdRsFqeKqvCyA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.24.7",
-                "@babel/helper-plugin-utils": "^7.24.7"
+                "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1849,12 +2031,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-sets-regex": {
-            "version": "7.25.4",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.29.7.tgz",
+            "integrity": "sha512-BLOhLht9DOJwIxlmp91wHvkXv1lguuHS3/FwUO8HL1H0u8s4hR1gASVFyilu9iGtcTRYqjTZmlsFFeQletntEg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.25.2",
-                "@babel/helper-plugin-utils": "^7.24.8"
+                "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1864,92 +2048,82 @@
             }
         },
         "node_modules/@babel/preset-env": {
-            "version": "7.25.4",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.7.tgz",
+            "integrity": "sha512-GYzX36n1nsciIb0uyH0GHwxwtNwPQIcpxSeiVLDtG/B7jB5xXgchnmL1f/jCX5o+pwnaDBtO60ONSJhEBJfxYA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.25.4",
-                "@babel/helper-compilation-targets": "^7.25.2",
-                "@babel/helper-plugin-utils": "^7.24.8",
-                "@babel/helper-validator-option": "^7.24.8",
-                "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.3",
-                "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.0",
-                "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.25.0",
-                "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.24.7",
-                "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.25.0",
+                "@babel/compat-data": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
+                "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.29.7",
+                "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.29.7",
+                "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.29.7",
+                "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^7.29.7",
+                "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.29.7",
+                "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.29.7",
                 "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-                "@babel/plugin-syntax-async-generators": "^7.8.4",
-                "@babel/plugin-syntax-class-properties": "^7.12.13",
-                "@babel/plugin-syntax-class-static-block": "^7.14.5",
-                "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-                "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-                "@babel/plugin-syntax-import-assertions": "^7.24.7",
-                "@babel/plugin-syntax-import-attributes": "^7.24.7",
-                "@babel/plugin-syntax-import-meta": "^7.10.4",
-                "@babel/plugin-syntax-json-strings": "^7.8.3",
-                "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-                "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-                "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-                "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
-                "@babel/plugin-syntax-top-level-await": "^7.14.5",
+                "@babel/plugin-syntax-import-assertions": "^7.29.7",
+                "@babel/plugin-syntax-import-attributes": "^7.29.7",
                 "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-                "@babel/plugin-transform-arrow-functions": "^7.24.7",
-                "@babel/plugin-transform-async-generator-functions": "^7.25.4",
-                "@babel/plugin-transform-async-to-generator": "^7.24.7",
-                "@babel/plugin-transform-block-scoped-functions": "^7.24.7",
-                "@babel/plugin-transform-block-scoping": "^7.25.0",
-                "@babel/plugin-transform-class-properties": "^7.25.4",
-                "@babel/plugin-transform-class-static-block": "^7.24.7",
-                "@babel/plugin-transform-classes": "^7.25.4",
-                "@babel/plugin-transform-computed-properties": "^7.24.7",
-                "@babel/plugin-transform-destructuring": "^7.24.8",
-                "@babel/plugin-transform-dotall-regex": "^7.24.7",
-                "@babel/plugin-transform-duplicate-keys": "^7.24.7",
-                "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.0",
-                "@babel/plugin-transform-dynamic-import": "^7.24.7",
-                "@babel/plugin-transform-exponentiation-operator": "^7.24.7",
-                "@babel/plugin-transform-export-namespace-from": "^7.24.7",
-                "@babel/plugin-transform-for-of": "^7.24.7",
-                "@babel/plugin-transform-function-name": "^7.25.1",
-                "@babel/plugin-transform-json-strings": "^7.24.7",
-                "@babel/plugin-transform-literals": "^7.25.2",
-                "@babel/plugin-transform-logical-assignment-operators": "^7.24.7",
-                "@babel/plugin-transform-member-expression-literals": "^7.24.7",
-                "@babel/plugin-transform-modules-amd": "^7.24.7",
-                "@babel/plugin-transform-modules-commonjs": "^7.24.8",
-                "@babel/plugin-transform-modules-systemjs": "^7.25.0",
-                "@babel/plugin-transform-modules-umd": "^7.24.7",
-                "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
-                "@babel/plugin-transform-new-target": "^7.24.7",
-                "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
-                "@babel/plugin-transform-numeric-separator": "^7.24.7",
-                "@babel/plugin-transform-object-rest-spread": "^7.24.7",
-                "@babel/plugin-transform-object-super": "^7.24.7",
-                "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
-                "@babel/plugin-transform-optional-chaining": "^7.24.8",
-                "@babel/plugin-transform-parameters": "^7.24.7",
-                "@babel/plugin-transform-private-methods": "^7.25.4",
-                "@babel/plugin-transform-private-property-in-object": "^7.24.7",
-                "@babel/plugin-transform-property-literals": "^7.24.7",
-                "@babel/plugin-transform-regenerator": "^7.24.7",
-                "@babel/plugin-transform-reserved-words": "^7.24.7",
-                "@babel/plugin-transform-shorthand-properties": "^7.24.7",
-                "@babel/plugin-transform-spread": "^7.24.7",
-                "@babel/plugin-transform-sticky-regex": "^7.24.7",
-                "@babel/plugin-transform-template-literals": "^7.24.7",
-                "@babel/plugin-transform-typeof-symbol": "^7.24.8",
-                "@babel/plugin-transform-unicode-escapes": "^7.24.7",
-                "@babel/plugin-transform-unicode-property-regex": "^7.24.7",
-                "@babel/plugin-transform-unicode-regex": "^7.24.7",
-                "@babel/plugin-transform-unicode-sets-regex": "^7.25.4",
+                "@babel/plugin-transform-arrow-functions": "^7.29.7",
+                "@babel/plugin-transform-async-generator-functions": "^7.29.7",
+                "@babel/plugin-transform-async-to-generator": "^7.29.7",
+                "@babel/plugin-transform-block-scoped-functions": "^7.29.7",
+                "@babel/plugin-transform-block-scoping": "^7.29.7",
+                "@babel/plugin-transform-class-properties": "^7.29.7",
+                "@babel/plugin-transform-class-static-block": "^7.29.7",
+                "@babel/plugin-transform-classes": "^7.29.7",
+                "@babel/plugin-transform-computed-properties": "^7.29.7",
+                "@babel/plugin-transform-destructuring": "^7.29.7",
+                "@babel/plugin-transform-dotall-regex": "^7.29.7",
+                "@babel/plugin-transform-duplicate-keys": "^7.29.7",
+                "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.7",
+                "@babel/plugin-transform-dynamic-import": "^7.29.7",
+                "@babel/plugin-transform-explicit-resource-management": "^7.29.7",
+                "@babel/plugin-transform-exponentiation-operator": "^7.29.7",
+                "@babel/plugin-transform-export-namespace-from": "^7.29.7",
+                "@babel/plugin-transform-for-of": "^7.29.7",
+                "@babel/plugin-transform-function-name": "^7.29.7",
+                "@babel/plugin-transform-json-strings": "^7.29.7",
+                "@babel/plugin-transform-literals": "^7.29.7",
+                "@babel/plugin-transform-logical-assignment-operators": "^7.29.7",
+                "@babel/plugin-transform-member-expression-literals": "^7.29.7",
+                "@babel/plugin-transform-modules-amd": "^7.29.7",
+                "@babel/plugin-transform-modules-commonjs": "^7.29.7",
+                "@babel/plugin-transform-modules-systemjs": "^7.29.7",
+                "@babel/plugin-transform-modules-umd": "^7.29.7",
+                "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.7",
+                "@babel/plugin-transform-new-target": "^7.29.7",
+                "@babel/plugin-transform-nullish-coalescing-operator": "^7.29.7",
+                "@babel/plugin-transform-numeric-separator": "^7.29.7",
+                "@babel/plugin-transform-object-rest-spread": "^7.29.7",
+                "@babel/plugin-transform-object-super": "^7.29.7",
+                "@babel/plugin-transform-optional-catch-binding": "^7.29.7",
+                "@babel/plugin-transform-optional-chaining": "^7.29.7",
+                "@babel/plugin-transform-parameters": "^7.29.7",
+                "@babel/plugin-transform-private-methods": "^7.29.7",
+                "@babel/plugin-transform-private-property-in-object": "^7.29.7",
+                "@babel/plugin-transform-property-literals": "^7.29.7",
+                "@babel/plugin-transform-regenerator": "^7.29.7",
+                "@babel/plugin-transform-regexp-modifiers": "^7.29.7",
+                "@babel/plugin-transform-reserved-words": "^7.29.7",
+                "@babel/plugin-transform-shorthand-properties": "^7.29.7",
+                "@babel/plugin-transform-spread": "^7.29.7",
+                "@babel/plugin-transform-sticky-regex": "^7.29.7",
+                "@babel/plugin-transform-template-literals": "^7.29.7",
+                "@babel/plugin-transform-typeof-symbol": "^7.29.7",
+                "@babel/plugin-transform-unicode-escapes": "^7.29.7",
+                "@babel/plugin-transform-unicode-property-regex": "^7.29.7",
+                "@babel/plugin-transform-unicode-regex": "^7.29.7",
+                "@babel/plugin-transform-unicode-sets-regex": "^7.29.7",
                 "@babel/preset-modules": "0.1.6-no-external-plugins",
-                "babel-plugin-polyfill-corejs2": "^0.4.10",
-                "babel-plugin-polyfill-corejs3": "^0.10.6",
-                "babel-plugin-polyfill-regenerator": "^0.6.1",
-                "core-js-compat": "^3.37.1",
+                "babel-plugin-polyfill-corejs2": "^0.4.15",
+                "babel-plugin-polyfill-corejs3": "^0.14.0",
+                "babel-plugin-polyfill-regenerator": "^0.6.6",
+                "core-js-compat": "^3.48.0",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -1957,6 +2131,20 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/preset-env/node_modules/babel-plugin-polyfill-corejs3": {
+            "version": "0.14.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
+            "integrity": "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-define-polyfill-provider": "^0.6.8",
+                "core-js-compat": "^3.48.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
             }
         },
         "node_modules/@babel/preset-env/node_modules/semver": {
@@ -1997,16 +2185,18 @@
             }
         },
         "node_modules/@babel/preset-react": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.29.7.tgz",
+            "integrity": "sha512-C+PV1TFUPTmBQGoPBL8j2QmLpZ117YTCwxIZeJOM96GbYMFSc7/pOXU5lVykwnZxyTqQxRsvoRk6f2FktZgGHA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "@babel/helper-validator-option": "^7.24.7",
-                "@babel/plugin-transform-react-display-name": "^7.24.7",
-                "@babel/plugin-transform-react-jsx": "^7.24.7",
-                "@babel/plugin-transform-react-jsx-development": "^7.24.7",
-                "@babel/plugin-transform-react-pure-annotations": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
+                "@babel/plugin-transform-react-display-name": "^7.29.7",
+                "@babel/plugin-transform-react-jsx": "^7.29.7",
+                "@babel/plugin-transform-react-jsx-development": "^7.29.7",
+                "@babel/plugin-transform-react-pure-annotations": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2016,15 +2206,17 @@
             }
         },
         "node_modules/@babel/preset-typescript": {
-            "version": "7.24.7",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.29.7.tgz",
+            "integrity": "sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.24.7",
-                "@babel/helper-validator-option": "^7.24.7",
-                "@babel/plugin-syntax-jsx": "^7.24.7",
-                "@babel/plugin-transform-modules-commonjs": "^7.24.7",
-                "@babel/plugin-transform-typescript": "^7.24.7"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
+                "@babel/plugin-syntax-jsx": "^7.29.7",
+                "@babel/plugin-transform-modules-commonjs": "^7.29.7",
+                "@babel/plugin-transform-typescript": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2088,11 +2280,6 @@
                 "source-map": "^0.6.0"
             }
         },
-        "node_modules/@babel/regjsgen": {
-            "version": "0.8.0",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@babel/runtime": {
             "version": "7.25.6",
             "dev": true,
@@ -2105,43 +2292,48 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.25.0",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.24.7",
-                "@babel/parser": "^7.25.0",
-                "@babel/types": "^7.25.0"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.25.6",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+            "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.24.7",
-                "@babel/generator": "^7.25.6",
-                "@babel/parser": "^7.25.6",
-                "@babel/template": "^7.25.0",
-                "@babel/types": "^7.25.6",
-                "debug": "^4.3.1",
-                "globals": "^11.1.0"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "debug": "^4.3.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.25.6",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.24.8",
-                "@babel/helper-validator-identifier": "^7.24.7",
-                "to-fast-properties": "^2.0.0"
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2882,26 +3074,28 @@
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.5",
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
             "license": "MIT",
             "dependencies": {
-                "@jridgewell/set-array": "^1.2.1",
-                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/sourcemap-codec": "^1.5.0",
                 "@jridgewell/trace-mapping": "^0.3.24"
-            },
-            "engines": {
-                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.2",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@jridgewell/set-array": {
-            "version": "1.2.1",
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
@@ -2916,11 +3110,15 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.0",
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.25",
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -4191,6 +4389,19 @@
                 "url": "https://github.com/sindresorhus/is?sponsor=1"
             }
         },
+        "node_modules/@sindresorhus/merge-streams": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+            "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/@sinonjs/commons": {
             "version": "3.0.1",
             "dev": true,
@@ -4468,10 +4679,11 @@
             }
         },
         "node_modules/@types/jest": {
-            "version": "29.5.12",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
-            "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
+            "version": "29.5.14",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+            "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "expect": "^29.0.0",
                 "pretty-format": "^29.0.0"
@@ -4536,11 +4748,6 @@
             "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
             "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
             "dev": true
-        },
-        "node_modules/@types/parse-json": {
-            "version": "4.0.2",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@types/prop-types": {
             "version": "15.7.12",
@@ -5618,18 +5825,6 @@
                 "node": ">= 6.0.0"
             }
         },
-        "node_modules/aggregate-error": {
-            "version": "3.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "clean-stack": "^2.0.0",
-                "indent-string": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/ajv": {
             "version": "6.12.6",
             "license": "MIT",
@@ -5995,6 +6190,28 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "deep-equal": "^2.0.5"
+            }
+        },
+        "node_modules/arkregex": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/arkregex/-/arkregex-0.0.7.tgz",
+            "integrity": "sha512-O/Ltrn9EUSn3ui0KVzfyrWGDUsHlzKxDVBtpQxL/6JmLRMAZAebfSNf/A/J5Ny5S6QIwrXX+RfXsu888HMs35A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@ark/util": "0.56.1"
+            }
+        },
+        "node_modules/arktype": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/arktype/-/arktype-2.2.2.tgz",
+            "integrity": "sha512-YYf1xhL2dh5aPZFlsY0RAsxv5HZqfLGLptH2ZP3JidTmsGRW8VOymhPjjMTkerL12vR2YtX0SK4c1mATtae8SA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@ark/schema": "0.56.1",
+                "@ark/util": "0.56.1",
+                "arkregex": "0.0.7"
             }
         },
         "node_modules/arr-diff": {
@@ -6405,12 +6622,14 @@
             }
         },
         "node_modules/babel-plugin-polyfill-corejs2": {
-            "version": "0.4.11",
+            "version": "0.4.17",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
+            "integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.22.6",
-                "@babel/helper-define-polyfill-provider": "^0.6.2",
+                "@babel/compat-data": "^7.28.6",
+                "@babel/helper-define-polyfill-provider": "^0.6.8",
                 "semver": "^6.3.1"
             },
             "peerDependencies": {
@@ -6438,14 +6657,43 @@
             }
         },
         "node_modules/babel-plugin-polyfill-regenerator": {
-            "version": "0.6.2",
+            "version": "0.6.8",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
+            "integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-define-polyfill-provider": "^0.6.2"
+                "@babel/helper-define-polyfill-provider": "^0.6.8"
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+            }
+        },
+        "node_modules/babel-plugin-syntax-hermes-parser": {
+            "version": "0.34.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.34.0.tgz",
+            "integrity": "sha512-q4xeAymMrot/21MHA3+fd5mcFF7stx6ntKFO/Of5ldyDpgTBcK1l0NiHAh4NdHHdb4aHqHgQOy7r6yk0IIlz8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hermes-parser": "0.34.0"
+            }
+        },
+        "node_modules/babel-plugin-syntax-hermes-parser/node_modules/hermes-estree": {
+            "version": "0.34.0",
+            "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.34.0.tgz",
+            "integrity": "sha512-6qLylexjmuKa/YYhMiNn/3VejBsdzwmYUGmNpc693/pJzymmbufhkRW/2K6GqFgu0ApRWoqF0NbM6u82jFcOXA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/babel-plugin-syntax-hermes-parser/node_modules/hermes-parser": {
+            "version": "0.34.0",
+            "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.34.0.tgz",
+            "integrity": "sha512-tcgan5UNZvu3WwmR3jDAlmwEAR2CMv8cwQVMe5j0NrLQkstf0l3ULbYPuTZWbXxbPa0PyZPiq5LYEcFVmhM9LQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hermes-estree": "0.34.0"
             }
         },
         "node_modules/babel-plugin-syntax-trailing-function-commas": {
@@ -6640,6 +6888,18 @@
                 }
             ],
             "license": "MIT"
+        },
+        "node_modules/baseline-browser-mapping": {
+            "version": "2.10.42",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
+            "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
+            "license": "Apache-2.0",
+            "bin": {
+                "baseline-browser-mapping": "dist/cli.cjs"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
         },
         "node_modules/basic-auth": {
             "version": "2.0.1",
@@ -6948,7 +7208,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.23.3",
+            "version": "4.28.4",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+            "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -6965,10 +7227,11 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "caniuse-lite": "^1.0.30001646",
-                "electron-to-chromium": "^1.5.4",
-                "node-releases": "^2.0.18",
-                "update-browserslist-db": "^1.1.0"
+                "baseline-browser-mapping": "^2.10.38",
+                "caniuse-lite": "^1.0.30001799",
+                "electron-to-chromium": "^1.5.376",
+                "node-releases": "^2.0.48",
+                "update-browserslist-db": "^1.2.3"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -7262,7 +7525,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001655",
+            "version": "1.0.30001800",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+            "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -7564,14 +7829,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/clean-stack": {
-            "version": "2.2.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/cli-cursor": {
@@ -8299,11 +8556,13 @@
             }
         },
         "node_modules/core-js-compat": {
-            "version": "3.38.1",
+            "version": "3.49.0",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+            "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.23.3"
+                "browserslist": "^4.28.1"
             },
             "funding": {
                 "type": "opencollective",
@@ -8554,7 +8813,9 @@
             }
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
@@ -8750,10 +9011,12 @@
             "license": "MIT"
         },
         "node_modules/debug": {
-            "version": "4.3.6",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "license": "MIT",
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -8763,6 +9026,12 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/debug/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
         },
         "node_modules/decamelize": {
             "version": "1.2.0",
@@ -8982,7 +9251,9 @@
             }
         },
         "node_modules/dedent": {
-            "version": "1.5.3",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+            "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
@@ -9137,57 +9408,95 @@
             }
         },
         "node_modules/del": {
-            "version": "6.1.1",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/del/-/del-8.0.1.tgz",
+            "integrity": "sha512-gPqh0mKTPvaUZGAuHbrBUYKZWBNAeHG7TU3QH5EhVwPMyKvmfJaNXhcD2jTcXsJRRcffuho4vaYweu80dRrMGA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "globby": "^11.0.1",
-                "graceful-fs": "^4.2.4",
-                "is-glob": "^4.0.1",
-                "is-path-cwd": "^2.2.0",
-                "is-path-inside": "^3.0.2",
-                "p-map": "^4.0.0",
-                "rimraf": "^3.0.2",
-                "slash": "^3.0.0"
+                "globby": "^14.0.2",
+                "is-glob": "^4.0.3",
+                "is-path-cwd": "^3.0.0",
+                "is-path-inside": "^4.0.0",
+                "p-map": "^7.0.2",
+                "presentable-error": "^0.0.1",
+                "slash": "^5.1.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/del/node_modules/glob": {
-            "version": "7.2.3",
+        "node_modules/del/node_modules/globby": {
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+            "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
             "dev": true,
-            "license": "ISC",
+            "license": "MIT",
             "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "@sindresorhus/merge-streams": "^2.1.0",
+                "fast-glob": "^3.3.3",
+                "ignore": "^7.0.3",
+                "path-type": "^6.0.0",
+                "slash": "^5.1.0",
+                "unicorn-magic": "^0.3.0"
             },
             "engines": {
-                "node": "*"
+                "node": ">=18"
             },
             "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/del/node_modules/rimraf": {
-            "version": "3.0.2",
+        "node_modules/del/node_modules/ignore": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
             "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/del/node_modules/is-path-inside": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+            "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
             },
             "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/del/node_modules/path-type": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+            "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/del/node_modules/slash": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+            "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/delayed-stream": {
@@ -9679,7 +9988,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.13",
+            "version": "1.5.387",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz",
+            "integrity": "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==",
             "license": "ISC"
         },
         "node_modules/electron/node_modules/@types/node": {
@@ -11405,7 +11716,9 @@
             "license": "MIT"
         },
         "node_modules/fast-glob": {
-            "version": "3.3.2",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11413,7 +11726,7 @@
                 "@nodelib/fs.walk": "^1.2.3",
                 "glob-parent": "^5.1.2",
                 "merge2": "^1.3.0",
-                "micromatch": "^4.0.4"
+                "micromatch": "^4.0.8"
             },
             "engines": {
                 "node": ">=8.6.0"
@@ -12027,7 +12340,9 @@
             "license": "MIT"
         },
         "node_modules/fs-extra": {
-            "version": "11.2.0",
+            "version": "11.3.6",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+            "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12278,6 +12593,19 @@
                 "node": "6.* || 8.* || >= 10.*"
             }
         },
+        "node_modules/get-east-asian-width": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+            "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/get-intrinsic": {
             "version": "1.2.4",
             "devOptional": true,
@@ -12452,14 +12780,6 @@
                 "node": ">=10.0"
             }
         },
-        "node_modules/globals": {
-            "version": "11.12.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/globalthis": {
             "version": "1.0.4",
             "devOptional": true,
@@ -12598,15 +12918,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/has-property-descriptors": {
             "version": "1.0.2",
             "devOptional": true,
@@ -12734,7 +13045,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -13088,14 +13401,6 @@
                 "node": ">=0.8.19"
             }
         },
-        "node_modules/indent-string": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/infer-owner": {
             "version": "1.0.4",
             "dev": true,
@@ -13163,18 +13468,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/is-absolute": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-relative": "^1.0.0",
-                "is-windows": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/is-accessor-descriptor": {
@@ -13304,11 +13597,13 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.15.1",
+            "version": "2.16.2",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+            "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "hasown": "^2.0.2"
+                "hasown": "^2.0.3"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -13436,119 +13731,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-git-dirty": {
-            "version": "2.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "execa": "^4.0.3",
-                "is-git-repository": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/is-git-dirty/node_modules/execa": {
-            "version": "4.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cross-spawn": "^7.0.0",
-                "get-stream": "^5.0.0",
-                "human-signals": "^1.1.1",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.0",
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2",
-                "strip-final-newline": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/is-git-dirty/node_modules/human-signals": {
-            "version": "1.1.1",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=8.12.0"
-            }
-        },
-        "node_modules/is-git-dirty/node_modules/is-stream": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-git-dirty/node_modules/signal-exit": {
-            "version": "3.0.7",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/is-git-repository": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "execa": "^4.0.3",
-                "is-absolute": "^1.0.0"
-            }
-        },
-        "node_modules/is-git-repository/node_modules/execa": {
-            "version": "4.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cross-spawn": "^7.0.0",
-                "get-stream": "^5.0.0",
-                "human-signals": "^1.1.1",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.0",
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2",
-                "strip-final-newline": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/is-git-repository/node_modules/human-signals": {
-            "version": "1.1.1",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=8.12.0"
-            }
-        },
-        "node_modules/is-git-repository/node_modules/is-stream": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-git-repository/node_modules/signal-exit": {
-            "version": "3.0.7",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/is-glob": {
             "version": "4.0.3",
             "dev": true,
@@ -13623,11 +13805,16 @@
             }
         },
         "node_modules/is-path-cwd": {
-            "version": "2.2.0",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-3.0.0.tgz",
+            "integrity": "sha512-kyiNFFLU0Ampr6SDZitD/DwUo4Zs1nSdnygUBqsu3LooL00Qvb5j+UnvApUn/TTj1J3OuE6BTdQ5rudKmU2ZaA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=6"
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-path-inside": {
@@ -13687,17 +13874,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-relative": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-unc-path": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/is-set": {
@@ -13773,17 +13949,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-unc-path": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "unc-path-regex": "^0.1.2"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/is-unicode-supported": {
@@ -14620,17 +14785,6 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
-        "node_modules/jetifier": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "bin": {
-                "jetifier": "bin/jetify",
-                "jetifier-standalone": "bin/jetifier-standalone",
-                "jetify": "bin/jetify"
-            }
-        },
         "node_modules/joi": {
             "version": "17.13.3",
             "dev": true,
@@ -14766,14 +14920,16 @@
             }
         },
         "node_modules/jsesc": {
-            "version": "2.5.2",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
             "dev": true,
             "license": "MIT",
             "bin": {
                 "jsesc": "bin/jsesc"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=6"
             }
         },
         "node_modules/json-buffer": {
@@ -16318,8 +16474,10 @@
             }
         },
         "node_modules/minipass": {
-            "version": "7.1.2",
-            "license": "ISC",
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+            "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
@@ -16696,6 +16854,7 @@
         },
         "node_modules/ms": {
             "version": "2.1.2",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/multer": {
@@ -16980,8 +17139,13 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.18",
-            "license": "MIT"
+            "version": "2.0.50",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+            "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/node-stream-zip": {
             "version": "1.15.0",
@@ -17395,14 +17559,13 @@
             }
         },
         "node_modules/p-map": {
-            "version": "4.0.0",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.5.tgz",
+            "integrity": "sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "aggregate-error": "^3.0.0"
-            },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -17719,7 +17882,9 @@
             "license": "MIT"
         },
         "node_modules/path-scurry": {
-            "version": "2.0.0",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -17727,7 +17892,7 @@
                 "minipass": "^7.1.2"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -17780,7 +17945,9 @@
             "license": "MIT"
         },
         "node_modules/picocolors": {
-            "version": "1.1.0",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
             "license": "ISC"
         },
         "node_modules/picomatch": {
@@ -17944,6 +18111,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/presentable-error": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/presentable-error/-/presentable-error-0.0.1.tgz",
+            "integrity": "sha512-E6rsNU1QNJgB3sjj7OANinGncFKuK+164sLXw1/CqBjj/EkXSoSdHCtWQGBNlREIGLnL7IEUEGa08YFVUbrhVg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/prettier": {
@@ -18487,97 +18667,152 @@
             }
         },
         "node_modules/react-native-builder-bob": {
-            "version": "0.21.3",
+            "version": "0.43.0",
+            "resolved": "https://registry.npmjs.org/react-native-builder-bob/-/react-native-builder-bob-0.43.0.tgz",
+            "integrity": "sha512-suE1OYf0umMQvzzQ+4Ba+5xMc8jLu60ILQi85x8SCBaBtVUSJfcaGvlv6+34xxXgy+a2PuyNzoOXr9STEweLrQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/core": "^7.18.5",
-                "@babel/plugin-proposal-class-properties": "^7.17.12",
-                "@babel/preset-env": "^7.18.2",
-                "@babel/preset-flow": "^7.17.12",
-                "@babel/preset-react": "^7.17.12",
-                "@babel/preset-typescript": "^7.17.12",
-                "browserslist": "^4.20.4",
-                "cosmiconfig": "^7.0.1",
-                "cross-spawn": "^7.0.3",
-                "dedent": "^0.7.0",
-                "del": "^6.1.1",
-                "fs-extra": "^10.1.0",
-                "glob": "^8.0.3",
-                "is-git-dirty": "^2.0.1",
-                "json5": "^2.2.1",
-                "kleur": "^4.1.4",
+                "@babel/core": "^7.29.0",
+                "@babel/plugin-transform-flow-strip-types": "^7.27.1",
+                "@babel/plugin-transform-strict-mode": "^7.27.1",
+                "@babel/preset-env": "^7.29.2",
+                "@babel/preset-react": "^7.28.5",
+                "@babel/preset-typescript": "^7.28.5",
+                "@jridgewell/sourcemap-codec": "^1.5.5",
+                "arktype": "^2.2.0",
+                "babel-plugin-syntax-hermes-parser": "^0.34.0",
+                "browserslist": "^4.28.2",
+                "cross-spawn": "^7.0.6",
+                "dedent": "^1.7.2",
+                "del": "^8.0.1",
+                "escape-string-regexp": "^5.0.0",
+                "fs-extra": "^11.3.4",
+                "glob": "^13.0.6",
+                "json5": "^2.2.3",
+                "kleur": "^4.1.5",
                 "prompts": "^2.4.2",
-                "which": "^2.0.2",
-                "yargs": "^17.5.1"
+                "typescript": "^6.0.3",
+                "which": "^6.0.1",
+                "yargs": "^18.0.0"
             },
             "bin": {
                 "bob": "bin/bob"
             },
             "engines": {
-                "node": ">= 16.0.0"
-            },
-            "optionalDependencies": {
-                "jetifier": "^2.0.0"
+                "node": "^20.19.0 || ^22.12.0 || >= 23.4.0"
             }
         },
-        "node_modules/react-native-builder-bob/node_modules/brace-expansion": {
-            "version": "2.0.1",
+        "node_modules/react-native-builder-bob/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/react-native-builder-bob/node_modules/cosmiconfig": {
-            "version": "7.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/parse-json": "^4.0.0",
-                "import-fresh": "^3.2.1",
-                "parse-json": "^5.0.0",
-                "path-type": "^4.0.0",
-                "yaml": "^1.10.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/react-native-builder-bob/node_modules/dedent": {
-            "version": "0.7.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/react-native-builder-bob/node_modules/fs-extra": {
-            "version": "10.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/react-native-builder-bob/node_modules/glob": {
-            "version": "8.1.0",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^5.0.1",
-                "once": "^1.3.0"
-            },
             "engines": {
                 "node": ">=12"
             },
             "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/react-native-builder-bob/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/react-native-builder-bob/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/react-native-builder-bob/node_modules/brace-expansion": {
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/react-native-builder-bob/node_modules/cliui": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+            "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^7.2.0",
+                "strip-ansi": "^7.1.0",
+                "wrap-ansi": "^9.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/react-native-builder-bob/node_modules/emoji-regex": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/react-native-builder-bob/node_modules/escape-string-regexp": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/react-native-builder-bob/node_modules/glob": {
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/react-native-builder-bob/node_modules/isexe": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+            "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/react-native-builder-bob/node_modules/kleur": {
@@ -18589,22 +18824,129 @@
             }
         },
         "node_modules/react-native-builder-bob/node_modules/minimatch": {
-            "version": "5.1.6",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "brace-expansion": "^5.0.5"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/react-native-builder-bob/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/react-native-builder-bob/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/react-native-builder-bob/node_modules/typescript": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/react-native-builder-bob/node_modules/which": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+            "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "isexe": "^4.0.0"
+            },
+            "bin": {
+                "node-which": "bin/which.js"
             },
             "engines": {
-                "node": ">=10"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
-        "node_modules/react-native-builder-bob/node_modules/yaml": {
-            "version": "1.10.2",
+        "node_modules/react-native-builder-bob/node_modules/wrap-ansi": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.1",
+                "string-width": "^7.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/react-native-builder-bob/node_modules/yargs": {
+            "version": "18.0.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+            "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^9.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "string-width": "^7.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^22.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=23"
+            }
+        },
+        "node_modules/react-native-builder-bob/node_modules/yargs-parser": {
+            "version": "22.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+            "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
             "dev": true,
             "license": "ISC",
             "engines": {
-                "node": ">= 6"
+                "node": "^20.19.0 || ^22.12.0 || >=23"
             }
         },
         "node_modules/react-native/node_modules/@jest/types": {
@@ -18930,11 +19272,15 @@
         },
         "node_modules/regenerate": {
             "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+            "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/regenerate-unicode-properties": {
-            "version": "10.1.1",
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.2.tgz",
+            "integrity": "sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -18948,14 +19294,6 @@
             "version": "0.14.1",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/regenerator-transform": {
-            "version": "0.15.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.8.4"
-            }
         },
         "node_modules/regex-not": {
             "version": "1.0.2",
@@ -18987,37 +19325,41 @@
             }
         },
         "node_modules/regexpu-core": {
-            "version": "5.3.2",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.4.0.tgz",
+            "integrity": "sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/regjsgen": "^0.8.0",
                 "regenerate": "^1.4.2",
-                "regenerate-unicode-properties": "^10.1.0",
-                "regjsparser": "^0.9.1",
+                "regenerate-unicode-properties": "^10.2.2",
+                "regjsgen": "^0.8.0",
+                "regjsparser": "^0.13.0",
                 "unicode-match-property-ecmascript": "^2.0.0",
-                "unicode-match-property-value-ecmascript": "^2.1.0"
+                "unicode-match-property-value-ecmascript": "^2.2.1"
             },
             "engines": {
                 "node": ">=4"
             }
         },
+        "node_modules/regjsgen": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
+            "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/regjsparser": {
-            "version": "0.9.1",
+            "version": "0.13.2",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.2.tgz",
+            "integrity": "sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "jsesc": "~0.5.0"
+                "jsesc": "~3.1.0"
             },
             "bin": {
                 "regjsparser": "bin/parser"
-            }
-        },
-        "node_modules/regjsparser/node_modules/jsesc": {
-            "version": "0.5.0",
-            "dev": true,
-            "bin": {
-                "jsesc": "bin/jsesc"
             }
         },
         "node_modules/remove-trailing-separator": {
@@ -19066,16 +19408,22 @@
             "license": "MIT"
         },
         "node_modules/resolve": {
-            "version": "1.22.8",
+            "version": "1.22.12",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "is-core-module": "^2.13.0",
+                "es-errors": "^1.3.0",
+                "is-core-module": "^2.16.1",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
             "bin": {
                 "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -20708,18 +21056,6 @@
                 "node": ">=6.4.0"
             }
         },
-        "node_modules/supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",
             "dev": true,
@@ -21057,14 +21393,6 @@
             "version": "1.1.1",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/to-fast-properties": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
         },
         "node_modules/to-object-path": {
             "version": "0.3.0",
@@ -21634,14 +21962,6 @@
                 "through": "^2.3.8"
             }
         },
-        "node_modules/unc-path-regex": {
-            "version": "0.1.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/undici": {
             "version": "6.19.8",
             "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
@@ -21658,7 +21978,9 @@
             "peer": true
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
-            "version": "2.0.0",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
+            "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -21667,6 +21989,8 @@
         },
         "node_modules/unicode-match-property-ecmascript": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+            "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -21678,7 +22002,9 @@
             }
         },
         "node_modules/unicode-match-property-value-ecmascript": {
-            "version": "2.1.0",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.1.tgz",
+            "integrity": "sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -21686,11 +22012,26 @@
             }
         },
         "node_modules/unicode-property-aliases-ecmascript": {
-            "version": "2.1.0",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz",
+            "integrity": "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/unicorn-magic": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+            "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/union-value": {
@@ -21807,7 +22148,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.1.0",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -21824,8 +22167,8 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "escalade": "^3.1.2",
-                "picocolors": "^1.0.1"
+                "escalade": "^3.2.0",
+                "picocolors": "^1.1.1"
             },
             "bin": {
                 "update-browserslist-db": "cli.js"
@@ -24127,20 +24470,19 @@
             "version": "0.2.2",
             "license": "MIT",
             "dependencies": {
-                "@backtrace/react-native": "^0.2.2",
                 "@backtrace/sdk-core": "^0.8.3",
-                "web-streams-polyfill": "^4.0.0"
+                "web-streams-polyfill": "^4.3.0"
             },
             "devDependencies": {
-                "@react-native-community/eslint-config": "^3.0.2",
-                "@types/jest": "^29.5.5",
+                "@react-native-community/eslint-config": "^3.2.0",
+                "@types/jest": "^29.5.14",
                 "@types/react": "~17.0.21",
                 "jest": "^29.7.0",
                 "pod-install": "^0.1.0",
                 "random-seed": "^0.3.0",
                 "react": "18.2.0",
                 "react-native": "^0.72.4",
-                "react-native-builder-bob": "^0.21.3",
+                "react-native-builder-bob": "^0.43.0",
                 "ts-jest": "^29.1.1",
                 "ts-loader": "^9.5.0",
                 "typescript": "^5.0.2"
@@ -24154,9 +24496,15 @@
             }
         },
         "packages/react-native/node_modules/web-streams-polyfill": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0.tgz",
-            "integrity": "sha512-0zJXHRAYEjM2tUfZ2DiSOHAa2aw1tisnnhU3ufD57R8iefL+DcdJyRBRyJpG+NUimDgbTI/lH+gAE1PAvV3Cgw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.3.0.tgz",
+            "integrity": "sha512-/Gnggvj9oSrEvJbDyyPtAnxBt5fGQM2iWOKQNu7ie1OxDgK40iZpyV3TKaRiEzVj1oA1UxKnEy9XPXh6PW3eVw==",
+            "license": "MIT",
+            "workspaces": [
+                "test/benchmark-test",
+                "test/rollup-test",
+                "test/webpack-test"
+            ],
             "engines": {
                 "node": ">= 8"
             }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -79,7 +79,7 @@
         "react-native": "*"
     },
     "devDependencies": {
-        "@react-native-community/eslint-config": "^3.0.2",
+        "@react-native-community/eslint-config": "^3.2.0",
         "@types/jest": "^29.5.5",
         "@types/react": "~17.0.21",
         "jest": "^29.7.0",
@@ -87,13 +87,13 @@
         "random-seed": "^0.3.0",
         "react": "18.2.0",
         "react-native": "^0.72.4",
-        "react-native-builder-bob": "^0.21.3",
+        "react-native-builder-bob": "^0.43.0",
         "ts-jest": "^29.1.1",
         "ts-loader": "^9.5.0",
         "typescript": "^5.0.2"
     },
     "dependencies": {
         "@backtrace/sdk-core": "^0.8.3",
-        "web-streams-polyfill": "^4.0.0"
+        "web-streams-polyfill": "^4.3.0"
     }
 }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -80,7 +80,7 @@
     },
     "devDependencies": {
         "@react-native-community/eslint-config": "^3.2.0",
-        "@types/jest": "^29.5.5",
+        "@types/jest": "^29.5.14",
         "@types/react": "~17.0.21",
         "jest": "^29.7.0",
         "pod-install": "^0.1.0",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -87,7 +87,7 @@
         "random-seed": "^0.3.0",
         "react": "18.2.0",
         "react-native": "^0.72.4",
-        "react-native-builder-bob": "^0.43.0",
+        "react-native-builder-bob": "^0.39.1",
         "ts-jest": "^29.1.1",
         "ts-loader": "^9.5.0",
         "typescript": "^5.0.2"

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -87,7 +87,7 @@
         "random-seed": "^0.3.0",
         "react": "18.2.0",
         "react-native": "^0.72.4",
-        "react-native-builder-bob": "^0.39.1",
+        "react-native-builder-bob": "^0.43.0",
         "ts-jest": "^29.1.1",
         "ts-loader": "^9.5.0",
         "typescript": "^5.0.2"

--- a/packages/react-native/tsconfig.json
+++ b/packages/react-native/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
         "rootDir": "./src",
-        "outDir": "./lib",
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,
         "module": "esnext",


### PR DESCRIPTION
Safe, non-breaking dependency bumps scoped only to `@backtrace/react-native`: 
- `@react-native-community/eslint-config` `^3.0.2`→`^3.2.0`, 
- `@types/jest` `^29.5.5`→`^29.5.14`
- `react-native-builder-bob` `^0.21.3`→`^0.43.0`, 
- `web-streams-polyfill` `^4.0.0`→`^4.3.0`


Dlso dropped `outDir` from tsconfig to clear a bob 0.43 build warning. 

Anything shared with other workspace packages (typescript, jest, ts-jest, react, react-native, sdk-core, etc.) was left untouched to preserve mono-repo compatibility. Verified with `bob build` (clean) and `npm test` (37/37 passing).
