### PR TITLE
chore(ci): restore sauce browser smoke tests

### DIFF
--- a/.github/actions/smoke-tests/action.yml
+++ b/.github/actions/smoke-tests/action.yml
@@ -44,11 +44,13 @@ runs:
                       - 'packages/sdk-core/**'
                       - 'smoketests/**'
                       - '.github/actions/smoke-tests/**'
+                      - '.github/workflows/**'
                   node:
                       - 'packages/sdk-core/**'
                       - 'packages/node/**'
                       - 'smoketests/**'
                       - '.github/actions/smoke-tests/**'
+                      - '.github/workflows/**'
 
         - run: npm run smoketest:node
           shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,13 @@ jobs:
                   node-version: 20.x
             - run: npm ci
             - run: npm run build
+            # NOTE: sc version must match wdio.conf.ts
+            - run: |
+                  SC_VERSION=5.5.3
+                  SC_DIR="node_modules/saucelabs/build/sc-loader/.sc-v$SC_VERSION-linux-x86_64"
+                  mkdir -p "$SC_DIR"
+                  curl -sSf "https://saucelabs.com/downloads/sauce-connect/$SC_VERSION/sauce-connect-${SC_VERSION}_linux.x86_64.tar.gz" | tar xz -C "$SC_DIR"
+                  chmod +x "$SC_DIR/sc"
             - name: smoke-test
               uses: ./.github/actions/smoke-tests
               with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,6 @@ jobs:
                   browser: ${{ matrix.browser }}
 
     smoke_browser_sauce:
-        if: github.event_name == 'workflow_dispatch'
         runs-on: ubuntu-latest
         continue-on-error: true
 

--- a/smoketests/wdio.conf.ts
+++ b/smoketests/wdio.conf.ts
@@ -50,6 +50,7 @@ export const config: Options.Testrunner & {
             {
                 sauceConnect: true,
                 sauceConnectOpts: {
+                    scVersion: '5.5.3',
                     // sc output is debug-level and dropped under logLevel info, print it so CI shows the exit reason
                     logger: (output: string) => console.log(`[sauce-connect] ${output}`),
                 },

--- a/smoketests/wdio.conf.ts
+++ b/smoketests/wdio.conf.ts
@@ -51,6 +51,8 @@ export const config: Options.Testrunner & {
                 sauceConnect: true,
                 sauceConnectOpts: {
                     scVersion: '5.5.3',
+                    // the static server runs on localhost
+                    proxyLocalhost: 'direct',
                     // sc output is debug-level and dropped under logLevel info, print it so CI shows the exit reason
                     logger: (output: string) => console.log(`[sauce-connect] ${output}`),
                 },


### PR DESCRIPTION
## Summary
Restores the sauce browser smoke tests, broken since the SC4 cutoff.

## Changes
* `.github/workflows/test.yml`: run `smoke_browser_sauce` on PRs again, pre-install the sc binary.
* `.github/actions/smoke-tests/action.yml`: run smoke tests when workflow files change.
* `smoketests/wdio.conf.ts`: pin sc to 5.5.3, proxy localhost directly.

ref: BT-7528