### PR TITLE
chore(smoketests): run local browser tests on the CI runner

### DIFF
--- a/.github/actions/smoke-tests/action.yml
+++ b/.github/actions/smoke-tests/action.yml
@@ -9,11 +9,11 @@ inputs:
         description: 'Direct submission URL to Backtrace instance'
         required: true
     sauce-username:
-        description: 'Sauce labs user name'
-        required: true
+        description: 'Sauce labs user name (needed when browser-runner is sauce)'
+        required: false
     sauce-access-key:
-        description: 'Sauce labs secret'
-        required: true
+        description: 'Sauce labs secret (needed when browser-runner is sauce)'
+        required: false
     ignore-browser:
         description: 'Ignore browser smoke-tests'
         required: false
@@ -22,6 +22,14 @@ inputs:
         description: 'Ignore node smoke-tests'
         required: false
         default: 'false'
+    browser-runner:
+        description: 'Where browser smoke-tests run: sauce or local'
+        required: false
+        default: 'sauce'
+    browser:
+        description: 'Browser to use when browser-runner is local: chrome, firefox or safari'
+        required: false
+        default: 'chrome'
 
 runs:
     using: 'composite'
@@ -51,9 +59,21 @@ runs:
 
         - run: npm run smoketest:browser
           shell: bash
-          if: steps.filter.outputs.browser == 'true' && inputs.ignore-browser == 'false'
+          if: steps.filter.outputs.browser == 'true' && inputs.ignore-browser == 'false' && inputs.browser-runner == 'sauce'
           env:
               SMOKETESTS_SUBMIT_LAYER_URL: ${{ inputs.submit-url }}
               SMOKETESTS_DIRECT_SUBMIT_URL: ${{ inputs.direct-submit-url }}
               SMOKETESTS_SAUCE_USERNAME: ${{ inputs.sauce-username }}
               SMOKETESTS_SAUCE_ACCESS_KEY: ${{ inputs.sauce-access-key }}
+
+        - run: sudo safaridriver --enable
+          shell: bash
+          if: steps.filter.outputs.browser == 'true' && inputs.ignore-browser == 'false' && inputs.browser-runner == 'local' && inputs.browser == 'safari'
+
+        - run: npm run smoketest:browser:local
+          shell: bash
+          if: steps.filter.outputs.browser == 'true' && inputs.ignore-browser == 'false' && inputs.browser-runner == 'local'
+          env:
+              SMOKETESTS_SUBMIT_LAYER_URL: ${{ inputs.submit-url }}
+              SMOKETESTS_DIRECT_SUBMIT_URL: ${{ inputs.direct-submit-url }}
+              SMOKETESTS_BROWSER: ${{ inputs.browser }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,57 @@ jobs:
               with:
                   submit-url: ${{ secrets.SMOKETESTS_SUBMIT_LAYER_URL }}
                   direct-submit-url: ${{ secrets.SMOKETESTS_DIRECT_SUBMIT_URL }}
+                  ignore-browser: 'true'
+
+    smoke_browser_local:
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - os: ubuntu-latest
+                      browser: chrome
+                    - os: ubuntu-latest
+                      browser: firefox
+                    - os: macos-latest
+                      browser: safari
+
+        runs-on: ${{ matrix.os }}
+
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 20.x
+            - run: npm ci
+            - run: npm run build
+            - name: smoke-test
+              uses: ./.github/actions/smoke-tests
+              with:
+                  submit-url: ${{ secrets.SMOKETESTS_SUBMIT_LAYER_URL }}
+                  direct-submit-url: ${{ secrets.SMOKETESTS_DIRECT_SUBMIT_URL }}
+                  ignore-node: 'true'
+                  browser-runner: 'local'
+                  browser: ${{ matrix.browser }}
+
+    smoke_browser_sauce:
+        runs-on: ubuntu-latest
+        continue-on-error: true
+
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 20.x
+            - run: npm ci
+            - run: npm run build
+            - name: smoke-test
+              uses: ./.github/actions/smoke-tests
+              with:
+                  submit-url: ${{ secrets.SMOKETESTS_SUBMIT_LAYER_URL }}
+                  direct-submit-url: ${{ secrets.SMOKETESTS_DIRECT_SUBMIT_URL }}
                   sauce-username: ${{ secrets.SMOKETESTS_SAUCE_USERNAME }}
                   sauce-access-key: ${{ secrets.SMOKETESTS_SAUCE_ACCESS_KEY }}
+                  ignore-node: 'true'
 
     test_linux:
         runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
     push:
         branches: [main, dev]
     pull_request:
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -66,6 +67,7 @@ jobs:
                   browser: ${{ matrix.browser }}
 
     smoke_browser_sauce:
+        if: github.event_name == 'workflow_dispatch'
         runs-on: ubuntu-latest
         continue-on-error: true
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "smoketest": "npm run start --workspace=smoketests",
         "smoketest:node": "npm run start:jest --workspace=smoketests",
         "smoketest:browser": "npm run start:wdio --workspace=smoketests",
+        "smoketest:browser:local": "npm run start:wdio:local --workspace=smoketests",
         "syncVersions": "ts-node ./scripts/syncVersions.ts",
         "prepare": "husky"
     },

--- a/smoketests/package.json
+++ b/smoketests/package.json
@@ -9,7 +9,9 @@
         "start:jest": "npm run prepare-packages && npm run jest",
         "start:wdio": "npm run prepare-packages && npm run wdio",
         "jest": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" NODE_NO_WARNINGS=1 NODE_ENV=test jest --runInBand",
-        "wdio": "wdio run ./wdio.conf.ts"
+        "wdio": "wdio run ./wdio.conf.ts",
+        "wdio:local": "wdio run ./wdio.local.conf.ts",
+        "start:wdio:local": "npm run prepare-packages && npm run wdio:local"
     },
     "author": "Backtrace <team@backtrace.io>",
     "license": "MIT",

--- a/smoketests/tests/wdio/react/tests.ts
+++ b/smoketests/tests/wdio/react/tests.ts
@@ -10,7 +10,11 @@ export function addSubmitTests(getUrl: (submitUrl: string) => string, buttonSele
         await button.click();
 
         const statusElement = $('#status');
-        await browser.waitUntil(async () => (await statusElement.getText()) !== 'running');
+        // the app starts at "waiting", so wait for a terminal status, not just "not running"
+        await browser.waitUntil(async () => {
+            const status = await statusElement.getText();
+            return status !== 'waiting' && status !== 'running';
+        });
 
         await expect(statusElement).toHaveText('Ok');
         await expect($('#rxid')).toHaveText(RXID_REGEX);

--- a/smoketests/tsconfig.json
+++ b/smoketests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "include": ["./tests", "./wdio.conf.ts"],
+    "include": ["./tests", "./wdio.conf.ts", "./wdio.local.conf.ts"],
     "compilerOptions": {
         "target": "ESNext",
         "module": "NodeNext",

--- a/smoketests/wdio.local.conf.ts
+++ b/smoketests/wdio.local.conf.ts
@@ -1,0 +1,37 @@
+import { config as sauceConfig } from './wdio.conf.js';
+
+const browser = process.env.SMOKETESTS_BROWSER ?? 'chrome';
+
+const capabilities: Record<string, WebdriverIO.Capabilities> = {
+    chrome: {
+        browserName: 'chrome',
+        'goog:chromeOptions': {
+            args: ['--headless=new', '--disable-gpu', '--window-size=1280,800'],
+        },
+    },
+    firefox: {
+        browserName: 'firefox',
+        'moz:firefoxOptions': {
+            args: ['-headless'],
+            ...(process.env.SMOKETESTS_FIREFOX_BINARY ? { binary: process.env.SMOKETESTS_FIREFOX_BINARY } : {}),
+        },
+    },
+    safari: {
+        browserName: 'safari',
+    },
+};
+
+const capability = capabilities[browser];
+if (!capability) {
+    throw new Error(`unsupported SMOKETESTS_BROWSER "${browser}", expected chrome, firefox or safari`);
+}
+
+export const config: typeof sauceConfig = {
+    ...sauceConfig,
+    user: undefined,
+    key: undefined,
+    services: (sauceConfig.services ?? []).filter((service) => !(Array.isArray(service) && service[0] === 'sauce')),
+    capabilities: [capability],
+    // safaridriver serves one session at a time
+    ...(browser === 'safari' ? { maxInstances: 1 } : {}),
+};


### PR DESCRIPTION
## Summary
Smoketests run on a browser installed on the runner, across Chrome, Firefox and Safari, in addition to Sauce.

## Changes
* `smoketests/wdio.local.conf.ts`: local wdio config, no Sauce service or credentials, browser picked with `SMOKETESTS_BROWSER`, single session for Safari.
* `smoketests/tests/wdio/react/tests.ts`: wait for a terminal status, the app starts at `waiting` so the old wait returned before submission started.
* `smoketests/package.json`, `package.json`: add `wdio:local`, `start:wdio:local`, `smoketest:browser:local`.
* `smoketests/tsconfig.json`: typecheck the new config.
* `.github/actions/smoke-tests/action.yml`: add `browser-runner` and `browser` inputs, enable safaridriver for Safari, make Sauce credentials optional.
* `.github/workflows/test.yml`: move browser smoke out of `test_linux_all` into `smoke_browser_local`, add `smoke_browser_sauce` on manual dispatch, add the `workflow_dispatch` trigger.

## Note
Safari needs `safaridriver --enable` first, so the action runs it before the Safari job. Sauce is run on-demand until the tunnel configuration is sorted.

ref: BT-7478