### PR TITLE
react-native: bump example app RN toolchain to 0.77.3 (BT-7067)

### DIFF
--- a/examples/sdk/reactNative/package-lock.json
+++ b/examples/sdk/reactNative/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@backtrace/react-native": "file:../../../packages/react-native",
                 "react": "18.3.1",
-                "react-native": "^0.77.0"
+                "react-native": "^0.77.3"
             },
             "devDependencies": {
                 "@babel/core": "^7.20.0",
@@ -18,10 +18,10 @@
                 "@babel/runtime": "^7.20.0",
                 "@backtrace/javascript-cli": "file:../../../tools/cli",
                 "@backtrace/sourcemap-tools": "file:../../../tools/sourcemap-tools",
-                "@react-native/babel-preset": "^0.77.0",
-                "@react-native/eslint-config": "^0.77.0",
-                "@react-native/metro-config": "^0.77.0",
-                "@react-native/typescript-config": "^0.77.0",
+                "@react-native/babel-preset": "^0.77.3",
+                "@react-native/eslint-config": "^0.77.3",
+                "@react-native/metro-config": "^0.77.3",
+                "@react-native/typescript-config": "^0.77.3",
                 "@types/react": "^18.2.6",
                 "typescript": "5.0.4"
             },
@@ -31,24 +31,22 @@
         },
         "../../../packages/react-native": {
             "name": "@backtrace/react-native",
-            "version": "0.2.0",
+            "version": "0.2.2",
             "license": "MIT",
             "dependencies": {
-                "@backtrace/react-native": "^0.2.0",
-                "@backtrace/sdk-core": "^0.8.0",
-                "web-streams-polyfill": "^4.0.0"
+                "@backtrace/sdk-core": "^0.8.3",
+                "web-streams-polyfill": "^4.3.0"
             },
             "devDependencies": {
-                "@react-native-community/eslint-config": "^3.0.2",
-                "@types/jest": "^29.5.5",
+                "@react-native-community/eslint-config": "^3.2.0",
+                "@types/jest": "^29.5.14",
                 "@types/react": "~17.0.21",
                 "jest": "^29.7.0",
                 "pod-install": "^0.1.0",
-                "prettier": "^2.0.5",
                 "random-seed": "^0.3.0",
                 "react": "18.2.0",
                 "react-native": "^0.72.4",
-                "react-native-builder-bob": "^0.21.3",
+                "react-native-builder-bob": "^0.43.0",
                 "ts-jest": "^29.1.1",
                 "ts-loader": "^9.5.0",
                 "typescript": "^5.0.2"
@@ -59,20 +57,6 @@
             "peerDependencies": {
                 "react": "*",
                 "react-native": "*"
-            }
-        },
-        "../../../packages/react-native/node_modules/prettier": {
-            "version": "2.8.8",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "prettier": "bin-prettier.js"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            },
-            "funding": {
-                "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
         "../../../packages/react-native/node_modules/web-streams-polyfill": {
@@ -88,7 +72,7 @@
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@backtrace/sourcemap-tools": "^0.2.4",
+                "@backtrace/sourcemap-tools": "^0.2.5",
                 "command-line-args": "^5.2.1",
                 "command-line-usage": "^7.0.1",
                 "glob": "^10.3.3",
@@ -113,7 +97,7 @@
         },
         "../../../tools/sourcemap-tools": {
             "name": "@backtrace/sourcemap-tools",
-            "version": "0.2.4",
+            "version": "0.2.5",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -146,12 +130,12 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.29.7",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.1.1"
             },
@@ -235,13 +219,13 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
-            "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+            "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.28.3",
-                "@babel/types": "^7.28.2",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/gen-mapping": "^0.3.12",
                 "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
@@ -251,12 +235,12 @@
             }
         },
         "node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.27.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
-            "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+            "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.27.3"
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -306,17 +290,17 @@
             "license": "ISC"
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.3.tgz",
-            "integrity": "sha512-V9f6ZFIYSLNEbuGA/92uOvYsGCJNsuA8ESZ4ldc09bWk/j8H8TKiPw8Mk1eG6olpnO0ALHJmYfZvF4MEE4gajg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
+            "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.3",
-                "@babel/helper-member-expression-to-functions": "^7.27.1",
-                "@babel/helper-optimise-call-expression": "^7.27.1",
-                "@babel/helper-replace-supers": "^7.27.1",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-                "@babel/traverse": "^7.28.3",
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "@babel/helper-member-expression-to-functions": "^7.29.7",
+                "@babel/helper-optimise-call-expression": "^7.29.7",
+                "@babel/helper-replace-supers": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -370,49 +354,49 @@
             }
         },
         "node_modules/@babel/helper-globals": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-member-expression-to-functions": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
-            "integrity": "sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
+            "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.27.1",
-                "@babel/types": "^7.27.1"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-            "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.27.1",
-                "@babel/types": "^7.27.1"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-            "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.27.1",
-                "@babel/traverse": "^7.28.3"
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -422,21 +406,21 @@
             }
         },
         "node_modules/@babel/helper-optimise-call-expression": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
-            "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
+            "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.27.1"
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-            "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+            "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -458,14 +442,14 @@
             }
         },
         "node_modules/@babel/helper-replace-supers": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
-            "integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
+            "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-member-expression-to-functions": "^7.27.1",
-                "@babel/helper-optimise-call-expression": "^7.27.1",
-                "@babel/traverse": "^7.27.1"
+                "@babel/helper-member-expression-to-functions": "^7.29.7",
+                "@babel/helper-optimise-call-expression": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -475,40 +459,40 @@
             }
         },
         "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
-            "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
+            "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.27.1",
-                "@babel/types": "^7.27.1"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-            "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -538,12 +522,12 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
-            "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.28.4"
+                "@babel/types": "^7.29.7"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -722,12 +706,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-flow": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.27.1.tgz",
-            "integrity": "sha512-p9OkPbZ5G7UT1MofwYFigGebnrzGJacoBSQM0/6bi/PUMVE+qlWDD/OalvQKbwgQzU6dl0xAv6r4X7Jme0RYxA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.29.7.tgz",
+            "integrity": "sha512-ajMX6QPcyomotqwpzhkYGxcK2i/us0rs1Qo9QvUpa+Fca0FTmqrzKrctoIYLMxcOhGZldGT/BAVkRGTWBiR8gQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -783,12 +767,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
-            "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+            "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -884,12 +868,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-typescript": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
-            "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+            "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1140,13 +1124,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-flow-strip-types": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.27.1.tgz",
-            "integrity": "sha512-G5eDKsu50udECw7DL2AcsysXiQyB7Nfg521t2OAJ4tbfTJ27doHLeF/vlI1NZGlLdbb/v+ibvtL1YBQqYOwJGg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.29.7.tgz",
+            "integrity": "sha512-wRHeUjUjCZnMHmiO5bRgjFLcoEh7JyTdByOW11ahhwNa4V0bmeGEaIvt51yq0zQp2yWIpqfxXXPyUP6GFJZHOQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/plugin-syntax-flow": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/plugin-syntax-flow": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1253,13 +1237,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-commonjs": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
-            "integrity": "sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
+            "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1"
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1643,16 +1627,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-typescript": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.0.tgz",
-            "integrity": "sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
+            "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.27.3",
-                "@babel/helper-create-class-features-plugin": "^7.27.1",
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-                "@babel/plugin-syntax-typescript": "^7.27.1"
+                "@babel/helper-annotate-as-pure": "^7.29.7",
+                "@babel/helper-create-class-features-plugin": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+                "@babel/plugin-syntax-typescript": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1819,14 +1803,14 @@
             }
         },
         "node_modules/@babel/preset-flow": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.27.1.tgz",
-            "integrity": "sha512-ez3a2it5Fn6P54W8QkbfIyyIbxlXvcxyWHHvno1Wg0Ej5eiJY5hBb8ExttoIOJJk7V2dZE6prP7iby5q2aQ0Lg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.29.7.tgz",
+            "integrity": "sha512-KYIRV0BuaN68CDdsqFkAD7MU7yipUqQNuNElwATdxaIdpTjhvtY82QvkBJs7zV3Evxj2jFAAZ1iO8nyy0nhjqA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-validator-option": "^7.27.1",
-                "@babel/plugin-transform-flow-strip-types": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
+                "@babel/plugin-transform-flow-strip-types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1848,16 +1832,16 @@
             }
         },
         "node_modules/@babel/preset-typescript": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
-            "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.29.7.tgz",
+            "integrity": "sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.27.1",
-                "@babel/helper-validator-option": "^7.27.1",
-                "@babel/plugin-syntax-jsx": "^7.27.1",
-                "@babel/plugin-transform-modules-commonjs": "^7.27.1",
-                "@babel/plugin-transform-typescript": "^7.27.1"
+                "@babel/helper-plugin-utils": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
+                "@babel/plugin-syntax-jsx": "^7.29.7",
+                "@babel/plugin-transform-modules-commonjs": "^7.29.7",
+                "@babel/plugin-transform-typescript": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1867,9 +1851,9 @@
             }
         },
         "node_modules/@babel/register": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.28.3.tgz",
-            "integrity": "sha512-CieDOtd8u208eI49bYl4z1J22ySFw87IGwE+IswFEExH7e3rLgKb0WNQeumnacQ1+VoDJLYI5QFA3AJZuyZQfA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.29.7.tgz",
+            "integrity": "sha512-AMGJoWuES861riy6pcB0fphE1YXybtQnBYQMuIyPv6mKLiosfa79BKTnAOyx215c/3RJPJpdQwoHZ3earVH7AA==",
             "license": "MIT",
             "dependencies": {
                 "clone-deep": "^4.0.1",
@@ -1900,31 +1884,31 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-            "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@babel/parser": "^7.27.2",
-                "@babel/types": "^7.27.1"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
-            "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+            "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@babel/generator": "^7.28.3",
-                "@babel/helper-globals": "^7.28.0",
-                "@babel/parser": "^7.28.4",
-                "@babel/template": "^7.27.2",
-                "@babel/types": "^7.28.4",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "debug": "^4.3.1"
             },
             "engines": {
@@ -1951,13 +1935,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
-            "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.27.1"
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1974,13 +1958,6 @@
         "node_modules/@backtrace/sourcemap-tools": {
             "resolved": "../../../tools/sourcemap-tools",
             "link": true
-        },
-        "node_modules/@bcoe/v8-coverage": {
-            "version": "0.2.3",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.4.0",
@@ -2169,72 +2146,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@jest/console": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "jest-message-util": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/core": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/console": "^29.7.0",
-                "@jest/reporters": "^29.7.0",
-                "@jest/test-result": "^29.7.0",
-                "@jest/transform": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "ansi-escapes": "^4.2.1",
-                "chalk": "^4.0.0",
-                "ci-info": "^3.2.0",
-                "exit": "^0.1.2",
-                "graceful-fs": "^4.2.9",
-                "jest-changed-files": "^29.7.0",
-                "jest-config": "^29.7.0",
-                "jest-haste-map": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-regex-util": "^29.6.3",
-                "jest-resolve": "^29.7.0",
-                "jest-resolve-dependencies": "^29.7.0",
-                "jest-runner": "^29.7.0",
-                "jest-runtime": "^29.7.0",
-                "jest-snapshot": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "jest-validate": "^29.7.0",
-                "jest-watcher": "^29.7.0",
-                "micromatch": "^4.0.4",
-                "pretty-format": "^29.7.0",
-                "slash": "^3.0.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-            },
-            "peerDependenciesMeta": {
-                "node-notifier": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@jest/create-cache-key-function": {
             "version": "29.7.0",
             "license": "MIT",
@@ -2258,33 +2169,6 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/@jest/expect": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "expect": "^29.7.0",
-                "jest-snapshot": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/expect-utils": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "jest-get-type": "^29.6.3"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
         "node_modules/@jest/fake-timers": {
             "version": "29.7.0",
             "license": "MIT",
@@ -2300,135 +2184,11 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/@jest/globals": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/environment": "^29.7.0",
-                "@jest/expect": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "jest-mock": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/reporters": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@bcoe/v8-coverage": "^0.2.3",
-                "@jest/console": "^29.7.0",
-                "@jest/test-result": "^29.7.0",
-                "@jest/transform": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@jridgewell/trace-mapping": "^0.3.18",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "collect-v8-coverage": "^1.0.0",
-                "exit": "^0.1.2",
-                "glob": "^7.1.3",
-                "graceful-fs": "^4.2.9",
-                "istanbul-lib-coverage": "^3.0.0",
-                "istanbul-lib-instrument": "^6.0.0",
-                "istanbul-lib-report": "^3.0.0",
-                "istanbul-lib-source-maps": "^4.0.0",
-                "istanbul-reports": "^3.1.3",
-                "jest-message-util": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "jest-worker": "^29.7.0",
-                "slash": "^3.0.0",
-                "string-length": "^4.0.1",
-                "strip-ansi": "^6.0.0",
-                "v8-to-istanbul": "^9.0.1"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-            },
-            "peerDependenciesMeta": {
-                "node-notifier": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@jest/reporters/node_modules/istanbul-lib-instrument": {
-            "version": "6.0.3",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@babel/core": "^7.23.9",
-                "@babel/parser": "^7.23.9",
-                "@istanbuljs/schema": "^0.1.3",
-                "istanbul-lib-coverage": "^3.2.0",
-                "semver": "^7.5.4"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@jest/schemas": {
             "version": "29.6.3",
             "license": "MIT",
             "dependencies": {
                 "@sinclair/typebox": "^0.27.8"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/source-map": {
-            "version": "29.6.3",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.18",
-                "callsites": "^3.0.0",
-                "graceful-fs": "^4.2.9"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/test-result": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/console": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "collect-v8-coverage": "^1.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/test-sequencer": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/test-result": "^29.7.0",
-                "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.7.0",
-                "slash": "^3.0.0"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -2566,31 +2326,31 @@
             }
         },
         "node_modules/@react-native/assets-registry": {
-            "version": "0.77.0",
-            "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.77.0.tgz",
-            "integrity": "sha512-Ms4tYYAMScgINAXIhE4riCFJPPL/yltughHS950l0VP5sm5glbimn9n7RFn9Tc8cipX74/ddbk19+ydK2iDMmA==",
+            "version": "0.77.3",
+            "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.77.3.tgz",
+            "integrity": "sha512-kLocY1mlQjCdrX0y4eYQblub9NDdX+rkNii3F2rumri532ILjMAvkdpehf2PwQDj0X6PZYF1XFjszPw5uzq0Aw==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@react-native/babel-plugin-codegen": {
-            "version": "0.77.0",
-            "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.77.0.tgz",
-            "integrity": "sha512-5TYPn1k+jdDOZJU4EVb1kZ0p9TCVICXK3uplRev5Gul57oWesAaiWGZOzfRS3lonWeuR4ij8v8PFfIHOaq0vmA==",
+            "version": "0.77.3",
+            "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.77.3.tgz",
+            "integrity": "sha512-UbjQY8vFCVD4Aw4uSRWslKa26l1uOZzYhhKzWWOrV36f2NnP9Siid2rPkLa+MIJk16G2UzDRtUrMhGuejxp9cQ==",
             "license": "MIT",
             "dependencies": {
                 "@babel/traverse": "^7.25.3",
-                "@react-native/codegen": "0.77.0"
+                "@react-native/codegen": "0.77.3"
             },
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@react-native/babel-preset": {
-            "version": "0.77.0",
-            "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.77.0.tgz",
-            "integrity": "sha512-Z4yxE66OvPyQ/iAlaETI1ptRLcDm7Tk6ZLqtCPuUX3AMg+JNgIA86979T4RSk486/JrBUBH5WZe2xjj7eEHXsA==",
+            "version": "0.77.3",
+            "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.77.3.tgz",
+            "integrity": "sha512-Cy1RoL5/nh2S/suWgfTuhUwkERoDN/Q2O6dZd3lcNcBrjd5Y++sBJGyBnHd9pqlSmOy8RLLBJZ9dOylycBOqzQ==",
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.25.2",
@@ -2634,7 +2394,7 @@
                 "@babel/plugin-transform-typescript": "^7.25.2",
                 "@babel/plugin-transform-unicode-regex": "^7.24.7",
                 "@babel/template": "^7.25.0",
-                "@react-native/babel-plugin-codegen": "0.77.0",
+                "@react-native/babel-plugin-codegen": "0.77.3",
                 "babel-plugin-syntax-hermes-parser": "0.25.1",
                 "babel-plugin-transform-flow-enums": "^0.0.2",
                 "react-refresh": "^0.14.0"
@@ -2647,9 +2407,9 @@
             }
         },
         "node_modules/@react-native/codegen": {
-            "version": "0.77.0",
-            "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.77.0.tgz",
-            "integrity": "sha512-rE9lXx41ZjvE8cG7e62y/yGqzUpxnSvJ6me6axiX+aDewmI4ZrddvRGYyxCnawxy5dIBHSnrpZse3P87/4Lm7w==",
+            "version": "0.77.3",
+            "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.77.3.tgz",
+            "integrity": "sha512-Q6ZJCE7h6Z3v3DiEZUnqzHbgwF3ZILN+ACTx6qu/x2X1cL96AatKwdX92e0+7J9RFg6gdoFYJgRrW8Q6VnWZsQ==",
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.25.3",
@@ -2668,19 +2428,19 @@
             }
         },
         "node_modules/@react-native/community-cli-plugin": {
-            "version": "0.77.0",
-            "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.77.0.tgz",
-            "integrity": "sha512-GRshwhCHhtupa3yyCbel14SlQligV8ffNYN5L1f8HCo2SeGPsBDNjhj2U+JTrMPnoqpwowPGvkCwyqwqYff4MQ==",
+            "version": "0.77.3",
+            "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.77.3.tgz",
+            "integrity": "sha512-8OKvow2jHojl1d3PW/84uTBPMnmxRyPtfhBL0sQxrWP5Kgooe5XALoWsoBIFk+aIFu/fV7Pv0AAd0cdLC0NtOg==",
             "license": "MIT",
             "dependencies": {
-                "@react-native/dev-middleware": "0.77.0",
-                "@react-native/metro-babel-transformer": "0.77.0",
+                "@react-native/dev-middleware": "0.77.3",
+                "@react-native/metro-babel-transformer": "0.77.3",
                 "chalk": "^4.0.0",
                 "debug": "^2.2.0",
                 "invariant": "^2.2.4",
-                "metro": "^0.81.0",
-                "metro-config": "^0.81.0",
-                "metro-core": "^0.81.0",
+                "metro": "^0.81.5",
+                "metro-config": "^0.81.5",
+                "metro-core": "^0.81.5",
                 "readline": "^1.3.0",
                 "semver": "^7.1.3"
             },
@@ -2688,10 +2448,10 @@
                 "node": ">=18"
             },
             "peerDependencies": {
-                "@react-native-community/cli-server-api": "*"
+                "@react-native-community/cli": "*"
             },
             "peerDependenciesMeta": {
-                "@react-native-community/cli-server-api": {
+                "@react-native-community/cli": {
                     "optional": true
                 }
             }
@@ -2712,26 +2472,27 @@
             "license": "MIT"
         },
         "node_modules/@react-native/debugger-frontend": {
-            "version": "0.77.0",
-            "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.77.0.tgz",
-            "integrity": "sha512-glOvSEjCbVXw+KtfiOAmrq21FuLE1VsmBsyT7qud4KWbXP43aUEhzn70mWyFuiIdxnzVPKe2u8iWTQTdJksR1w==",
+            "version": "0.77.3",
+            "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.77.3.tgz",
+            "integrity": "sha512-FTERmc43r/3IpTvUZTr9gVVTgOIrg1hrkN57POr/CiL8RbcY/nv6vfNM7/CXG5WF8ckHiLeWTcRHzJUl1+rFkw==",
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@react-native/dev-middleware": {
-            "version": "0.77.0",
-            "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.77.0.tgz",
-            "integrity": "sha512-DAlEYujm43O+Dq98KP2XfLSX5c/TEGtt+JBDEIOQewk374uYY52HzRb1+Gj6tNaEj/b33no4GibtdxbO5zmPhg==",
+            "version": "0.77.3",
+            "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.77.3.tgz",
+            "integrity": "sha512-tCylGMjibJAEl2r2nWX5L5CvK6XFLGbjhe7Su7OcxRGrynHin87rAmcaTeoTtbtsREFlFM0f4qxcmwCxmbZHJw==",
             "license": "MIT",
             "dependencies": {
                 "@isaacs/ttlcache": "^1.4.1",
-                "@react-native/debugger-frontend": "0.77.0",
+                "@react-native/debugger-frontend": "0.77.3",
                 "chrome-launcher": "^0.15.2",
                 "chromium-edge-launcher": "^0.2.0",
                 "connect": "^3.6.5",
                 "debug": "^2.2.0",
+                "invariant": "^2.2.4",
                 "nullthrows": "^1.1.1",
                 "open": "^7.0.3",
                 "selfsigned": "^2.4.1",
@@ -2758,24 +2519,24 @@
             "license": "MIT"
         },
         "node_modules/@react-native/dev-middleware/node_modules/ws": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
-            "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+            "version": "6.2.4",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.4.tgz",
+            "integrity": "sha512-PNIUUyLI5YpkJZj60YBzX1o0ByQ4ovvfmq9N/Kig/PAYbVlGyz4R6G0SEWrD0O9acc0sT2+IdMBVLFv8FSi0Nw==",
             "license": "MIT",
             "dependencies": {
                 "async-limiter": "~1.0.0"
             }
         },
         "node_modules/@react-native/eslint-config": {
-            "version": "0.77.0",
-            "resolved": "https://registry.npmjs.org/@react-native/eslint-config/-/eslint-config-0.77.0.tgz",
-            "integrity": "sha512-azEiJNe/v1MjXE5Cekn8ygV4an0T3mNem4Afmeaq9tO9rfbOYr3VpTMFgc4B42SZgS4S6lyIqvwTfc8bSp0KRw==",
+            "version": "0.77.3",
+            "resolved": "https://registry.npmjs.org/@react-native/eslint-config/-/eslint-config-0.77.3.tgz",
+            "integrity": "sha512-pA8cQZNSTzCiI2Z8S30OnDnPrOuqq6D06qKVAOFFjeqK81jGR/NXmcULemBIh8UbPAEKKRZsSNq9Ovs2XI3dcA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.25.2",
                 "@babel/eslint-parser": "^7.25.1",
-                "@react-native/eslint-plugin": "0.77.0",
+                "@react-native/eslint-plugin": "0.77.3",
                 "@typescript-eslint/eslint-plugin": "^7.1.1",
                 "@typescript-eslint/parser": "^7.1.1",
                 "eslint-config-prettier": "^8.5.0",
@@ -2795,9 +2556,9 @@
             }
         },
         "node_modules/@react-native/eslint-plugin": {
-            "version": "0.77.0",
-            "resolved": "https://registry.npmjs.org/@react-native/eslint-plugin/-/eslint-plugin-0.77.0.tgz",
-            "integrity": "sha512-1DXUDiqsgvFpK633SsOF01aAtWAaI/+KqPJAoZOVdSsodk70wNYyrHpF9rJBXWhyT/peTBE5y2kK2kT/Y7JcQA==",
+            "version": "0.77.3",
+            "resolved": "https://registry.npmjs.org/@react-native/eslint-plugin/-/eslint-plugin-0.77.3.tgz",
+            "integrity": "sha512-EyxZXYgSpebHhHvSLraLBV8/RJ6Yz6DwGZjhVNFHrdeayBge8kMNbuij3cGJywE+Ud8Fi8YNSFV6PDVQttYIpQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2805,31 +2566,31 @@
             }
         },
         "node_modules/@react-native/gradle-plugin": {
-            "version": "0.77.0",
-            "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.77.0.tgz",
-            "integrity": "sha512-rmfh93jzbndSq7kihYHUQ/EGHTP8CCd3GDCmg5SbxSOHAaAYx2HZ28ZG7AVcGUsWeXp+e/90zGIyfOzDRx0Zaw==",
+            "version": "0.77.3",
+            "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.77.3.tgz",
+            "integrity": "sha512-GRVNBDowaFub9j+WBLGI09bDbCq+f7ugaNRr6lmZnLx/xdmiKUj9YKyARt4zn8m65MRK2JGlJk0OqmQOvswpzQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@react-native/js-polyfills": {
-            "version": "0.77.0",
-            "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.77.0.tgz",
-            "integrity": "sha512-kHFcMJVkGb3ptj3yg1soUsMHATqal4dh0QTGAbYihngJ6zy+TnP65J3GJq4UlwqFE9K1RZkeCmTwlmyPFHOGvA==",
+            "version": "0.77.3",
+            "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.77.3.tgz",
+            "integrity": "sha512-XqxnQRyKD11u5ZYG5LPnElThWYJf3HMosqqkJGB4nwx6nc6WKxj1sR9snptibExDMGioZ2OyvPWCF8tX+qggrw==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@react-native/metro-babel-transformer": {
-            "version": "0.77.0",
-            "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.77.0.tgz",
-            "integrity": "sha512-19GfvhBRKCU3UDWwCnDR4QjIzz3B2ZuwhnxMRwfAgPxz7QY9uKour9RGmBAVUk1Wxi/SP7dLEvWnmnuBO39e2A==",
+            "version": "0.77.3",
+            "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.77.3.tgz",
+            "integrity": "sha512-eBX5ibF1ovuZGwo08UOhnnkZDnhl8DdrCulJ8V/LCnpC6CihhQyxtolO+BmzXjUFyGiH7ImoxX7+mpXI74NYGg==",
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.25.2",
-                "@react-native/babel-preset": "0.77.0",
+                "@react-native/babel-preset": "0.77.3",
                 "hermes-parser": "0.25.1",
                 "nullthrows": "^1.1.1"
             },
@@ -2841,38 +2602,38 @@
             }
         },
         "node_modules/@react-native/metro-config": {
-            "version": "0.77.0",
-            "resolved": "https://registry.npmjs.org/@react-native/metro-config/-/metro-config-0.77.0.tgz",
-            "integrity": "sha512-IhcsIDdoIYkXf3FoZxayRGg2oMLBhpqWEH6IDJlJTQamOQ3PUm2uF1e7yzvnatZ18A6JCNhOlxnBK7m5ZWQPYQ==",
+            "version": "0.77.3",
+            "resolved": "https://registry.npmjs.org/@react-native/metro-config/-/metro-config-0.77.3.tgz",
+            "integrity": "sha512-KqjMH4mBpssGP3zEfrsr05o3CYBr573PP8YOHwOS3yOEGY8PFPzXWxGYmZ9b98sCjUvruZ6CbybLWt5bZ0wVnQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@react-native/js-polyfills": "0.77.0",
-                "@react-native/metro-babel-transformer": "0.77.0",
-                "metro-config": "^0.81.0",
-                "metro-runtime": "^0.81.0"
+                "@react-native/js-polyfills": "0.77.3",
+                "@react-native/metro-babel-transformer": "0.77.3",
+                "metro-config": "^0.81.5",
+                "metro-runtime": "^0.81.5"
             },
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@react-native/normalize-colors": {
-            "version": "0.77.0",
-            "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.77.0.tgz",
-            "integrity": "sha512-qjmxW3xRZe4T0ZBEaXZNHtuUbRgyfybWijf1yUuQwjBt24tSapmIslwhCjpKidA0p93ssPcepquhY0ykH25mew==",
+            "version": "0.77.3",
+            "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.77.3.tgz",
+            "integrity": "sha512-9gHhvK0EKskgIN4JiwzQdxiKhLCgH2LpCp+v38ZxWQpXTMbTDDE4AJRqYgWp2v9WUFQB/S5+XqBDZDgn/MGq9A==",
             "license": "MIT"
         },
         "node_modules/@react-native/typescript-config": {
-            "version": "0.77.0",
-            "resolved": "https://registry.npmjs.org/@react-native/typescript-config/-/typescript-config-0.77.0.tgz",
-            "integrity": "sha512-WunTrKSQtGKi7gVf24jinHkXXi3tSkChRfrUPFY1njNWwVNtJ/H0ElSlJKUIWaBcd6DKG4ZddKsftWBAWTV0Sg==",
+            "version": "0.77.3",
+            "resolved": "https://registry.npmjs.org/@react-native/typescript-config/-/typescript-config-0.77.3.tgz",
+            "integrity": "sha512-lSiHcIiSxbyaFVXey3qQWVPr2pfuCWNzxGdfjVbFz1fdwZGt6M1PgX1VUODYB0NCbyRPYILa8n7qQDFmpmmxVQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@react-native/virtualized-lists": {
-            "version": "0.77.0",
-            "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.77.0.tgz",
-            "integrity": "sha512-ppPtEu9ISO9iuzpA2HBqrfmDpDAnGGduNDVaegadOzbMCPAB3tC9Blxdu9W68LyYlNQILIsP6/FYtLwf7kfNew==",
+            "version": "0.77.3",
+            "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.77.3.tgz",
+            "integrity": "sha512-3B0TPbLp7ZMWTlsOf+MzcuKuqF2HZzqh94+tPvw1thF5PxPaO2yZjVxfjrQ9EtdhQisG4siwiXVHB9DD6VkU4A==",
             "license": "MIT",
             "dependencies": {
                 "invariant": "^2.2.4",
@@ -3283,35 +3044,6 @@
         "node_modules/anser": {
             "version": "1.4.10",
             "license": "MIT"
-        },
-        "node_modules/ansi-escapes": {
-            "version": "4.3.2",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "type-fest": "^0.21.3"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/ansi-escapes/node_modules/type-fest": {
-            "version": "0.21.3",
-            "dev": true,
-            "license": "(MIT OR CC0-1.0)",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
         },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
@@ -3854,16 +3586,6 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
-        "node_modules/char-regex": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/chrome-launcher": {
             "version": "0.15.2",
             "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.2.tgz",
@@ -3909,13 +3631,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/cjs-module-lexer": {
-            "version": "1.4.1",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/cliui": {
             "version": "8.0.1",
             "license": "ISC",
@@ -3941,24 +3656,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/co": {
-            "version": "4.6.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "iojs": ">= 1.0.0",
-                "node": ">= 0.12.0"
-            }
-        },
-        "node_modules/collect-v8-coverage": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/commander": {
             "version": "12.1.0",
@@ -4087,28 +3784,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/create-jest": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "chalk": "^4.0.0",
-                "exit": "^0.1.2",
-                "graceful-fs": "^4.2.9",
-                "jest-config": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "prompts": "^2.0.1"
-            },
-            "bin": {
-                "create-jest": "bin/create-jest.js"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
             "dev": true,
@@ -4191,36 +3866,11 @@
                 }
             }
         },
-        "node_modules/dedent": {
-            "version": "1.5.3",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "peerDependencies": {
-                "babel-plugin-macros": "^3.1.0"
-            },
-            "peerDependenciesMeta": {
-                "babel-plugin-macros": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "dev": true,
             "license": "MIT",
             "peer": true
-        },
-        "node_modules/deepmerge": {
-            "version": "4.3.1",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/define-data-property": {
             "version": "1.1.4",
@@ -4273,26 +3923,6 @@
                 "npm": "1.2.8000 || >= 1.4.16"
             }
         },
-        "node_modules/detect-newline": {
-            "version": "3.1.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/diff-sequences": {
-            "version": "29.6.3",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
         "node_modules/dir-glob": {
             "version": "3.0.1",
             "dev": true,
@@ -4325,19 +3955,6 @@
         "node_modules/electron-to-chromium": {
             "version": "1.5.29",
             "license": "ISC"
-        },
-        "node_modules/emittery": {
-            "version": "0.13.1",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/emittery?sponsor=1"
-            }
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -5005,56 +4622,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/execa": {
-            "version": "5.1.1",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.0",
-                "human-signals": "^2.1.0",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.1",
-                "onetime": "^5.1.2",
-                "signal-exit": "^3.0.3",
-                "strip-final-newline": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/exit": {
-            "version": "0.1.2",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/expect": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/expect-utils": "^29.7.0",
-                "jest-get-type": "^29.6.3",
-                "jest-matcher-utils": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-util": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
         "node_modules/exponential-backoff": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
@@ -5259,11 +4826,23 @@
             "integrity": "sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==",
             "license": "MIT"
         },
-        "node_modules/flow-parser": {
-            "version": "0.287.0",
-            "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.287.0.tgz",
-            "integrity": "sha512-92XfPmSg6zV/UD/R3Hw+sxBUi3SiIL8COqD7p3HRZysX1ksrw5MdPhpqox0U0Hd5lqQ9F1AJCi92fnRO7WDgFw==",
+        "node_modules/flow-estree": {
+            "version": "0.321.0",
+            "resolved": "https://registry.npmjs.org/flow-estree/-/flow-estree-0.321.0.tgz",
+            "integrity": "sha512-rQY7YKoo+PKpAHQjEP2cxyIefk04OCEKUlbtV4y6LAUG3Ly7guQX9YH8th6drSmYcNkMgpqWMaHRhhYaAF69CA==",
             "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/flow-parser": {
+            "version": "0.321.0",
+            "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.321.0.tgz",
+            "integrity": "sha512-9LNK2rp/NWWbwdEK6mxC54XfQRyD2lVV0iPVBYf+5o5vvqJl7ietkR1hX3/dZ39j0GAbL4PIFoeekDViOW0x/Q==",
+            "license": "MIT",
+            "dependencies": {
+                "flow-estree": "0.321.0"
+            },
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -5369,19 +4948,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8.0.0"
-            }
-        },
-        "node_modules/get-stream": {
-            "version": "6.0.1",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/get-symbol-description": {
@@ -5578,46 +5144,33 @@
                 "hermes-estree": "0.25.1"
             }
         },
-        "node_modules/html-escaper": {
-            "version": "2.0.2",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/http-errors": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
             "license": "MIT",
             "dependencies": {
-                "depd": "2.0.0",
-                "inherits": "2.0.4",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "toidentifier": "1.0.1"
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
             },
             "engines": {
                 "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/http-errors/node_modules/statuses": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/human-signals": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10.17.0"
             }
         },
         "node_modules/ignore": {
@@ -5666,95 +5219,6 @@
             "peer": true,
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/import-local": {
-            "version": "3.2.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "pkg-dir": "^4.2.0",
-                "resolve-cwd": "^3.0.0"
-            },
-            "bin": {
-                "import-local-fixture": "fixtures/cli.js"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/import-local/node_modules/find-up": {
-            "version": "4.1.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/import-local/node_modules/locate-path": {
-            "version": "5.0.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "p-locate": "^4.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/import-local/node_modules/p-limit": {
-            "version": "2.3.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "p-try": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/import-local/node_modules/p-locate": {
-            "version": "4.1.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "p-limit": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/import-local/node_modules/pkg-dir": {
-            "version": "4.2.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "find-up": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/imurmurhash": {
@@ -5959,16 +5423,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/is-generator-fn": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/is-generator-function": {
             "version": "1.0.10",
             "dev": true,
@@ -6096,19 +5550,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-stream": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-string": {
@@ -6250,66 +5691,6 @@
                 "semver": "bin/semver.js"
             }
         },
-        "node_modules/istanbul-lib-report": {
-            "version": "3.0.1",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "istanbul-lib-coverage": "^3.0.0",
-                "make-dir": "^4.0.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/istanbul-lib-report/node_modules/make-dir": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "semver": "^7.5.3"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/istanbul-lib-source-maps": {
-            "version": "4.0.1",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "debug": "^4.1.1",
-                "istanbul-lib-coverage": "^3.0.0",
-                "source-map": "^0.6.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/istanbul-reports": {
-            "version": "3.1.7",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "html-escaper": "^2.0.0",
-                "istanbul-lib-report": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/iterator.prototype": {
             "version": "1.1.2",
             "dev": true,
@@ -6320,206 +5701,6 @@
                 "has-symbols": "^1.0.3",
                 "reflect.getprototypeof": "^1.0.4",
                 "set-function-name": "^2.0.1"
-            }
-        },
-        "node_modules/jest": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/core": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "import-local": "^3.0.2",
-                "jest-cli": "^29.7.0"
-            },
-            "bin": {
-                "jest": "bin/jest.js"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-            },
-            "peerDependenciesMeta": {
-                "node-notifier": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/jest-changed-files": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "execa": "^5.0.0",
-                "jest-util": "^29.7.0",
-                "p-limit": "^3.1.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-circus": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/environment": "^29.7.0",
-                "@jest/expect": "^29.7.0",
-                "@jest/test-result": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "co": "^4.6.0",
-                "dedent": "^1.0.0",
-                "is-generator-fn": "^2.0.0",
-                "jest-each": "^29.7.0",
-                "jest-matcher-utils": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-runtime": "^29.7.0",
-                "jest-snapshot": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "p-limit": "^3.1.0",
-                "pretty-format": "^29.7.0",
-                "pure-rand": "^6.0.0",
-                "slash": "^3.0.0",
-                "stack-utils": "^2.0.3"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-cli": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/core": "^29.7.0",
-                "@jest/test-result": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "chalk": "^4.0.0",
-                "create-jest": "^29.7.0",
-                "exit": "^0.1.2",
-                "import-local": "^3.0.2",
-                "jest-config": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "jest-validate": "^29.7.0",
-                "yargs": "^17.3.1"
-            },
-            "bin": {
-                "jest": "bin/jest.js"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-            },
-            "peerDependenciesMeta": {
-                "node-notifier": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/jest-config": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@babel/core": "^7.11.6",
-                "@jest/test-sequencer": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "babel-jest": "^29.7.0",
-                "chalk": "^4.0.0",
-                "ci-info": "^3.2.0",
-                "deepmerge": "^4.2.2",
-                "glob": "^7.1.3",
-                "graceful-fs": "^4.2.9",
-                "jest-circus": "^29.7.0",
-                "jest-environment-node": "^29.7.0",
-                "jest-get-type": "^29.6.3",
-                "jest-regex-util": "^29.6.3",
-                "jest-resolve": "^29.7.0",
-                "jest-runner": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "jest-validate": "^29.7.0",
-                "micromatch": "^4.0.4",
-                "parse-json": "^5.2.0",
-                "pretty-format": "^29.7.0",
-                "slash": "^3.0.0",
-                "strip-json-comments": "^3.1.1"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "@types/node": "*",
-                "ts-node": ">=9.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "ts-node": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/jest-diff": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "chalk": "^4.0.0",
-                "diff-sequences": "^29.6.3",
-                "jest-get-type": "^29.6.3",
-                "pretty-format": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-docblock": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "detect-newline": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-each": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "chalk": "^4.0.0",
-                "jest-get-type": "^29.6.3",
-                "jest-util": "^29.7.0",
-                "pretty-format": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-environment-node": {
@@ -6567,36 +5748,6 @@
                 "fsevents": "^2.3.2"
             }
         },
-        "node_modules/jest-leak-detector": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "jest-get-type": "^29.6.3",
-                "pretty-format": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-matcher-utils": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "chalk": "^4.0.0",
-                "jest-diff": "^29.7.0",
-                "jest-get-type": "^29.6.3",
-                "pretty-format": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
         "node_modules/jest-message-util": {
             "version": "29.7.0",
             "license": "MIT",
@@ -6627,172 +5778,9 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/jest-pnp-resolver": {
-            "version": "1.2.3",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=6"
-            },
-            "peerDependencies": {
-                "jest-resolve": "*"
-            },
-            "peerDependenciesMeta": {
-                "jest-resolve": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/jest-regex-util": {
             "version": "29.6.3",
             "license": "MIT",
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-resolve": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "chalk": "^4.0.0",
-                "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.7.0",
-                "jest-pnp-resolver": "^1.2.2",
-                "jest-util": "^29.7.0",
-                "jest-validate": "^29.7.0",
-                "resolve": "^1.20.0",
-                "resolve.exports": "^2.0.0",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-resolve-dependencies": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "jest-regex-util": "^29.6.3",
-                "jest-snapshot": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-runner": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/console": "^29.7.0",
-                "@jest/environment": "^29.7.0",
-                "@jest/test-result": "^29.7.0",
-                "@jest/transform": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "emittery": "^0.13.1",
-                "graceful-fs": "^4.2.9",
-                "jest-docblock": "^29.7.0",
-                "jest-environment-node": "^29.7.0",
-                "jest-haste-map": "^29.7.0",
-                "jest-leak-detector": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-resolve": "^29.7.0",
-                "jest-runtime": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "jest-watcher": "^29.7.0",
-                "jest-worker": "^29.7.0",
-                "p-limit": "^3.1.0",
-                "source-map-support": "0.5.13"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-runner/node_modules/source-map-support": {
-            "version": "0.5.13",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
-            }
-        },
-        "node_modules/jest-runtime": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/environment": "^29.7.0",
-                "@jest/fake-timers": "^29.7.0",
-                "@jest/globals": "^29.7.0",
-                "@jest/source-map": "^29.6.3",
-                "@jest/test-result": "^29.7.0",
-                "@jest/transform": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "chalk": "^4.0.0",
-                "cjs-module-lexer": "^1.0.0",
-                "collect-v8-coverage": "^1.0.0",
-                "glob": "^7.1.3",
-                "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-mock": "^29.7.0",
-                "jest-regex-util": "^29.6.3",
-                "jest-resolve": "^29.7.0",
-                "jest-snapshot": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "slash": "^3.0.0",
-                "strip-bom": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-snapshot": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@babel/core": "^7.11.6",
-                "@babel/generator": "^7.7.2",
-                "@babel/plugin-syntax-jsx": "^7.7.2",
-                "@babel/plugin-syntax-typescript": "^7.7.2",
-                "@babel/types": "^7.3.3",
-                "@jest/expect-utils": "^29.7.0",
-                "@jest/transform": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "babel-preset-current-node-syntax": "^1.0.0",
-                "chalk": "^4.0.0",
-                "expect": "^29.7.0",
-                "graceful-fs": "^4.2.9",
-                "jest-diff": "^29.7.0",
-                "jest-get-type": "^29.6.3",
-                "jest-matcher-utils": "^29.7.0",
-                "jest-message-util": "^29.7.0",
-                "jest-util": "^29.7.0",
-                "natural-compare": "^1.4.0",
-                "pretty-format": "^29.7.0",
-                "semver": "^7.5.3"
-            },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
@@ -6835,26 +5823,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/jest-watcher": {
-            "version": "29.7.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jest/test-result": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "ansi-escapes": "^4.2.1",
-                "chalk": "^4.0.0",
-                "emittery": "^0.13.1",
-                "jest-util": "^29.7.0",
-                "string-length": "^4.0.1"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-worker": {
@@ -6979,13 +5947,6 @@
             "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
             "license": "MIT"
         },
-        "node_modules/json-parse-even-better-errors": {
-            "version": "2.3.1",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "dev": true,
@@ -7040,16 +6001,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/kleur": {
-            "version": "3.0.3",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/leven": {
             "version": "3.1.0",
             "license": "MIT",
@@ -7094,13 +6045,6 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "license": "MIT"
-        },
-        "node_modules/lines-and-columns": {
-            "version": "1.2.4",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/locate-path": {
             "version": "3.0.0",
@@ -7581,16 +6525,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/minimatch": {
             "version": "3.1.2",
             "license": "ISC",
@@ -7646,9 +6580,9 @@
             "license": "MIT"
         },
         "node_modules/node-forge": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-            "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+            "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
             "license": "(BSD-3-Clause OR GPL-2.0)",
             "engines": {
                 "node": ">= 6.13.0"
@@ -7667,19 +6601,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/npm-run-path": {
-            "version": "4.0.1",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "path-key": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/nullthrows": {
@@ -7809,22 +6730,6 @@
                 "wrappy": "1"
             }
         },
-        "node_modules/onetime": {
-            "version": "5.1.2",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/open": {
             "version": "7.4.2",
             "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
@@ -7917,25 +6822,6 @@
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/parse-json": {
-            "version": "5.2.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@babel/code-frame": "^7.0.0",
-                "error-ex": "^1.3.1",
-                "json-parse-even-better-errors": "^2.3.0",
-                "lines-and-columns": "^1.1.6"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/parseurl": {
@@ -8099,20 +6985,6 @@
                 "asap": "~2.0.6"
             }
         },
-        "node_modules/prompts": {
-            "version": "2.4.2",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "kleur": "^3.0.3",
-                "sisteransi": "^1.0.5"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/prop-types": {
             "version": "15.8.1",
             "dev": true,
@@ -8136,23 +7008,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/pure-rand": {
-            "version": "6.1.0",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/dubzzz"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fast-check"
-                }
-            ],
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/queue": {
             "version": "6.0.2",
@@ -8216,19 +7071,19 @@
             "license": "MIT"
         },
         "node_modules/react-native": {
-            "version": "0.77.0",
-            "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.77.0.tgz",
-            "integrity": "sha512-oCgHLGHFIp6F5UbyHSedyUXrZg6/GPe727freGFvlT7BjPJ3K6yvvdlsp7OEXSAHz6Fe7BI2n5cpUyqmP9Zn+Q==",
+            "version": "0.77.3",
+            "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.77.3.tgz",
+            "integrity": "sha512-fIYZ9+zX+iGcb/xGZA6oN3Uq9x46PdqVYtlyG+WmOIFQPVXgryaS9FJLdTvoTpsEA2JXGSGgNOdm640IdAW3cA==",
             "license": "MIT",
             "dependencies": {
                 "@jest/create-cache-key-function": "^29.6.3",
-                "@react-native/assets-registry": "0.77.0",
-                "@react-native/codegen": "0.77.0",
-                "@react-native/community-cli-plugin": "0.77.0",
-                "@react-native/gradle-plugin": "0.77.0",
-                "@react-native/js-polyfills": "0.77.0",
-                "@react-native/normalize-colors": "0.77.0",
-                "@react-native/virtualized-lists": "0.77.0",
+                "@react-native/assets-registry": "0.77.3",
+                "@react-native/codegen": "0.77.3",
+                "@react-native/community-cli-plugin": "0.77.3",
+                "@react-native/gradle-plugin": "0.77.3",
+                "@react-native/js-polyfills": "0.77.3",
+                "@react-native/normalize-colors": "0.77.3",
+                "@react-native/virtualized-lists": "0.77.3",
                 "abort-controller": "^3.0.0",
                 "anser": "^1.4.9",
                 "ansi-regex": "^5.0.0",
@@ -8244,8 +7099,8 @@
                 "jest-environment-node": "^29.6.3",
                 "jsc-android": "^250231.0.0",
                 "memoize-one": "^5.0.0",
-                "metro-runtime": "^0.81.0",
-                "metro-source-map": "^0.81.0",
+                "metro-runtime": "^0.81.5",
+                "metro-source-map": "^0.81.5",
                 "nullthrows": "^1.1.1",
                 "pretty-format": "^29.7.0",
                 "promise": "^8.3.0",
@@ -8302,9 +7157,9 @@
             "license": "BSD"
         },
         "node_modules/recast": {
-            "version": "0.23.11",
-            "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
-            "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
+            "version": "0.23.12",
+            "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.12.tgz",
+            "integrity": "sha512-dEWRjcINDu/F4l2dYx57ugBtD7HV9KXESyxhzw/MqWLeglJrsjJKqACPyUPg+6AF8mIgm+Zi0dZ3ACoIg+QtpA==",
             "license": "MIT",
             "dependencies": {
                 "ast-types": "^0.16.1",
@@ -8432,34 +7287,11 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/resolve-cwd": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "resolve-from": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/resolve-from": {
             "version": "5.0.0",
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/resolve.exports": {
-            "version": "2.0.2",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/reusify": {
@@ -8570,24 +7402,24 @@
             }
         },
         "node_modules/send": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
-            "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+            "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
             "license": "MIT",
             "dependencies": {
                 "debug": "2.6.9",
                 "depd": "2.0.0",
                 "destroy": "1.2.0",
-                "encodeurl": "~1.0.2",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "etag": "~1.8.1",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
+                "fresh": "~0.5.2",
+                "http-errors": "~2.0.1",
                 "mime": "1.6.0",
                 "ms": "2.1.3",
-                "on-finished": "2.4.1",
+                "on-finished": "~2.4.1",
                 "range-parser": "~1.2.1",
-                "statuses": "2.0.1"
+                "statuses": "~2.0.2"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -8608,6 +7440,15 @@
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "license": "MIT"
         },
+        "node_modules/send/node_modules/encodeurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/send/node_modules/on-finished": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -8621,9 +7462,9 @@
             }
         },
         "node_modules/send/node_modules/statuses": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
@@ -8639,15 +7480,15 @@
             }
         },
         "node_modules/serve-static": {
-            "version": "1.16.2",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-            "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+            "version": "1.16.3",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+            "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
             "license": "MIT",
             "dependencies": {
                 "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "parseurl": "~1.3.3",
-                "send": "0.19.0"
+                "send": "~0.19.1"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -8764,13 +7605,6 @@
             "version": "3.0.7",
             "license": "ISC"
         },
-        "node_modules/sisteransi": {
-            "version": "1.0.5",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/slash": {
             "version": "3.0.0",
             "license": "MIT",
@@ -8846,20 +7680,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/string-length": {
-            "version": "4.0.2",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "char-regex": "^1.0.2",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/string-natural-compare": {
@@ -8969,26 +7789,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/strip-bom": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/strip-final-newline": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
             "dev": true,
@@ -9076,9 +7876,9 @@
             "license": "MIT"
         },
         "node_modules/tmp": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
             "license": "MIT",
             "engines": {
                 "node": ">=14.14"
@@ -9358,21 +8158,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4.0"
-            }
-        },
-        "node_modules/v8-to-istanbul": {
-            "version": "9.3.0",
-            "dev": true,
-            "license": "ISC",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.12",
-                "@types/istanbul-lib-coverage": "^2.0.1",
-                "convert-source-map": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10.12.0"
             }
         },
         "node_modules/vlq": {

--- a/examples/sdk/reactNative/package.json
+++ b/examples/sdk/reactNative/package.json
@@ -11,7 +11,7 @@
     "dependencies": {
         "@backtrace/react-native": "file:../../../packages/react-native",
         "react": "18.3.1",
-        "react-native": "^0.77.0"
+        "react-native": "^0.77.3"
     },
     "devDependencies": {
         "@babel/core": "^7.20.0",
@@ -19,10 +19,10 @@
         "@babel/runtime": "^7.20.0",
         "@backtrace/javascript-cli": "file:../../../tools/cli",
         "@backtrace/sourcemap-tools": "file:../../../tools/sourcemap-tools",
-        "@react-native/babel-preset": "^0.77.0",
-        "@react-native/eslint-config": "^0.77.0",
-        "@react-native/metro-config": "^0.77.0",
-        "@react-native/typescript-config": "^0.77.0",
+        "@react-native/babel-preset": "^0.77.3",
+        "@react-native/eslint-config": "^0.77.3",
+        "@react-native/metro-config": "^0.77.3",
+        "@react-native/typescript-config": "^0.77.3",
         "@types/react": "^18.2.6",
         "typescript": "5.0.4"
     },


### PR DESCRIPTION
Patch bump of react-native and `@react-native/*` to `^0.77.3` in the example app; stays on React 18 and Metro 0.81.x.