### PR TITLE
bugfix: deliver breadcrumbs to native crash reports

### DIFF
--- a/packages/react-native/src/BacktraceClient.ts
+++ b/packages/react-native/src/BacktraceClient.ts
@@ -22,6 +22,9 @@ import { ReactNativeRequestHandler } from './ReactNativeRequestHandler';
 import { ReactStackTraceConverter } from './ReactStackTraceConverter';
 import { type FileSystem } from './storage/FileSystem';
 
+// Must match the private attribute name BreadcrumbsManager sets on JS reports.
+const BREADCRUMB_ATTRIBUTE_NAME = 'breadcrumbs.lastId';
+
 export class BacktraceClient extends BacktraceCoreClient<BacktraceConfiguration> {
     private _crashReporter?: CrashReporter;
     private readonly _exceptionHandler: ExceptionHandler = generateUnhandledExceptionHandler();
@@ -56,7 +59,11 @@ export class BacktraceClient extends BacktraceCoreClient<BacktraceConfiguration>
 
         const breadcrumbsManager = this.modules.get(BreadcrumbsManager);
         if (breadcrumbsManager && this.sessionFiles) {
-            breadcrumbsManager.setStorage(FileBreadcrumbsStorage.factory(this.sessionFiles, fileSystem));
+            breadcrumbsManager.setStorage(
+                FileBreadcrumbsStorage.factory(this.sessionFiles, fileSystem, (lastBreadcrumbId) =>
+                    this.refreshNativeBreadcrumbs(lastBreadcrumbId),
+                ),
+            );
         }
 
         this.attributeManager.attributeEvents.on(
@@ -131,6 +138,14 @@ export class BacktraceClient extends BacktraceCoreClient<BacktraceConfiguration>
         if (captureUnhandledRejections) {
             this._exceptionHandler.captureUnhandledPromiseRejections(this);
         }
+    }
+
+    private refreshNativeBreadcrumbs(lastBreadcrumbId: number) {
+        if (!this._crashReporter) {
+            return;
+        }
+        this._crashReporter.updateAttachments(this.attachments);
+        this._crashReporter.updateAttributes({ [BREADCRUMB_ATTRIBUTE_NAME]: lastBreadcrumbId });
     }
 
     private initializeNativeCrashReporter(): CrashReporter | undefined {

--- a/packages/react-native/src/breadcrumbs/FileBreadcrumbsStorage.ts
+++ b/packages/react-native/src/breadcrumbs/FileBreadcrumbsStorage.ts
@@ -36,11 +36,13 @@ export class FileBreadcrumbsStorage implements BreadcrumbsStorage {
         session: SessionFiles,
         private readonly _fileSystem: FileSystem,
         private readonly _limits: BreadcrumbsStorageLimits,
+        onFilesChange?: (lastBreadcrumbId: number) => void,
     ) {
         this._sink = new FileChunkSink({
             maxFiles: 2,
             fs: this._fileSystem,
             file: (n) => session.getFileName(FileBreadcrumbsStorage.getFileName(n)),
+            onFilesChange: onFilesChange && (() => onFilesChange(this._lastBreadcrumbId)),
         });
 
         const splitters: ChunkSplitterFactory<string>[] = [];
@@ -72,8 +74,12 @@ export class FileBreadcrumbsStorage implements BreadcrumbsStorage {
         this._destinationWriter = this._destinationStream.getWriter();
     }
 
-    public static factory(session: SessionFiles, fileSystem: FileSystem): BreadcrumbsStorageFactory {
-        return ({ limits }) => new FileBreadcrumbsStorage(session, fileSystem, limits);
+    public static factory(
+        session: SessionFiles,
+        fileSystem: FileSystem,
+        onFilesChange?: (lastBreadcrumbId: number) => void,
+    ): BreadcrumbsStorageFactory {
+        return ({ limits }) => new FileBreadcrumbsStorage(session, fileSystem, limits, onFilesChange);
     }
 
     public getAttachments(): BacktraceFileAttachment[] {

--- a/packages/react-native/src/storage/FileChunkSink.ts
+++ b/packages/react-native/src/storage/FileChunkSink.ts
@@ -17,6 +17,11 @@ interface FileChunkSinkOptions {
      * File system to use.
      */
     readonly fs: FileSystem;
+
+    /**
+     * Called after the tracked file set changes.
+     */
+    readonly onFilesChange?: () => void;
 }
 
 /**
@@ -57,6 +62,7 @@ export class FileChunkSink {
         return (n) => {
             const stream = this.createStream(n);
             this._streamTracker.push(stream);
+            this._options.onFilesChange?.();
             return stream;
         };
     }

--- a/packages/react-native/src/storage/combinedChunkSplitter.ts
+++ b/packages/react-native/src/storage/combinedChunkSplitter.ts
@@ -21,7 +21,8 @@ export function combinedChunkSplitter<W extends Chunk>(
         for (const splitter of splitters) {
             const [c1, c2] = splitter(chunk);
             chunk = c1;
-            if (c2) {
+            // An empty second chunk still means "split here"; dropping it loses the split.
+            if (c2 !== undefined) {
                 // Prepend second chunk to the rest
                 rest.unshift(c2);
             }

--- a/packages/react-native/tests/nativeBreadcrumbPropagationTests.spec.ts
+++ b/packages/react-native/tests/nativeBreadcrumbPropagationTests.spec.ts
@@ -53,8 +53,10 @@ function breadcrumbPathsSentToNative(): string[] {
         .filter((p: string) => p.includes('breadcrumb'));
 }
 
-function attributesSentToNative(): Record<string, string> {
-    return Object.assign({}, ...nativeMock.useAttributes.mock.calls.map((call) => call[0]));
+async function settle() {
+    for (let i = 0; i < 10; i++) {
+        await nextTick();
+    }
 }
 
 describe('BacktraceClient native breadcrumb propagation', () => {
@@ -67,21 +69,24 @@ describe('BacktraceClient native breadcrumb propagation', () => {
     it('Should tell the native crash reporter about the breadcrumb files created after rotation', async () => {
         const client = createClient();
         client.initialize();
-
-        const pathsAtInit = nativeMock.initialize.mock.calls[0][3].filter((p: string) => p.includes('breadcrumb'));
         nativeMock.useAttachments.mockClear();
 
         for (let i = 0; i < 20; i++) {
             client.breadcrumbs?.info(`breadcrumb-${i}`);
             await nextTick();
         }
+        await settle();
 
         const sentLater = breadcrumbPathsSentToNative();
-        expect(sentLater.length).toBeGreaterThan(0);
-        expect(sentLater.some((p) => !pathsAtInit.includes(p))).toBe(true);
+        expect(sentLater.some((p) => /bt-breadcrumbs-[1-9]/.test(p))).toBe(true);
+
+        const calls = nativeMock.useAttachments.mock.calls;
+        const lastPaths = calls[calls.length - 1][0].filter((p: string) => p.includes('breadcrumb'));
+        expect(lastPaths.length).toBeGreaterThan(0);
+        expect(lastPaths.some((p: string) => p.includes('bt-breadcrumbs-0_'))).toBe(false);
     });
 
-    it('Should send the last breadcrumb id to the native crash reporter', async () => {
+    it('Should send a fresh last breadcrumb id to the native crash reporter on every rotation', async () => {
         const client = createClient();
         client.initialize();
         nativeMock.useAttributes.mockClear();
@@ -90,7 +95,13 @@ describe('BacktraceClient native breadcrumb propagation', () => {
             client.breadcrumbs?.info(`breadcrumb-${i}`);
             await nextTick();
         }
+        await settle();
 
-        expect(attributesSentToNative()['breadcrumbs.lastId']).toBeDefined();
+        const pushed = nativeMock.useAttributes.mock.calls
+            .map((call) => call[0]['breadcrumbs.lastId'])
+            .filter((value) => value !== undefined)
+            .map(Number);
+        expect(pushed.length).toBeGreaterThan(1);
+        expect(pushed[pushed.length - 1]).toBeGreaterThan(pushed[0]);
     });
 });

--- a/packages/react-native/tests/nativeBreadcrumbPropagationTests.spec.ts
+++ b/packages/react-native/tests/nativeBreadcrumbPropagationTests.spec.ts
@@ -1,0 +1,96 @@
+import { NativeModules } from 'react-native';
+import { promisify } from 'util';
+import { mockStreamFileSystem } from './_mocks/fileSystem';
+
+// This package's jest config replaces the react-native preset's setupFiles, so the real Platform throws.
+jest.mock('react-native', () => ({
+    NativeModules: {},
+    Platform: {
+        OS: 'ios',
+        select: (options: Record<string, unknown>) => (options.ios !== undefined ? options.ios : options.default),
+    },
+}));
+
+jest.mock('../src/common/platformHelper', () => ({
+    version: () => '0.81.6',
+}));
+
+const nativeMock = {
+    initialize: jest.fn(),
+    useAttributes: jest.fn(),
+    useAttachments: jest.fn(),
+    crash: jest.fn(),
+};
+
+// CrashReporter caches BacktraceReactNative in a static field, so the mock has to land before the module loads.
+NativeModules.BacktraceReactNative = nativeMock;
+NativeModules.BacktraceDirectoryProvider = { applicationDirectory: () => '/' };
+(globalThis as unknown as { RN$Bridgeless: boolean }).RN$Bridgeless = true;
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { BacktraceClient } = require('../src/BacktraceClient');
+const { CrashReporter } = require('../src/crashReporter/CrashReporter');
+/* eslint-enable @typescript-eslint/no-var-requires */
+
+const nextTick = promisify(process.nextTick);
+
+function createClient() {
+    return new BacktraceClient({
+        options: {
+            url: 'https://submit.backtrace.io/universe/token/json',
+            database: { enable: true, captureNativeCrashes: true, path: '/backtrace' },
+            metrics: { enable: false },
+            breadcrumbs: { maximumBreadcrumbs: 4 },
+            userAttributes: { application: 'nativeBreadcrumbPropagation', 'application.version': '1.0.0' },
+        },
+        fileSystem: mockStreamFileSystem(),
+    });
+}
+
+function breadcrumbPathsSentToNative(): string[] {
+    return nativeMock.useAttachments.mock.calls
+        .flatMap((call) => call[0])
+        .filter((p: string) => p.includes('breadcrumb'));
+}
+
+function attributesSentToNative(): Record<string, string> {
+    return Object.assign({}, ...nativeMock.useAttributes.mock.calls.map((call) => call[0]));
+}
+
+describe('BacktraceClient native breadcrumb propagation', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        // Static, so initialize() would be a no-op after the first test.
+        (CrashReporter as unknown as { initialized: boolean }).initialized = false;
+    });
+
+    it('Should tell the native crash reporter about the breadcrumb files created after rotation', async () => {
+        const client = createClient();
+        client.initialize();
+
+        const pathsAtInit = nativeMock.initialize.mock.calls[0][3].filter((p: string) => p.includes('breadcrumb'));
+        nativeMock.useAttachments.mockClear();
+
+        for (let i = 0; i < 20; i++) {
+            client.breadcrumbs?.info(`breadcrumb-${i}`);
+            await nextTick();
+        }
+
+        const sentLater = breadcrumbPathsSentToNative();
+        expect(sentLater.length).toBeGreaterThan(0);
+        expect(sentLater.some((p) => !pathsAtInit.includes(p))).toBe(true);
+    });
+
+    it('Should send the last breadcrumb id to the native crash reporter', async () => {
+        const client = createClient();
+        client.initialize();
+        nativeMock.useAttributes.mockClear();
+
+        for (let i = 0; i < 20; i++) {
+            client.breadcrumbs?.info(`breadcrumb-${i}`);
+            await nextTick();
+        }
+
+        expect(attributesSentToNative()['breadcrumbs.lastId']).toBeDefined();
+    });
+});

--- a/packages/react-native/tests/storage/combinedChunkSplitter.spec.ts
+++ b/packages/react-native/tests/storage/combinedChunkSplitter.spec.ts
@@ -1,0 +1,36 @@
+import { combinedChunkSplitter } from '../../src/storage/combinedChunkSplitter';
+import { lengthChunkSplitter } from '../../src/storage/lengthChunkSplitter';
+import { lineChunkSplitter } from '../../src/storage/lineChunkSplitter';
+
+const join = (chunks: string[]) => chunks.join('');
+
+describe('combinedChunkSplitter', () => {
+    it('should split when any splitter splits', () => {
+        const splitter = combinedChunkSplitter(join, lengthChunkSplitter(4), lineChunkSplitter(10));
+
+        const [c1, c2] = splitter('abcdefgh');
+
+        expect(c1).toEqual('abcd');
+        expect(c2).toEqual('efgh');
+    });
+
+    it('should not split when no splitter splits', () => {
+        const splitter = combinedChunkSplitter(join, lineChunkSplitter(10), lengthChunkSplitter(1000));
+
+        const [c1, c2] = splitter('line-1\n');
+
+        expect(c1).toEqual('line-1\n');
+        expect(c2).toBeUndefined();
+    });
+
+    it('should keep the split when the second chunk is empty', () => {
+        const splitter = combinedChunkSplitter(join, lineChunkSplitter(2), lengthChunkSplitter(1000, 'skip'));
+
+        splitter('line-1\n');
+        const [c1, c2] = splitter('line-2\n');
+
+        expect(c1).toEqual('line-2\n');
+        expect(c2).toBeDefined();
+        expect(c2?.length).toEqual(0);
+    });
+});


### PR DESCRIPTION
## Summary
Breadcrumbs never reached native crash reports: nothing pushed the chunk files or `breadcrumbs.lastId` after init, and rotation never triggered because exact-boundary splits were dropped.

## Changes
* `FileChunkSink.ts`: adds an `onFilesChange` hook, fires it whenever a chunk file is created.
* `FileBreadcrumbsStorage.ts`: forwards the hook with the current last breadcrumb id.
* `BacktraceClient.ts`: pushes the attachment list and `breadcrumbs.lastId` to the native crash reporter on every chunk creation.
* `combinedChunkSplitter.ts`: keeps empty second chunks so exact-boundary splits are not dropped.
* `nativeBreadcrumbPropagationTests.spec.ts`: new, asserts rotated files reach native, chunk 0 drops out of the last push, pushed id advances.
* `combinedChunkSplitter.spec.ts`: new, covers splitter combining and the exact-boundary split.

ref: BT-7501, BT-7564