### PR TITLE
chore(husky): skip commit-msg prefix check for merge commits

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,3 +1,8 @@
 #!/usr/bin/env sh
+# Merge commits
+if git rev-parse -q --verify MERGE_HEAD >/dev/null 2>&1; then
+    exit 0
+fi
+
 message="$(cat "$1")"
 node .husky/scripts/commit-msg.js "$message"


### PR DESCRIPTION
## Summary
Merge commits fail the prefix check: the message is git-generated and the staged files are the incoming branch's.

## Changes
`.husky/commit-msg`: exit early when `MERGE_HEAD` exists.

ref: BT-7481