### PR TITLE
chore(ci): fix smoketests

### DIFF
--- a/.github/actions/smoke-tests/action.yml
+++ b/.github/actions/smoke-tests/action.yml
@@ -34,9 +34,13 @@ runs:
                       - 'packages/browser/**'
                       - 'packages/react/**'
                       - 'packages/sdk-core/**'
+                      - 'smoketests/**'
+                      - '.github/actions/smoke-tests/**'
                   node:
                       - 'packages/sdk-core/**'
                       - 'packages/node/**'
+                      - 'smoketests/**'
+                      - '.github/actions/smoke-tests/**'
 
         - run: npm run smoketest:node
           shell: bash

--- a/smoketests/tests/jest/node/tests.ts
+++ b/smoketests/tests/jest/node/tests.ts
@@ -1,3 +1,5 @@
+// explicit import so jest matcher types win over expect-webdriverio's global expect
+import { expect } from '@jest/globals';
 import { npm } from '../../__helpers/npm.js';
 import { RXID_REGEX } from '../../__helpers/rxid.js';
 import { DIRECT_SUBMIT_URL, SUBMIT_LAYER_URL } from '../../__helpers/urls.js';

--- a/smoketests/wdio.conf.ts
+++ b/smoketests/wdio.conf.ts
@@ -4,13 +4,6 @@ export const config: Options.Testrunner & {
     capabilities: WebdriverIO.Capabilities[];
 } = {
     runner: 'local',
-    autoCompileOpts: {
-        autoCompile: true,
-        tsNodeOpts: {
-            project: './tsconfig.json',
-            transpileOnly: true,
-        },
-    },
 
     user: process.env.SMOKETESTS_SAUCE_USERNAME,
     key: process.env.SMOKETESTS_SAUCE_ACCESS_KEY,

--- a/smoketests/wdio.conf.ts
+++ b/smoketests/wdio.conf.ts
@@ -49,6 +49,10 @@ export const config: Options.Testrunner & {
             'sauce',
             {
                 sauceConnect: true,
+                sauceConnectOpts: {
+                    // sc output is debug-level and dropped under logLevel info, print it so CI shows the exit reason
+                    logger: (output: string) => console.log(`[sauce-connect] ${output}`),
+                },
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 setJobName(config, capabilities: any) {
                     return `@backtrace/javascript smoketests for ${capabilities.browserName} on ${capabilities.platformName}`;


### PR DESCRIPTION
## Summary
CI fixes around the smoke tests: the paths filter skipped the suites for PRs that change them, the suites fail type-check since the wdio 9 bump, and sauce connect's exit reason is now shown in logs.

## Changes
* `.github/actions/smoke-tests/action.yml`: add `smoketests/**` and the action itself to the browser and node filters.
* `smoketests/tests/jest/node/tests.ts`: import `expect` from `@jest/globals` so jest matcher types win over expect-webdriverio's global.
* `smoketests/wdio.conf.ts`: drop the removed `autoCompileOpts` block, print sauce connect output so its exit reason shows in CI.

## Note
`test_linux_all` stays red on the Sauce tunnels outage (tunnel provisioning 401s DC-wide since Jul 31); unrelated to this change.