### PR TITLE
react-native: Build windows on node v20 and test on v18 and v20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,16 +102,21 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [18.x]
+                build-version: [20.x]
+                node-version: [18.x, 20.x]
 
         steps:
             - uses: actions/checkout@v4
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4
               with:
-                  node-version: ${{ matrix.node-version }}
+                  node-version: ${{ matrix.build-version }}
             - run: npm ci
             - run: npm run build
+            - name: Test using Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ matrix.node-version }}
             - run: npm test
             - name: smoke-test
               uses: ./.github/actions/smoke-tests


### PR DESCRIPTION
This PR updates the CI workflow to run Windows builds on Node.js 20 while still testing against both Node.js 18 and 20. The change improves compatibility with the current runtime expectations and broadens test coverage across supported Node versions.